### PR TITLE
Add missing imports in Dialog example

### DIFF
--- a/packages/@headlessui-react/README.md
+++ b/packages/@headlessui-react/README.md
@@ -1591,6 +1591,9 @@ This component can be used to render content inside a Dialog/Modal. This contain
 ### Basic example
 
 ```jsx
+import { useState } from 'react'
+import { Dialog } from '@headlessui/react'
+
 function Example() {
   let [isOpen, setIsOpen] = useState(true)
 


### PR DESCRIPTION
I think this makes it easier to copy and paste 🧙 