### PR TITLE
refactor: use 'useState setter' instead of state itself

### DIFF
--- a/packages/@headlessui-react/src/hooks/use-id.ts
+++ b/packages/@headlessui-react/src/hooks/use-id.ts
@@ -17,8 +17,9 @@ export function useId() {
   const [id, setId] = React.useState(state.serverHandoffComplete ? generateId : null)
 
   useIsoMorphicEffect(() => {
-    if (id === null) setId(generateId())
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    setId(prevId => prevId === null
+      ? generateId()
+      : prevId)
   }, [])
 
   React.useEffect(() => {


### PR DESCRIPTION
Is there any reason to use the state itself instead of the setter?
If not, it's better to use the setter to avoid suppressing the lint rule.