### PR TITLE
Added new examples for switch components (React, Vue)

### DIFF
--- a/packages/@headlessui-react/README.md
+++ b/packages/@headlessui-react/README.md
@@ -1286,12 +1286,12 @@ function NotificationsToggle() {
       onChange={setEnabled}
       className={`${
         enabled ? 'bg-blue-600' : 'bg-gray-200'
-      } relative inline-flex h-6 rounded-full w-8`}
+      } relative inline-flex items-center h-6 rounded-full w-11`}
     >
       <span className="sr-only">Enable notifications</span>
       <span
         className={`${
-          enabled ? 'translate-x-4' : 'translate-x-0'
+          enabled ? 'translate-x-6' : 'translate-x-1'
         } inline-block w-4 h-4 transform bg-white rounded-full`}
       />
     </Switch>
@@ -1320,11 +1320,11 @@ function NotificationsToggle() {
         onChange={setEnabled}
         className={`${
           enabled ? 'bg-blue-600' : 'bg-gray-200'
-        } relative inline-flex h-6 rounded-full w-8`}
+        } relative inline-flex items-center h-6 rounded-full w-11`}
       >
         <span
           className={`${
-            enabled ? 'translate-x-4' : 'translate-x-0'
+            enabled ? 'translate-x-6' : 'translate-x-1'
           } inline-block w-4 h-4 transform bg-white rounded-full`}
         />
       </Switch>

--- a/packages/@headlessui-vue/README.md
+++ b/packages/@headlessui-vue/README.md
@@ -1093,13 +1093,13 @@ Switches are built using the `Switch` component. Optionally you can also use the
   <Switch
     as="button"
     v-model="switchValue"
-    class="relative inline-flex w-8 h-6 rounded-full"
+    class="relative inline-flex items-center h-6 rounded-full w-11"
     :class="switchValue ? 'bg-blue-600' : 'bg-gray-200'"
     v-slot="{ checked }"
   >
     <span
       class="inline-block w-4 h-4 transform bg-white rounded-full"
-      :class="{ 'translate-x-5': checked, 'translate-x-0': !checked }"
+      :class="{ 'translate-x-6': checked, 'translate-x-1': !checked }"
     />
   </Switch>
 </template>
@@ -1140,13 +1140,13 @@ Clicking the label will toggle the switch state, like you'd expect from a native
     <Switch
       as="button"
       v-model="switchValue"
-      class="relative inline-flex w-8 h-6 rounded-full"
+      class="relative inline-flex items-center h-6 rounded-full w-11"
       :class="switchValue ? 'bg-blue-600' : 'bg-gray-200'"
       v-slot="{ checked }"
     >
       <span
         class="inline-block w-4 h-4 transform bg-white rounded-full"
-        :class="{ 'translate-x-5': checked, 'translate-x-0': !checked }"
+        :class="{ 'translate-x-6': checked, 'translate-x-1': !checked }"
       />
     </Switch>
   </SwitchGroup>


### PR DESCRIPTION
A discord member states that the current examples in the readme file don't look good at the moment.
I think it is useful to have a nice example here to increase the enjoyment of headlessui.
However, the switch should not look like the one in TailwindUI since this is a paid collection.
Thus, I changed the style a little in order to look okay for a first starting point.

![image](https://user-images.githubusercontent.com/6071634/108502011-6a69dd00-72b2-11eb-9107-62ac142fc761.png)
