### PR TITLE
Skip the Provider component and simplify context

### DIFF
--- a/packages/@headlessui-vue/src/components/description/description.test.ts
+++ b/packages/@headlessui-vue/src/components/description/description.test.ts
@@ -1,10 +1,12 @@
-import { defineComponent, h, nextTick } from 'vue'
+import { defineComponent, h, nextTick, ref } from 'vue'
 import prettier from 'prettier'
 
 import { render } from '../../test-utils/vue-testing-library'
 import { Description, useDescriptions } from './description'
 
 import { html } from '../../test-utils/html'
+import { click } from '../../test-utils/interactions'
+import { getByText } from '../../test-utils/accessibility-assertions'
 
 function format(input: Element | string) {
   let contents = (typeof input === 'string' ? input : (input as HTMLElement).outerHTML).trim()
@@ -36,18 +38,14 @@ function renderTemplate(input: string | Partial<Parameters<typeof defineComponen
   )
 }
 
-it('should be possible to use a DescriptionProvider without using a Description', async () => {
+it('should be possible to use useDescriptions without using a Description', async () => {
   let { container } = renderTemplate({
     render() {
-      return h('div', [
-        h(this.DescriptionProvider, () => [
-          h('div', { 'aria-describedby': this.describedby }, ['No description']),
-        ]),
-      ])
+      return h('div', [h('div', { 'aria-describedby': this.describedby }, ['No description'])])
     },
     setup() {
-      let [describedby, DescriptionProvider] = useDescriptions()
-      return { describedby, DescriptionProvider }
+      let describedby = useDescriptions()
+      return { describedby }
     },
   })
 
@@ -60,21 +58,19 @@ it('should be possible to use a DescriptionProvider without using a Description'
   )
 })
 
-it('should be possible to use a DescriptionProvider and a single Description, and have them linked', async () => {
+it('should be possible to use useDescriptions and a single Description, and have them linked', async () => {
   let { container } = renderTemplate({
     render() {
       return h('div', [
-        h(this.DescriptionProvider, () => [
-          h('div', { 'aria-describedby': this.describedby }, [
-            h(Description, () => 'I am a description'),
-            h('span', 'Contents'),
-          ]),
+        h('div', { 'aria-describedby': this.describedby }, [
+          h(Description, () => 'I am a description'),
+          h('span', 'Contents'),
         ]),
       ])
     },
     setup() {
-      let [describedby, DescriptionProvider] = useDescriptions()
-      return { describedby, DescriptionProvider }
+      let describedby = useDescriptions()
+      return { describedby }
     },
   })
 
@@ -94,22 +90,20 @@ it('should be possible to use a DescriptionProvider and a single Description, an
   )
 })
 
-it('should be possible to use a DescriptionProvider and multiple Description components, and have them linked', async () => {
+it('should be possible to use useDescriptions and multiple Description components, and have them linked', async () => {
   let { container } = renderTemplate({
     render() {
       return h('div', [
-        h(this.DescriptionProvider, () => [
-          h('div', { 'aria-describedby': this.describedby }, [
-            h(Description, () => 'I am a description'),
-            h('span', 'Contents'),
-            h(Description, () => 'I am also a description'),
-          ]),
+        h('div', { 'aria-describedby': this.describedby }, [
+          h(Description, () => 'I am a description'),
+          h('span', 'Contents'),
+          h(Description, () => 'I am also a description'),
         ]),
       ])
     },
     setup() {
-      let [describedby, DescriptionProvider] = useDescriptions()
-      return { describedby, DescriptionProvider }
+      let describedby = useDescriptions()
+      return { describedby }
     },
   })
 
@@ -127,6 +121,50 @@ it('should be possible to use a DescriptionProvider and multiple Description com
         <p id="headlessui-description-2">
           I am also a description
         </p>
+      </div>
+    `)
+  )
+})
+
+it('should be possible to update a prop from the parent and it should reflect in the Description component', async () => {
+  let { container } = renderTemplate({
+    render() {
+      return h('div', [
+        h('div', { 'aria-describedby': this.describedby }, [
+          h(Description, () => 'I am a description'),
+          h('button', { onClick: () => this.count++ }, '+1'),
+        ]),
+      ])
+    },
+    setup() {
+      let count = ref(0)
+      let describedby = useDescriptions({ props: { 'data-count': count } })
+      return { count, describedby }
+    },
+  })
+
+  await new Promise<void>(nextTick)
+
+  expect(format(container.firstElementChild)).toEqual(
+    format(html`
+      <div aria-describedby="headlessui-description-1">
+        <p data-count="0" id="headlessui-description-1">
+          I am a description
+        </p>
+        <button>+1</button>
+      </div>
+    `)
+  )
+
+  await click(getByText('+1'))
+
+  expect(format(container.firstElementChild)).toEqual(
+    format(html`
+      <div aria-describedby="headlessui-description-1">
+        <p data-count="1" id="headlessui-description-1">
+          I am a description
+        </p>
+        <button>+1</button>
       </div>
     `)
   )

--- a/packages/@headlessui-vue/src/components/dialog/dialog.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.ts
@@ -109,17 +109,15 @@ export let Dialog = defineComponent({
           h(Portal, {}, () => [
             h(PortalGroup, { target: this.dialogRef }, () => [
               h(ForcePortalRoot, { force: false }, () => [
-                h(this.DescriptionProvider, { slot }, () => [
-                  render({
-                    props: { ...passThroughProps, ...propsWeControl },
-                    slot,
-                    attrs: this.$attrs,
-                    slots: this.$slots,
-                    visible: open,
-                    features: Features.RenderStrategy | Features.Static,
-                    name: 'Dialog',
-                  }),
-                ]),
+                render({
+                  props: { ...passThroughProps, ...propsWeControl },
+                  slot,
+                  attrs: this.$attrs,
+                  slots: this.$slots,
+                  visible: open,
+                  features: Features.RenderStrategy | Features.Static,
+                  name: 'Dialog',
+                }),
               ]),
             ]),
           ]),
@@ -182,7 +180,10 @@ export let Dialog = defineComponent({
 
     useFocusTrap(containers, enabled, focusTrapOptions)
     useInertOthers(internalDialogRef, enabled)
-    let [describedby, DescriptionProvider] = useDescriptions()
+    let describedby = useDescriptions({
+      name: 'DialogDescription',
+      slot: { open: props.open },
+    })
 
     let titleId = ref<StateDefinition['titleId']['value']>(null)
 
@@ -271,7 +272,6 @@ export let Dialog = defineComponent({
       dialogState,
       titleId,
       describedby,
-      DescriptionProvider,
     }
   },
 })

--- a/packages/@headlessui-vue/src/components/radio-group/radio-group.ts
+++ b/packages/@headlessui-vue/src/components/radio-group/radio-group.ts
@@ -1,7 +1,6 @@
 import {
   computed,
   defineComponent,
-  h,
   inject,
   onMounted,
   onUnmounted,
@@ -60,7 +59,6 @@ function useRadioGroupContext(component: string) {
 export let RadioGroup = defineComponent({
   name: 'RadioGroup',
   emits: ['update:modelValue'],
-  inheritAttrs: false, // Manually handling this
   props: {
     as: { type: [Object, String], default: 'div' },
     disabled: { type: [Boolean], default: false },
@@ -70,9 +68,6 @@ export let RadioGroup = defineComponent({
     let { modelValue, disabled, ...passThroughProps } = this.$props
 
     let propsWeControl = {
-      // Manually passthrough the attributes, because Vue can't automatically pass
-      // it to the underlying div because of all the wrapper components below.
-      ...this.$attrs,
       ref: 'el',
       id: this.id,
       role: 'radiogroup',
@@ -81,23 +76,19 @@ export let RadioGroup = defineComponent({
       onKeydown: this.handleKeyDown,
     }
 
-    return h(this.DescriptionProvider, () => [
-      h(this.LabelProvider, () => [
-        render({
-          props: { ...passThroughProps, ...propsWeControl },
-          slot: {},
-          attrs: this.$attrs,
-          slots: this.$slots,
-          name: 'RadioGroup',
-        }),
-      ]),
-    ])
+    return render({
+      props: { ...passThroughProps, ...propsWeControl },
+      slot: {},
+      attrs: this.$attrs,
+      slots: this.$slots,
+      name: 'RadioGroup',
+    })
   },
   setup(props, { emit }) {
     let radioGroupRef = ref<HTMLElement | null>(null)
     let options = ref<StateDefinition['options']['value']>([])
-    let [labelledby, LabelProvider] = useLabels()
-    let [describedby, DescriptionProvider] = useDescriptions()
+    let labelledby = useLabels({ name: 'RadioGroupLabel' })
+    let describedby = useDescriptions({ name: 'RadioGroupDescription' })
 
     let value = computed(() => props.modelValue)
 
@@ -214,8 +205,6 @@ export let RadioGroup = defineComponent({
       describedby,
       el: radioGroupRef,
       handleKeyDown,
-      LabelProvider,
-      DescriptionProvider,
     }
   },
 })
@@ -229,7 +218,6 @@ enum OptionState {
 
 export let RadioGroupOption = defineComponent({
   name: 'RadioGroupOption',
-  inheritAttrs: false, // Manually handling this
   props: {
     as: { type: [Object, String], default: 'div' },
     value: { type: [Object, String] },
@@ -251,9 +239,6 @@ export let RadioGroupOption = defineComponent({
 
     let slot = { checked: this.checked, active: Boolean(this.state & OptionState.Active) }
     let propsWeControl = {
-      // Manually passthrough the attributes, because Vue can't automatically pass
-      // it to the underlying div because of all the wrapper components below.
-      ...this.$attrs,
       id: this.id,
       ref: 'el',
       role: 'radio',
@@ -267,23 +252,19 @@ export let RadioGroupOption = defineComponent({
       onBlur: this.handleBlur,
     }
 
-    return h(this.DescriptionProvider, () => [
-      h(this.LabelProvider, () => [
-        render({
-          props: { ...passThroughProps, ...propsWeControl },
-          slot,
-          attrs: this.$attrs,
-          slots: this.$slots,
-          name: 'RadioGroupOption',
-        }),
-      ]),
-    ])
+    return render({
+      props: { ...passThroughProps, ...propsWeControl },
+      slot,
+      attrs: this.$attrs,
+      slots: this.$slots,
+      name: 'RadioGroupOption',
+    })
   },
   setup(props) {
     let api = useRadioGroupContext('RadioGroupOption')
     let id = `headlessui-radiogroup-option-${useId()}`
-    let [labelledby, LabelProvider] = useLabels()
-    let [describedby, DescriptionProvider] = useDescriptions()
+    let labelledby = useLabels({ name: 'RadioGroupLabel' })
+    let describedby = useDescriptions({ name: 'RadioGroupDescription' })
 
     let optionRef = ref<HTMLElement | null>(null)
     let propsRef = computed(() => ({ value: props.value }))
@@ -298,8 +279,6 @@ export let RadioGroupOption = defineComponent({
       labelledby,
       describedby,
       state,
-      LabelProvider,
-      DescriptionProvider,
       checked: computed(() => toRaw(api.value.value) === toRaw(props.value)),
       handleClick() {
         let value = props.value

--- a/packages/@headlessui-vue/src/components/switch/switch.ts
+++ b/packages/@headlessui-vue/src/components/switch/switch.ts
@@ -1,6 +1,5 @@
 import {
   defineComponent,
-  h,
   inject,
   provide,
   ref,
@@ -30,49 +29,28 @@ let GroupContext = Symbol('GroupContext') as InjectionKey<StateDefinition>
 
 export let SwitchGroup = defineComponent({
   name: 'SwitchGroup',
-  inheritAttrs: false, // Manually handling this
   props: {
     as: { type: [Object, String], default: 'template' },
   },
   setup(props, { slots, attrs }) {
     let switchRef = ref<StateDefinition['switchRef']['value']>(null)
-    let [labelledby, LabelProvider] = useLabels()
-    let [describedby, DescriptionProvider] = useDescriptions()
+    let labelledby = useLabels({
+      name: 'SwitchLabel',
+      props: {
+        onClick() {
+          if (!switchRef.value) return
+          switchRef.value.click()
+          switchRef.value.focus({ preventScroll: true })
+        },
+      },
+    })
+    let describedby = useDescriptions({ name: 'SwitchDescription' })
 
     let api = { switchRef, labelledby, describedby }
 
     provide(GroupContext, api)
 
-    return () =>
-      h(DescriptionProvider, { name: 'SwitchDescription' }, () => [
-        h(
-          LabelProvider,
-          {
-            name: 'SwitchLabel',
-            props: {
-              onClick() {
-                if (!switchRef.value) return
-                switchRef.value.click()
-                switchRef.value.focus({ preventScroll: true })
-              },
-            },
-          },
-          () => [
-            render({
-              props: {
-                // Manually passthrough the attributes, because Vue can't automatically pass
-                // it to the underlying div because of all the wrapper components below.
-                ...attrs,
-                ...props,
-              },
-              slot: {},
-              slots,
-              attrs,
-              name: 'SwitchGroup',
-            }),
-          ]
-        ),
-      ])
+    return () => render({ props, slot: {}, slots, attrs, name: 'SwitchGroup' })
   },
 })
 


### PR DESCRIPTION
I was on a walk, and I realised that in Vue you can just call
provide(Symbol, context), which means that a hook like `useLabels` can
just provide context...

This simplifies a lot!
