### PR TITLE
IE11 Bug: document.createTreeWalker crashes with "Argument is not optional"

### DIFF
--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -318,7 +318,7 @@ let Items = forwardRefWithAs(function Items<TTag extends ElementType = typeof DE
         if (node.hasAttribute('role')) return NodeFilter.FILTER_SKIP
         return NodeFilter.FILTER_ACCEPT
       },
-    })
+    }, false)
 
     while (walker.nextNode()) {
       ;(walker.currentNode as HTMLElement).setAttribute('role', 'none')

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -312,13 +312,20 @@ let Items = forwardRefWithAs(function Items<TTag extends ElementType = typeof DE
     if (!container) return
     if (state.menuState !== MenuStates.Open) return
 
-    let walker = document.createTreeWalker(container, NodeFilter.SHOW_ELEMENT, {
-      acceptNode(node: HTMLElement) {
-        if (node.getAttribute('role') === 'menuitem') return NodeFilter.FILTER_REJECT
-        if (node.hasAttribute('role')) return NodeFilter.FILTER_SKIP
-        return NodeFilter.FILTER_ACCEPT
-      },
-    }, false)
+    function acceptNode(node: HTMLElement) {
+      if (node.getAttribute('role') === 'menuitem') return NodeFilter.FILTER_REJECT
+      if (node.hasAttribute('role')) return NodeFilter.FILTER_SKIP
+      return NodeFilter.FILTER_ACCEPT
+    }
+  
+    // Work around Internet Explorer wanting a function instead of an object.
+    // IE also *requires* this argument where other browsers don't.
+    function safeFilter(node: HTMLElement) {
+        return acceptNode(node);
+    }
+    safeFilter.acceptNode = acceptNode;
+
+    let walker = document.createTreeWalker(container, NodeFilter.SHOW_ELEMENT, safeFilter, false)
 
     while (walker.nextNode()) {
       ;(walker.currentNode as HTMLElement).setAttribute('role', 'none')


### PR DESCRIPTION
Hello,

We're using `headlessui/react` in a project that requires IE11 support unfortunately.
The code crashes though when we use the `Menu.Items` component, as IE expects all 4 arguments to be passed to `document.createTreeWalker`.

The [fourth parameter](https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker/expandEntityReferences) is deprecated in modern browsers however, so I understand if you decline this PR, though I would ask you to consider this change :)

Similar issue on another project for some more context: https://github.com/webcomponents/webcomponentsjs/issues/556

This was the only instance in the codebase where I could find `createTreeWalker` usage.