### PR TITLE
Use Dependabot to check for npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    labels:
+      - 'dependencies'


### PR DESCRIPTION
## Changes:

Dependabot will check for npm updates each working day (Monday trough Friday).
It will label any pull requests it makes with the `dependencies` label.

## Context:

I think it's a good idea to use a bot to check for updates.