### PR TITLE
Update <Switch.Label as={CustomComponent}> documentation

### DIFF
--- a/packages/@headlessui-react/README.md
+++ b/packages/@headlessui-react/README.md
@@ -1331,6 +1331,24 @@ function NotificationsToggle() {
 }
 ```
 
+When passing a component to `<Switch.Label as={YourOwnComponent}>`, we expect that you pass the `ref`, `id` and `onClick` props to the underlying `<label>` element.
+
+```jsx
+import { forwardRef } from 'react';
+ 
+const CustomLabel = forwardRef((props, ref) => {
+  return <label ref={ref} id={props.id} onClick={props.onClick}>{props.children}</label>
+})
+```
+```jsx
+<Switch.Group>
+  <Switch.Label as={CustomLabel}>Enable notifications</Switch.Label>
+  <Switch checked={enabled} onChange={setEnabled} className="...">
+    {/* ... */}
+  </Switch>
+</Switch.Group>
+```
+
 ### Component API
 
 #### Switch


### PR DESCRIPTION
Adds an example on what props are expected to be passed down to the underlying label element in case you use a custom component for it.