### PR TITLE
fix typo

### DIFF
--- a/packages/@headlessui-react/pages/listbox/listbox-with-pure-tailwind.tsx
+++ b/packages/@headlessui-react/pages/listbox/listbox-with-pure-tailwind.tsx
@@ -10,7 +10,7 @@ const people = [
   'Tom Cook',
   'Tanya Fox',
   'Hellen Schmidt',
-  'Caronline Schultz',
+  'Caroline Schultz',
   'Mason Heaney',
   'Claudie Smitham',
   'Emil Schaefer',

--- a/packages/@headlessui-vue/examples/src/components/listbox/listbox.vue
+++ b/packages/@headlessui-vue/examples/src/components/listbox/listbox.vue
@@ -100,7 +100,7 @@ export default {
       'Tom Cook',
       'Tanya Fox',
       'Hellen Schmidt',
-      'Caronline Schultz',
+      'Caroline Schultz',
       'Mason Heaney',
       'Claudie Smitham',
       'Emil Schaefer',


### PR DESCRIPTION
Extremely minor fix but saw in the docs that the same group of people were used in multiple places where `Caroline` is `Caroline`, however connected to the internet she is... ;)