### PR TITLE
Match RadioGroupOption types to RadioGroup in radio-group.ts

### DIFF
--- a/packages/@headlessui-vue/src/components/radio-group/radio-group.ts
+++ b/packages/@headlessui-vue/src/components/radio-group/radio-group.ts
@@ -215,7 +215,7 @@ export let RadioGroupOption = defineComponent({
   name: 'RadioGroupOption',
   props: {
     as: { type: [Object, String], default: 'div' },
-    value: { type: [Object, String] },
+    value: { type: [Object, String, Number, Boolean] },
     disabled: { type: Boolean, default: false },
     class: { type: [String, Function], required: false },
     className: { type: [String, Function], required: false },


### PR DESCRIPTION
Regarding Vue implementation

RadioGroup modelValue is set to
```
modelValue: { type: [Object, String, Number, Boolean] },
```
But RadioGroupOption value is set to
```
value: { type: [Object, String] },
```
So this is just a simple tweak to RadioGroupOption value types to match modelValue allowed types for RadioGroup to stop prop types warning when using Number or Boolean