### PR TITLE
Allow keeping the menu open by preventing the event

### DIFF
--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -490,7 +490,8 @@ function Item<TTag extends React.ElementType = typeof DEFAULT_ITEM_TAG>(
   }, [bag, id])
 
   const handleClick = React.useCallback(
-    (event: { preventDefault: Function }) => {
+    (event: { preventDefault: Function, isDefaultPrevented: Function }) => {
+      if (event.isDefaultPrevented()) return
       if (disabled) return event.preventDefault()
       dispatch({ type: ActionTypes.CloseMenu })
       d.nextFrame(() => state.buttonRef.current?.focus())

--- a/packages/@headlessui-vue/src/components/menu/menu.ts
+++ b/packages/@headlessui-vue/src/components/menu/menu.ts
@@ -413,6 +413,7 @@ export const MenuItem = defineComponent({
     onUnmounted(() => api.unregisterItem(id))
 
     function handleClick(event: MouseEvent) {
+      if (event.isDefaultPrevented()) return
       if (disabled) return event.preventDefault()
       api.closeMenu()
       nextTick(() => api.buttonRef.value?.focus())


### PR DESCRIPTION
## Usecase
I have an additional item inside my menu items (think like a "mark as read" icon). When this is clicked I wish to perform a different action and then prevent the default of the menu being closed.

## Usage

```jsx
const handleMarkAsRead(event) {
   event.preventDefault();
   //... mark as read logic
}

<Menu.Item>
  {({active}) => (
    <a href="#" className={active ? 'bg-gray-500' : 'bg-gray-300'}>
      <span>Sam sent you a message!</span>
      <span class="text-blue-500 hover:text-blue-600" onClick={handleMarkAsRead}>Mark as Read</span>
    </a>
  )}
</Menu.Item>
```