### PR TITLE
Not [import React from 'react'] for the New JSX Transform

### DIFF
--- a/packages/@headlessui-react/.eslintrc.js
+++ b/packages/@headlessui-react/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+  },
+}

--- a/packages/@headlessui-react/pages/_app.tsx
+++ b/packages/@headlessui-react/pages/_app.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import Head from 'next/head'
 
@@ -58,9 +58,9 @@ function tap<T>(value: T, cb: (value: T) => void) {
 }
 
 function useKeyDisplay() {
-  const [mounted, setMounted] = React.useState(false)
+  const [mounted, setMounted] = useState(false)
 
-  React.useEffect(() => {
+  useEffect(() => {
     setMounted(true)
   }, [])
 
@@ -70,11 +70,11 @@ function useKeyDisplay() {
 }
 
 function KeyCaster() {
-  const [keys, setKeys] = React.useState<string[]>([])
+  const [keys, setKeys] = useState<string[]>([])
   const d = useDisposables()
   const KeyDisplay = useKeyDisplay()
 
-  React.useEffect(() => {
+  useEffect(() => {
     function handler(event: KeyboardEvent) {
       setKeys(current => [
         event.shiftKey && event.key !== 'Shift'

--- a/packages/@headlessui-react/pages/transitions/component-examples/dropdown.tsx
+++ b/packages/@headlessui-react/pages/transitions/component-examples/dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import Head from 'next/head'
 import { Transition } from '@headlessui/react'
 

--- a/packages/@headlessui-react/pages/transitions/component-examples/modal.tsx
+++ b/packages/@headlessui-react/pages/transitions/component-examples/modal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { Transition } from '@headlessui/react'
 
 export default function Home() {

--- a/packages/@headlessui-react/pages/transitions/component-examples/nested/hidden.tsx
+++ b/packages/@headlessui-react/pages/transitions/component-examples/nested/hidden.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { Transition } from '@headlessui/react'
 
 export default function Home() {

--- a/packages/@headlessui-react/pages/transitions/component-examples/nested/unmount.tsx
+++ b/packages/@headlessui-react/pages/transitions/component-examples/nested/unmount.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { Transition } from '@headlessui/react'
 
 export default function Home() {

--- a/packages/@headlessui-react/pages/transitions/component-examples/peek-a-boo.tsx
+++ b/packages/@headlessui-react/pages/transitions/component-examples/peek-a-boo.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { Transition } from '@headlessui/react'
 
 export default function Home() {

--- a/packages/@headlessui-react/pages/transitions/full-page-examples/full-page-transition.tsx
+++ b/packages/@headlessui-react/pages/transitions/full-page-examples/full-page-transition.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Head from 'next/head'
 import { Transition } from '@headlessui/react'
 

--- a/packages/@headlessui-react/pages/transitions/full-page-examples/layout-with-sidebar.tsx
+++ b/packages/@headlessui-react/pages/transitions/full-page-examples/layout-with-sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import Head from 'next/head'
 import { Transition } from '@headlessui/react'
 

--- a/packages/@headlessui-react/playground-utils/hooks/use-popper.ts
+++ b/packages/@headlessui-react/playground-utils/hooks/use-popper.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import { useCallback, useRef, useMemo, RefCallback } from 'react'
 import { createPopper, Options } from '@popperjs/core'
 
 /**
@@ -6,13 +6,13 @@ import { createPopper, Options } from '@popperjs/core'
  */
 export function usePopper(
   options?: Partial<Options>
-): [React.RefCallback<Element | null>, React.RefCallback<HTMLElement | null>] {
-  const reference = React.useRef<Element>(null)
-  const popper = React.useRef<HTMLElement>(null)
+): [RefCallback<Element | null>, RefCallback<HTMLElement | null>] {
+  const reference = useRef<Element>(null)
+  const popper = useRef<HTMLElement>(null)
 
-  const cleanupCallback = React.useRef(() => {})
+  const cleanupCallback = useRef(() => {})
 
-  const instantiatePopper = React.useCallback(() => {
+  const instantiatePopper = useCallback(() => {
     if (!reference.current) return
     if (!popper.current) return
 
@@ -21,7 +21,7 @@ export function usePopper(
     cleanupCallback.current = createPopper(reference.current, popper.current, options).destroy
   }, [reference, popper, cleanupCallback, options])
 
-  return React.useMemo(
+  return useMemo(
     () => [
       referenceDomNode => {
         reference.current = referenceDomNode


### PR DESCRIPTION
Please check the official blog.
[Introducing the New JSX Transform – React Blog](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)

> Upgrading to the new transform is completely optional, but it has a few benefits:
> 
> With the new transform, you can use JSX without importing React.
> Depending on your setup, its compiled output may slightly improve the bundle size.
> It will enable future improvements that reduce the number of concepts you need to learn React.


> Next.js v9.5.3+ uses the new transform for compatible React versions.

