### PR TITLE
Update `enum` to `const enum`

### DIFF
--- a/packages/@headlessui-react/pages/_app.tsx
+++ b/packages/@headlessui-react/pages/_app.tsx
@@ -15,7 +15,7 @@ function NextLink(props: PropsOf<'a'>) {
   )
 }
 
-enum KeyDisplayMac {
+const enum KeyDisplayMac {
   ArrowUp = '↑',
   ArrowDown = '↓',
   ArrowLeft = '←',
@@ -37,7 +37,7 @@ enum KeyDisplayMac {
   ' ' = '␣',
 }
 
-enum KeyDisplayWindows {
+const enum KeyDisplayWindows {
   ArrowUp = '↑',
   ArrowDown = '↓',
   ArrowLeft = '←',

--- a/packages/@headlessui-react/pages/transitions/full-page-examples/full-page-transition.tsx
+++ b/packages/@headlessui-react/pages/transitions/full-page-examples/full-page-transition.tsx
@@ -28,7 +28,7 @@ function usePrevious<T>(value: T) {
   return ref.current
 }
 
-enum Direction {
+const enum Direction {
   Forwards = ' -> ',
   Backwards = ' <- ',
 }

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -10,14 +10,14 @@ import { useIsoMorphicEffect } from '../../hooks/use-iso-morphic-effect'
 import { useSyncRefs } from '../../hooks/use-sync-refs'
 import { useId } from '../../hooks/use-id'
 
-enum MenuStates {
+const enum MenuStates {
   Open,
   Closed,
 }
 
 // TODO: This must already exist somewhere, right? 🤔
 // Ref: https://www.w3.org/TR/uievents-key/#named-key-attribute-values
-enum Key {
+const enum Key {
   Space = ' ',
   Enter = 'Enter',
   Escape = 'Escape',
@@ -46,7 +46,7 @@ type StateDefinition = {
   activeItemIndex: number | null
 }
 
-enum ActionTypes {
+const enum ActionTypes {
   ToggleMenu,
   OpenMenu,
   CloseMenu,
@@ -59,7 +59,7 @@ enum ActionTypes {
   UnregisterItem,
 }
 
-enum Focus {
+const enum Focus {
   FirstItem,
   PreviousItem,
   NextItem,

--- a/packages/@headlessui-react/src/components/transitions/transition.tsx
+++ b/packages/@headlessui-react/src/components/transitions/transition.tsx
@@ -22,7 +22,7 @@ type TransitionContextValues = {
 } | null
 const TransitionContext = React.createContext<TransitionContextValues>(null)
 
-enum TreeStates {
+const enum TreeStates {
   Visible = 'visible',
   Hidden = 'hidden',
 }

--- a/packages/@headlessui-vue/src/components/menu/menu.ts
+++ b/packages/@headlessui-vue/src/components/menu/menu.ts
@@ -14,14 +14,14 @@ import { match } from '../../utils/match'
 import { render } from '../../utils/render'
 import { useId } from '../../hooks/use-id'
 
-enum MenuStates {
+const enum MenuStates {
   Open,
   Closed,
 }
 
 // TODO: This must already exist somewhere, right? 🤔
 // Ref: https://www.w3.org/TR/uievents-key/#named-key-attribute-values
-enum Key {
+const enum Key {
   Space = ' ',
   Enter = 'Enter',
   Escape = 'Escape',
@@ -39,7 +39,7 @@ enum Key {
   Tab = 'Tab',
 }
 
-enum Focus {
+const enum Focus {
   FirstItem,
   PreviousItem,
   NextItem,


### PR DESCRIPTION
This PR updates all TypeScript enums to `const enum`.

**Reason**: this will reduce the bundle size

### `enum`

Input
```ts
enum Key {
  Space = ' ',
  Enter = 'Enter',
  Escape = 'Escape',
  Backspace = 'Backspace',

  ArrowUp = 'ArrowUp',
  ArrowDown = 'ArrowDown',

  Home = 'Home',
  End = 'End',

  PageUp = 'PageUp',
  PageDown = 'PageDown',

  Tab = 'Tab',
}

console.log(Key.Enter)
```

Output
```js
"use strict";
var Key;
(function (Key) {
    Key["Space"] = " ";
    Key["Enter"] = "Enter";
    Key["Escape"] = "Escape";
    Key["Backspace"] = "Backspace";
    Key["ArrowUp"] = "ArrowUp";
    Key["ArrowDown"] = "ArrowDown";
    Key["Home"] = "Home";
    Key["End"] = "End";
    Key["PageUp"] = "PageUp";
    Key["PageDown"] = "PageDown";
    Key["Tab"] = "Tab";
})(Key || (Key = {}));

console.log(Key.Enter);
```

### `const enum`

Input
```ts
const enum Key {
  Space = ' ',
  Enter = 'Enter',
  Escape = 'Escape',
  Backspace = 'Backspace',

  ArrowUp = 'ArrowUp',
  ArrowDown = 'ArrowDown',

  Home = 'Home',
  End = 'End',

  PageUp = 'PageUp',
  PageDown = 'PageDown',

  Tab = 'Tab',
}

console.log(Key.Enter)
```

Output
```js
"use strict";

console.log("Enter" /* Enter */);
```