### PR TITLE
class name functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `Switch.Description` component, which adds the `aria-describedby` to the actual Switch ([#220](https://github.com/tailwindlabs/headlessui/pull/220))
 - Add `FocusTrap` component ([#220](https://github.com/tailwindlabs/headlessui/pull/220))
 - Add `Popover` component ([#220](https://github.com/tailwindlabs/headlessui/pull/220))
+- All components that accept a `className`, can now also receive a function with the renderProp argument ([#257](https://github.com/tailwindlabs/headlessui/pull/257))
 
 ## [Unreleased - Vue]
 

--- a/packages/@headlessui-react/src/components/disclosure/disclosure.tsx
+++ b/packages/@headlessui-react/src/components/disclosure/disclosure.tsx
@@ -1,5 +1,5 @@
 // WAI-ARIA: https://www.w3.org/TR/wai-aria-practices-1.2/#disclosure
-import {
+import React, {
   createContext,
   useContext,
   Fragment,
@@ -23,7 +23,6 @@ import { useSyncRefs } from '../../hooks/use-sync-refs'
 import { useId } from '../../hooks/use-id'
 import { Keys } from '../keyboard'
 import { isDisabledReactIssue7711 } from '../../utils/bugs'
-import React from 'react'
 
 enum DisclosureStates {
   Open,

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -29,7 +29,6 @@ import { match } from '../../utils/match'
 import { disposables } from '../../utils/disposables'
 import { Keys } from '../keyboard'
 import { Focus, calculateActiveIndex } from '../../utils/calculate-active-index'
-import { resolvePropValue } from '../../utils/resolve-prop-value'
 import { isDisabledReactIssue7711 } from '../../utils/bugs'
 import { isFocusableElement, FocusableMode } from '../../utils/focus-management'
 
@@ -525,15 +524,12 @@ function Option<
   // But today is not that day..
   TType = Parameters<typeof Listbox>[0]['value']
 >(
-  props: Props<TTag, OptionRenderPropArg, ListboxOptionPropsWeControl | 'className' | 'value'> & {
+  props: Props<TTag, OptionRenderPropArg, ListboxOptionPropsWeControl | 'value'> & {
     disabled?: boolean
     value: TType
-
-    // Special treatment, can either be a string or a function that resolves to a string
-    className?: ((bag: OptionRenderPropArg) => string) | string
   }
 ) {
-  let { disabled = false, value, className, ...passthroughProps } = props
+  let { disabled = false, value, ...passthroughProps } = props
   let [state, dispatch] = useListboxContext([Listbox.name, Option.name].join('.'))
   let id = `headlessui-listbox-option-${useId()}`
   let active =
@@ -610,7 +606,6 @@ function Option<
     id,
     role: 'option',
     tabIndex: -1,
-    className: resolvePropValue(className, propsBag),
     'aria-disabled': disabled === true ? true : undefined,
     'aria-selected': selected === true ? true : undefined,
     onClick: handleClick,

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -29,7 +29,6 @@ import { useSyncRefs } from '../../hooks/use-sync-refs'
 import { useId } from '../../hooks/use-id'
 import { Keys } from '../keyboard'
 import { Focus, calculateActiveIndex } from '../../utils/calculate-active-index'
-import { resolvePropValue } from '../../utils/resolve-prop-value'
 import { isDisabledReactIssue7711 } from '../../utils/bugs'
 import { isFocusableElement, FocusableMode } from '../../utils/focus-management'
 
@@ -446,15 +445,12 @@ type MenuItemPropsWeControl =
   | 'onFocus'
 
 function Item<TTag extends ElementType = typeof DEFAULT_ITEM_TAG>(
-  props: Props<TTag, ItemRenderPropArg, MenuItemPropsWeControl | 'className'> & {
+  props: Props<TTag, ItemRenderPropArg, MenuItemPropsWeControl> & {
     disabled?: boolean
     onClick?: (event: { preventDefault: Function }) => void
-
-    // Special treatment, can either be a string or a function that resolves to a string
-    className?: ((bag: ItemRenderPropArg) => string) | string
   }
 ) {
-  let { disabled = false, className, onClick, ...passthroughProps } = props
+  let { disabled = false, onClick, ...passthroughProps } = props
   let [state, dispatch] = useMenuContext([Menu.name, Item.name].join('.'))
   let id = `headlessui-menu-item-${useId()}`
   let active = state.activeItemIndex !== null ? state.items[state.activeItemIndex].id === id : false
@@ -514,7 +510,6 @@ function Item<TTag extends ElementType = typeof DEFAULT_ITEM_TAG>(
     id,
     role: 'menuitem',
     tabIndex: -1,
-    className: resolvePropValue(className, propsBag),
     'aria-disabled': disabled === true ? true : undefined,
     onClick: handleClick,
     onFocus: handleFocus,

--- a/packages/@headlessui-react/src/components/switch/switch.tsx
+++ b/packages/@headlessui-react/src/components/switch/switch.tsx
@@ -16,7 +16,6 @@ import { Props } from '../../types'
 import { render } from '../../utils/render'
 import { useId } from '../../hooks/use-id'
 import { Keys } from '../keyboard'
-import { resolvePropValue } from '../../utils/resolve-prop-value'
 import { isDisabledReactIssue7711 } from '../../utils/bugs'
 
 interface StateDefinition {
@@ -95,19 +94,12 @@ type SwitchPropsWeControl =
   | 'onKeyPress'
 
 export function Switch<TTag extends ElementType = typeof DEFAULT_SWITCH_TAG>(
-  props: Props<
-    TTag,
-    SwitchRenderPropArg,
-    SwitchPropsWeControl | 'checked' | 'onChange' | 'className'
-  > & {
+  props: Props<TTag, SwitchRenderPropArg, SwitchPropsWeControl | 'checked' | 'onChange'> & {
     checked: boolean
     onChange(checked: boolean): void
-
-    // Special treatment, can either be a string or a function that resolves to a string
-    className?: ((bag: SwitchRenderPropArg) => string) | string
   }
 ) {
-  let { checked, onChange, className, ...passThroughProps } = props
+  let { checked, onChange, ...passThroughProps } = props
   let id = `headlessui-switch-${useId()}`
   let groupContext = useContext(GroupContext)
 
@@ -140,7 +132,6 @@ export function Switch<TTag extends ElementType = typeof DEFAULT_SWITCH_TAG>(
     ref: groupContext === null ? undefined : groupContext.setSwitch,
     role: 'switch',
     tabIndex: 0,
-    className: resolvePropValue(className, propsBag),
     'aria-checked': checked,
     'aria-labelledby': groupContext?.label?.id,
     'aria-describedby': groupContext?.description?.id,

--- a/packages/@headlessui-react/src/types.ts
+++ b/packages/@headlessui-react/src/types.ts
@@ -17,11 +17,12 @@ export type Props<
   TSlot = any,
   TOmitableProps extends keyof any = __
 > = (TOmitableProps extends __
-  ? Omit<PropsOf<TTag>, 'as' | 'children' | 'refName'>
-  : Omit<PropsOf<TTag>, TOmitableProps | 'as' | 'children' | 'refName'>) & {
+  ? Omit<PropsOf<TTag>, 'as' | 'children' | 'refName' | 'className'>
+  : Omit<PropsOf<TTag>, TOmitableProps | 'as' | 'children' | 'refName' | 'className'>) & {
   as?: TTag
   children?: ReactNode | ((bag: TSlot) => ReactElement)
   refName?: string
+  className?: string | ((bag: TSlot) => string)
 }
 
 type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never }

--- a/packages/@headlessui-react/src/types.ts
+++ b/packages/@headlessui-react/src/types.ts
@@ -12,18 +12,34 @@ export type PropsOf<TTag = any> = TTag extends React.ElementType
   ? React.ComponentProps<TTag>
   : never
 
-export type Props<
-  TTag,
-  TSlot = any,
-  TOmitableProps extends keyof any = __
-> = (TOmitableProps extends __
-  ? Omit<PropsOf<TTag>, 'as' | 'children' | 'refName' | 'className'>
-  : Omit<PropsOf<TTag>, TOmitableProps | 'as' | 'children' | 'refName' | 'className'>) & {
+type PropsWeControl = 'as' | 'children' | 'refName' | 'className'
+
+// Resolve the props of the component, but ensure to omit certain props that we control
+type CleanProps<TTag, TOmitableProps extends keyof any = __> = TOmitableProps extends __
+  ? Omit<PropsOf<TTag>, PropsWeControl>
+  : Omit<PropsOf<TTag>, TOmitableProps | PropsWeControl>
+
+// Add certain props that we control
+type OurProps<TTag, TSlot = any> = {
   as?: TTag
   children?: ReactNode | ((bag: TSlot) => ReactElement)
   refName?: string
-  className?: string | ((bag: TSlot) => string)
 }
+
+// Conditionally override the `className`, to also allow for a function
+// if and only if the PropsOf<TTag> already define `className`.
+// This will allow us to have a TS error on as={Fragment}
+type ClassNameOverride<TTag, TSlot = any> = PropsOf<TTag> extends { className?: any }
+  ? { className?: string | ((bag: TSlot) => string) }
+  : {}
+
+// Provide clean TypeScript props, which exposes some of our custom API's.
+export type Props<TTag, TSlot = any, TOmitableProps extends keyof any = __> = CleanProps<
+  TTag,
+  TOmitableProps
+> &
+  OurProps<TTag, TSlot> &
+  ClassNameOverride<TTag, TSlot>
 
 type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never }
 export type XOR<T, U> = T | U extends __

--- a/packages/@headlessui-react/src/utils/render.ts
+++ b/packages/@headlessui-react/src/utils/render.ts
@@ -104,6 +104,11 @@ function _render<TTag extends ElementType, TBag>(
     | ReactElement
     | ReactElement[]
 
+  // Allow for className to be a function with the bag as the contents
+  if (passThroughProps.className && typeof passThroughProps.className === 'function') {
+    ;(passThroughProps as any).className = passThroughProps.className(bag)
+  }
+
   if (Component === Fragment) {
     if (Object.keys(passThroughProps).length > 0) {
       if (Array.isArray(resolvedChildren) && resolvedChildren.length > 1) {

--- a/packages/@headlessui-react/src/utils/resolve-prop-value.ts
+++ b/packages/@headlessui-react/src/utils/resolve-prop-value.ts
@@ -1,5 +1,0 @@
-export function resolvePropValue<TProperty, TBag>(property: TProperty, bag: TBag) {
-  if (property === undefined) return undefined
-  if (typeof property === 'function') return property(bag)
-  return property
-}


### PR DESCRIPTION
Every component that accepts a className should be able to pass in a
function. This function will retrieve the render prop arg for this
component. The function should resolve to a string in the end.

This makes the API a bit nicer if you just need to change the classNames
based on some internal state.

E.g.:

```jsx
// Before
<Menu.Button as={Fragment}>
  {({ open }) => (
    <button className={open ? 'font-bold' : 'font-normal'}>
      Hello
    </button>
  )}
</Menu.Button>

// After
<Menu.Button className={({ open }) => open ? 'font-bold' : 'font-normal'}>
  Hello
</Menu.Button>
```