### PR TITLE
Update docs: added ability to scroll top in readme file

### DIFF
--- a/packages/@headlessui-react/README.md
+++ b/packages/@headlessui-react/README.md
@@ -367,7 +367,7 @@ function MyComponent({ isShowing }) {
 | ----- | ---------------------- | ----------------------------------------------------------------------------------- |
 | `ref` | React.MutableRefObject | A ref that needs to be manually added to the child node when using the render prop. |
 
----
+**[:arrow_up: back to top](#components)**
 
 ## Menu Button (Dropdown)
 
@@ -761,6 +761,8 @@ function MyDropdown() {
 | ---------- | ------- | ---------------------------------------------------------------------------------- |
 | `active`   | Boolean | Whether or not the item is the active/focused item in the list.                    |
 | `disabled` | Boolean | Whether or not the item is the disabled for keyboard navigation and ARIA purposes. |
+
+**[:arrow_up: back to top](#components)**
 
 ## Listbox (Select)
 
@@ -1250,6 +1252,8 @@ function MyListbox() {
 | `selected` | Boolean | Whether or not the option is the selected option in the list.                        |
 | `disabled` | Boolean | Whether or not the option is the disabled for keyboard navigation and ARIA purposes. |
 
+**[:arrow_up: back to top](#components)**
+
 ## Switch (Toggle)
 
 [View live demo on CodeSandbox](https://codesandbox.io/s/headlessuireact-switch-example-y40i1?file=/src/App.js)
@@ -1375,3 +1379,5 @@ function NotificationsToggle() {
 | Prop       | Type                    | Default                                 | Description                                              |
 | ---------- | ----------------------- | --------------------------------------- | -------------------------------------------------------- |
 | `as`       | String \| Component     | `React.Fragment` _(no wrapper element)_| The element or component the `Switch.Group` should render as. |
+
+**[:arrow_up: back to top](#components)**

--- a/packages/@headlessui-vue/README.md
+++ b/packages/@headlessui-vue/README.md
@@ -373,6 +373,8 @@ To tell an element to render its children directly with no wrapper element, use 
 | `active`   | Boolean | Whether or not the item is the active/focused item in the list.                    |
 | `disabled` | Boolean | Whether or not the item is the disabled for keyboard navigation and ARIA purposes. |
 
+**[:arrow_up: back to top](#components)**
+
 ## Listbox (Select)
 
 [View live demo on CodeSandbox](https://codesandbox.io/s/headlessuivue-listbox-example-mi67g?file=/src/App.vue)
@@ -1037,6 +1039,8 @@ export default {
 | `selected` | Boolean | Whether or not the option is the selected option in the list.                        |
 | `disabled` | Boolean | Whether or not the option is the disabled for keyboard navigation and ARIA purposes. |
 
+**[:arrow_up: back to top](#components)**
+
 ## Switch (Toggle)
 
 [View live demo on CodeSandbox](https://codesandbox.io/s/headlessuivue-switch-example-8ycp6?file=/src/App.vue)
@@ -1193,3 +1197,5 @@ export default {
 | Prop       | Type                    | Default                                 | Description                                              |
 | ---------- | ----------------------- | --------------------------------------- | -------------------------------------------------------- |
 | `as`       | String \| Component     | `template` _(no wrapper element)_| The element or component the `SwitchGroup` should render as. |
+
+**[:arrow_up: back to top](#components)**


### PR DESCRIPTION
I found scrolling from the bottom to the top of the readme file a bit difficult. So decided to add a link to the `#components` section at the end of each section, here's a glimpse:

<img width="866" alt="Screen Shot 2020-10-06 at 23 18 37" src="https://user-images.githubusercontent.com/53334880/95252759-48ebe580-082a-11eb-8d92-b28a2638985d.png">
