### PR TITLE
Add displayName to all contexts in react

### DIFF
--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -169,6 +169,7 @@ const reducers: {
 }
 
 const ListboxContext = React.createContext<[StateDefinition, React.Dispatch<Actions>] | null>(null)
+ListboxContext.displayName = 'ListboxContext'
 
 function stateReducer(state: StateDefinition, action: Actions) {
   return match(action.type, reducers, state, action)

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -170,6 +170,7 @@ const reducers: {
 }
 
 const MenuContext = React.createContext<[StateDefinition, React.Dispatch<Actions>] | null>(null)
+MenuContext.displayName = 'MenuContext'
 
 function useMenuContext(component: string) {
   const context = React.useContext(MenuContext)

--- a/packages/@headlessui-react/src/components/switch/switch.tsx
+++ b/packages/@headlessui-react/src/components/switch/switch.tsx
@@ -14,6 +14,7 @@ type StateDefinition = {
 }
 
 const GroupContext = React.createContext<StateDefinition | null>(null)
+GroupContext.displayName = 'GroupContext'
 
 function useGroupContext(component: string) {
   const context = React.useContext(GroupContext)

--- a/packages/@headlessui-react/src/components/transitions/transition.tsx
+++ b/packages/@headlessui-react/src/components/transitions/transition.tsx
@@ -21,6 +21,7 @@ type TransitionContextValues = {
   appear: boolean
 } | null
 const TransitionContext = React.createContext<TransitionContextValues>(null)
+TransitionContext.displayName = 'TransitionContext'
 
 enum TreeStates {
   Visible = 'visible',
@@ -81,6 +82,7 @@ type NestingContextValues = {
 }
 
 const NestingContext = React.createContext<NestingContextValues | null>(null)
+NestingContext.displayName = 'NestingContext'
 
 function useNesting(done?: () => void) {
   const doneRef = React.useRef(done)


### PR DESCRIPTION
The default displayName for a react context is Context so in the react devtools we get
![image](https://user-images.githubusercontent.com/709773/102027411-d2aac700-3e08-11eb-85ac-379b460d69fb.png)

This can make it difficult to navigate the react devtools when there are a lot of contexts in play. This PR adds a displayName to the all contexts in the react portion of HeadlessUI meaning we end up with
![image](https://user-images.githubusercontent.com/709773/102027425-e9511e00-3e08-11eb-94ff-9cf0f329033e.png)

Which is easier to understand at a glance and makes navigating around easier as we can find them in the search.

https://reactjs.org/docs/context.html#contextdisplayname