### PR TITLE
docs: Vue component names not dot-separated

### DIFF
--- a/packages/@headlessui-vue/README.md
+++ b/packages/@headlessui-vue/README.md
@@ -1160,7 +1160,7 @@ export default {
 | `checked` | Boolean | Whether or not the switch is checked. |
 
 
-#### Switch.Label
+#### SwitchLabel
 
 ```html
 <SwitchGroup>
@@ -1177,7 +1177,7 @@ export default {
 | ---------- | ----------------------- | --------------------------------------- | -------------------------------------------------------- |
 | `as`       | String \| Component     | `label` | The element or component the `SwitchLabel` should render as. |
 
-#### Switch.Group
+#### SwitchGroup
 
 ```html
 <SwitchGroup>


### PR DESCRIPTION
Hello!

💁‍♀️ This PR makes a small correction in the Vue documentation for the `Switch` component.

Super small fix, but looks like the docs for React made their way over to Vue 🎉 