### PR TITLE
chore: use dependabot for github actions only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,9 @@
 version: 2
 updates:
-  - package-ecosystem: 'npm'
+  - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'daily'
     labels:
       - 'dependencies'
+      - 'github_actions'


### PR DESCRIPTION
## Changes:

* Dependabot will no longer check for npm updates
* Dependabot will instead check for GitHub Actions updates
* Add label for `github-actions` type updates

## Context:

Using Dependabot for the JavaScript package updates has some limitations:

* It's quite spammy with pull requests.
* It does not know how to group updates that belong together into one pull request.

I think you will like your upgrades a lot more if you switch to **Depfu** or **Renovate** to update your JavaScript dependencies.

If you switch to **Depfu**, you'll still need to use Dependabot to check for GitHub actions updates.
So this pull request "reverts" using Dependabot for JavaScript packages, and instead enables it for GitHub Actions.

The Renovate bot can check for GitHub Actions updates though, so if you decide to use Renovate you can close this PR, and just delete the `dependabot.yml` file and be done with it.

## Discussion:

If you want me to tweak this pull request, let me know.
I can remove the `dependencies` label and only have the `github-actions` label.

Or you can just remove the Dependabot bot altogether by reverting #23.

## Relevant issues/pulls:

https://github.com/tailwindlabs/headlessui/pull/23 Introduced Dependabot for NPM updates, and contains the observation that Dependabot doesn't know how to group the `jest` and `babel-jest` dependencies into one pull request.