### PR TITLE
fix "Transition" link href in @headlessui-react readme

### DIFF
--- a/packages/@headlessui-react/README.md
+++ b/packages/@headlessui-react/README.md
@@ -27,7 +27,7 @@ yarn add @headlessui/react
 
 _This project is still in early development. New components will be added regularly over the coming months._
 
-- [Transition](#menu-button-dropdown)
+- [Transition](#transition)
 - [Menu Button (Dropdown)](#menu-button-dropdown)
 
 ### Roadmap


### PR DESCRIPTION
Just spotted this.﻿
