### PR TITLE
Open closed state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased - React]
 
-- Nothing yet!
+### Added 
+
+- Introduce Open/Closed state, to simplify component communication ([#466](https://github.com/tailwindlabs/headlessui/pull/466))
 
 ## [Unreleased - Vue]
 
-- Nothing yet!
+### Added 
+
+- Introduce Open/Closed state, to simplify component communication ([#466](https://github.com/tailwindlabs/headlessui/pull/466))
 
 ## [@headlessui/react@v1.1.1] - 2021-04-28
 

--- a/packages/@headlessui-react/pages/dialog/dialog.tsx
+++ b/packages/@headlessui-react/pages/dialog/dialog.tsx
@@ -20,7 +20,7 @@ function Nested({ onClose, level = 0 }) {
   return (
     <>
       <Dialog open={true} onClose={onClose} className="fixed z-10 inset-0">
-        {true && <Dialog.Overlay className="fixed inset-0 bg-gray-500 opacity-25" />}
+        <Dialog.Overlay className="fixed inset-0 bg-gray-500 opacity-25" />
         <div
           className="z-10 fixed left-12 top-24 bg-white w-96 p-4"
           style={{
@@ -69,8 +69,8 @@ export default function Home() {
       <button onClick={() => setNested(true)}>Show nested</button>
       {nested && <Nested onClose={() => setNested(false)} />}
 
-      <Transition show={isOpen} as={Fragment}>
-        <Dialog open={isOpen} onClose={setIsOpen} static>
+      <Transition show={isOpen} as={Fragment} afterLeave={() => console.log('done')}>
+        <Dialog onClose={setIsOpen}>
           <div className="fixed z-10 inset-0 overflow-y-auto">
             <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
               <Transition.Child
@@ -136,96 +136,78 @@ export default function Home() {
                           </p>
                           <div className="relative inline-block text-left mt-10">
                             <Menu>
-                              {({ open }) => (
-                                <>
-                                  <span className="rounded-md shadow-sm">
-                                    <Menu.Button
-                                      ref={trigger}
-                                      className="inline-flex justify-center w-full px-4 py-2 text-sm font-medium leading-5 text-gray-700 transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md hover:text-gray-500 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-50 active:text-gray-800"
-                                    >
-                                      <span>Choose a reason</span>
-                                      <svg
-                                        className="w-5 h-5 ml-2 -mr-1"
-                                        viewBox="0 0 20 20"
-                                        fill="currentColor"
-                                      >
-                                        <path
-                                          fillRule="evenodd"
-                                          d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-                                          clipRule="evenodd"
-                                        />
-                                      </svg>
-                                    </Menu.Button>
-                                  </span>
-
-                                  <Transition
-                                    show={open}
-                                    enter="transition duration-100 ease-out"
-                                    enterFrom="transform scale-95 opacity-0"
-                                    enterTo="transform scale-100 opacity-100"
-                                    leave="transition duration-75 ease-out"
-                                    leaveFrom="transform scale-100 opacity-100"
-                                    leaveTo="transform scale-95 opacity-0"
+                              <span className="rounded-md shadow-sm">
+                                <Menu.Button
+                                  ref={trigger}
+                                  className="inline-flex justify-center w-full px-4 py-2 text-sm font-medium leading-5 text-gray-700 transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md hover:text-gray-500 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-50 active:text-gray-800"
+                                >
+                                  <span>Choose a reason</span>
+                                  <svg
+                                    className="w-5 h-5 ml-2 -mr-1"
+                                    viewBox="0 0 20 20"
+                                    fill="currentColor"
                                   >
-                                    <Portal>
-                                      <Menu.Items
-                                        ref={container}
-                                        static
-                                        className="z-20 w-56 mt-2 origin-top-right bg-white border border-gray-200 divide-y divide-gray-100 rounded-md shadow-lg outline-none"
+                                    <path
+                                      fillRule="evenodd"
+                                      d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+                                      clipRule="evenodd"
+                                    />
+                                  </svg>
+                                </Menu.Button>
+                              </span>
+
+                              <Transition
+                                enter="transition duration-300 ease-out"
+                                enterFrom="transform scale-95 opacity-0"
+                                enterTo="transform scale-100 opacity-100"
+                                leave="transition duration-75 ease-out"
+                                leaveFrom="transform scale-100 opacity-100"
+                                leaveTo="transform scale-95 opacity-0"
+                              >
+                                <Portal>
+                                  <Menu.Items
+                                    ref={container}
+                                    className="z-20 w-56 mt-2 origin-top-right bg-white border border-gray-200 divide-y divide-gray-100 rounded-md shadow-lg outline-none"
+                                  >
+                                    <div className="px-4 py-3">
+                                      <p className="text-sm leading-5">Signed in as</p>
+                                      <p className="text-sm font-medium leading-5 text-gray-900 truncate">
+                                        tom@example.com
+                                      </p>
+                                    </div>
+
+                                    <div className="py-1">
+                                      <Menu.Item
+                                        as="a"
+                                        href="#account-settings"
+                                        className={resolveClass}
                                       >
-                                        <div className="px-4 py-3">
-                                          <p className="text-sm leading-5">Signed in as</p>
-                                          <p className="text-sm font-medium leading-5 text-gray-900 truncate">
-                                            tom@example.com
-                                          </p>
-                                        </div>
+                                        Account settings
+                                      </Menu.Item>
+                                      <Menu.Item as="a" href="#support" className={resolveClass}>
+                                        Support
+                                      </Menu.Item>
+                                      <Menu.Item
+                                        as="a"
+                                        disabled
+                                        href="#new-feature"
+                                        className={resolveClass}
+                                      >
+                                        New feature (soon)
+                                      </Menu.Item>
+                                      <Menu.Item as="a" href="#license" className={resolveClass}>
+                                        License
+                                      </Menu.Item>
+                                    </div>
 
-                                        <div className="py-1">
-                                          <Menu.Item
-                                            as="a"
-                                            href="#account-settings"
-                                            className={resolveClass}
-                                          >
-                                            Account settings
-                                          </Menu.Item>
-                                          <Menu.Item
-                                            as="a"
-                                            href="#support"
-                                            className={resolveClass}
-                                          >
-                                            Support
-                                          </Menu.Item>
-                                          <Menu.Item
-                                            as="a"
-                                            disabled
-                                            href="#new-feature"
-                                            className={resolveClass}
-                                          >
-                                            New feature (soon)
-                                          </Menu.Item>
-                                          <Menu.Item
-                                            as="a"
-                                            href="#license"
-                                            className={resolveClass}
-                                          >
-                                            License
-                                          </Menu.Item>
-                                        </div>
-
-                                        <div className="py-1">
-                                          <Menu.Item
-                                            as="a"
-                                            href="#sign-out"
-                                            className={resolveClass}
-                                          >
-                                            Sign out
-                                          </Menu.Item>
-                                        </div>
-                                      </Menu.Items>
-                                    </Portal>
-                                  </Transition>
-                                </>
-                              )}
+                                    <div className="py-1">
+                                      <Menu.Item as="a" href="#sign-out" className={resolveClass}>
+                                        Sign out
+                                      </Menu.Item>
+                                    </div>
+                                  </Menu.Items>
+                                </Portal>
+                              </Transition>
                             </Menu>
                           </div>
                         </div>

--- a/packages/@headlessui-react/pages/disclosure/disclosure.tsx
+++ b/packages/@headlessui-react/pages/disclosure/disclosure.tsx
@@ -6,25 +6,18 @@ export default function Home() {
     <div className="flex justify-center w-screen h-full p-12 bg-gray-50">
       <div className="w-full max-w-xs mx-auto">
         <Disclosure>
-          {({ open }) => (
-            <>
-              <Disclosure.Button>Trigger</Disclosure.Button>
+          <Disclosure.Button>Trigger</Disclosure.Button>
 
-              <Transition
-                show={open}
-                enter="transition duration-100 ease-out"
-                enterFrom="transform scale-95 opacity-0"
-                enterTo="transform scale-100 opacity-100"
-                leave="transition duration-75 ease-out"
-                leaveFrom="transform scale-100 opacity-100"
-                leaveTo="transform scale-95 opacity-0"
-              >
-                <Disclosure.Panel static className="p-4 bg-white mt-4">
-                  Content
-                </Disclosure.Panel>
-              </Transition>
-            </>
-          )}
+          <Transition
+            enter="transition duration-1000 ease-out"
+            enterFrom="transform scale-95 opacity-0"
+            enterTo="transform scale-100 opacity-100"
+            leave="transition duration-1000 ease-out"
+            leaveFrom="transform scale-100 opacity-100"
+            leaveTo="transform scale-95 opacity-0"
+          >
+            <Disclosure.Panel className="p-4 bg-white mt-4">Content</Disclosure.Panel>
+          </Transition>
         </Disclosure>
       </div>
     </div>

--- a/packages/@headlessui-react/pages/menu/menu-with-transition-and-popper.tsx
+++ b/packages/@headlessui-react/pages/menu/menu-with-transition-and-popper.tsx
@@ -26,73 +26,65 @@ export default function Home() {
     <div className="flex justify-center w-screen h-full p-12 bg-gray-50">
       <div className="inline-block mt-64 text-left">
         <Menu>
-          {({ open }) => (
-            <>
-              <span className="rounded-md shadow-sm">
-                <Menu.Button
-                  ref={trigger}
-                  className="inline-flex justify-center w-full px-4 py-2 text-sm font-medium leading-5 text-gray-700 transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md hover:text-gray-500 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-50 active:text-gray-800"
-                >
-                  <span>Options</span>
-                  <svg className="w-5 h-5 ml-2 -mr-1" viewBox="0 0 20 20" fill="currentColor">
-                    <path
-                      fillRule="evenodd"
-                      d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                </Menu.Button>
-              </span>
+          <span className="rounded-md shadow-sm">
+            <Menu.Button
+              ref={trigger}
+              className="inline-flex justify-center w-full px-4 py-2 text-sm font-medium leading-5 text-gray-700 transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md hover:text-gray-500 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-50 active:text-gray-800"
+            >
+              <span>Options</span>
+              <svg className="w-5 h-5 ml-2 -mr-1" viewBox="0 0 20 20" fill="currentColor">
+                <path
+                  fillRule="evenodd"
+                  d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </Menu.Button>
+          </span>
 
-              <div ref={container} className="w-56">
-                <Transition
-                  show={open}
-                  enter="transition duration-100 ease-out"
-                  enterFrom="transform scale-95 opacity-0"
-                  enterTo="transform scale-100 opacity-100"
-                  leave="transition duration-75 ease-out"
-                  leaveFrom="transform scale-100 opacity-100"
-                  leaveTo="transform scale-95 opacity-0"
-                >
-                  <Menu.Items
-                    static
-                    className="bg-white border border-gray-200 divide-y divide-gray-100 rounded-md shadow-lg outline-none"
-                  >
-                    <div className="px-4 py-3">
-                      <p className="text-sm leading-5">Signed in as</p>
-                      <p className="text-sm font-medium leading-5 text-gray-900 truncate">
-                        tom@example.com
-                      </p>
-                    </div>
+          <div ref={container} className="w-56">
+            <Transition
+              enter="transition duration-100 ease-out"
+              enterFrom="transform scale-95 opacity-0"
+              enterTo="transform scale-100 opacity-100"
+              leave="transition duration-75 ease-out"
+              leaveFrom="transform scale-100 opacity-100"
+              leaveTo="transform scale-95 opacity-0"
+            >
+              <Menu.Items className="bg-white border border-gray-200 divide-y divide-gray-100 rounded-md shadow-lg outline-none">
+                <div className="px-4 py-3">
+                  <p className="text-sm leading-5">Signed in as</p>
+                  <p className="text-sm font-medium leading-5 text-gray-900 truncate">
+                    tom@example.com
+                  </p>
+                </div>
 
-                    <div className="py-1">
-                      <Menu.Item as="a" href="#account-settings" className={resolveClass}>
-                        Account settings
-                      </Menu.Item>
-                      <Menu.Item>
-                        {data => (
-                          <a href="#support" className={resolveClass(data)}>
-                            Support
-                          </a>
-                        )}
-                      </Menu.Item>
-                      <Menu.Item as="a" disabled href="#new-feature" className={resolveClass}>
-                        New feature (soon)
-                      </Menu.Item>
-                      <Menu.Item as="a" href="#license" className={resolveClass}>
-                        License
-                      </Menu.Item>
-                    </div>
-                    <div className="py-1">
-                      <Menu.Item as="a" href="#sign-out" className={resolveClass}>
-                        Sign out
-                      </Menu.Item>
-                    </div>
-                  </Menu.Items>
-                </Transition>
-              </div>
-            </>
-          )}
+                <div className="py-1">
+                  <Menu.Item as="a" href="#account-settings" className={resolveClass}>
+                    Account settings
+                  </Menu.Item>
+                  <Menu.Item>
+                    {data => (
+                      <a href="#support" className={resolveClass(data)}>
+                        Support
+                      </a>
+                    )}
+                  </Menu.Item>
+                  <Menu.Item as="a" disabled href="#new-feature" className={resolveClass}>
+                    New feature (soon)
+                  </Menu.Item>
+                  <Menu.Item as="a" href="#license" className={resolveClass}>
+                    License
+                  </Menu.Item>
+                </div>
+                <div className="py-1">
+                  <Menu.Item as="a" href="#sign-out" className={resolveClass}>
+                    Sign out
+                  </Menu.Item>
+                </div>
+              </Menu.Items>
+            </Transition>
+          </div>
         </Menu>
       </div>
     </div>

--- a/packages/@headlessui-react/pages/menu/menu-with-transition.tsx
+++ b/packages/@headlessui-react/pages/menu/menu-with-transition.tsx
@@ -18,65 +18,57 @@ export default function Home() {
     <div className="flex justify-center w-screen h-full p-12 bg-gray-50">
       <div className="relative inline-block text-left">
         <Menu>
-          {({ open }) => (
-            <>
-              <span className="rounded-md shadow-sm">
-                <Menu.Button className="inline-flex justify-center w-full px-4 py-2 text-sm font-medium leading-5 text-gray-700 transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md hover:text-gray-500 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-50 active:text-gray-800">
-                  <span>Options</span>
-                  <svg className="w-5 h-5 ml-2 -mr-1" viewBox="0 0 20 20" fill="currentColor">
-                    <path
-                      fillRule="evenodd"
-                      d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                </Menu.Button>
-              </span>
+          <span className="rounded-md shadow-sm">
+            <Menu.Button className="inline-flex justify-center w-full px-4 py-2 text-sm font-medium leading-5 text-gray-700 transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md hover:text-gray-500 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-50 active:text-gray-800">
+              <span>Options</span>
+              <svg className="w-5 h-5 ml-2 -mr-1" viewBox="0 0 20 20" fill="currentColor">
+                <path
+                  fillRule="evenodd"
+                  d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </Menu.Button>
+          </span>
 
-              <Transition
-                show={open}
-                enter="transition duration-100 ease-out"
-                enterFrom="transform scale-95 opacity-0"
-                enterTo="transform scale-100 opacity-100"
-                leave="transition duration-75 ease-out"
-                leaveFrom="transform scale-100 opacity-100"
-                leaveTo="transform scale-95 opacity-0"
-              >
-                <Menu.Items
-                  static
-                  className="absolute right-0 w-56 mt-2 origin-top-right bg-white border border-gray-200 divide-y divide-gray-100 rounded-md shadow-lg outline-none"
-                >
-                  <div className="px-4 py-3">
-                    <p className="text-sm leading-5">Signed in as</p>
-                    <p className="text-sm font-medium leading-5 text-gray-900 truncate">
-                      tom@example.com
-                    </p>
-                  </div>
+          <Transition
+            enter="transition duration-1000 ease-out"
+            enterFrom="transform scale-95 opacity-0"
+            enterTo="transform scale-100 opacity-100"
+            leave="transition duration-1000 ease-out"
+            leaveFrom="transform scale-100 opacity-100"
+            leaveTo="transform scale-95 opacity-0"
+          >
+            <Menu.Items className="absolute right-0 w-56 mt-2 origin-top-right bg-white border border-gray-200 divide-y divide-gray-100 rounded-md shadow-lg outline-none">
+              <div className="px-4 py-3">
+                <p className="text-sm leading-5">Signed in as</p>
+                <p className="text-sm font-medium leading-5 text-gray-900 truncate">
+                  tom@example.com
+                </p>
+              </div>
 
-                  <div className="py-1">
-                    <Menu.Item as="a" href="#account-settings" className={resolveClass}>
-                      Account settings
-                    </Menu.Item>
-                    <Menu.Item as="a" href="#support" className={resolveClass}>
-                      Support
-                    </Menu.Item>
-                    <Menu.Item as="a" disabled href="#new-feature" className={resolveClass}>
-                      New feature (soon)
-                    </Menu.Item>
-                    <Menu.Item as="a" href="#license" className={resolveClass}>
-                      License
-                    </Menu.Item>
-                  </div>
+              <div className="py-1">
+                <Menu.Item as="a" href="#account-settings" className={resolveClass}>
+                  Account settings
+                </Menu.Item>
+                <Menu.Item as="a" href="#support" className={resolveClass}>
+                  Support
+                </Menu.Item>
+                <Menu.Item as="a" disabled href="#new-feature" className={resolveClass}>
+                  New feature (soon)
+                </Menu.Item>
+                <Menu.Item as="a" href="#license" className={resolveClass}>
+                  License
+                </Menu.Item>
+              </div>
 
-                  <div className="py-1">
-                    <Menu.Item as="a" href="#sign-out" className={resolveClass}>
-                      Sign out
-                    </Menu.Item>
-                  </div>
-                </Menu.Items>
-              </Transition>
-            </>
-          )}
+              <div className="py-1">
+                <Menu.Item as="a" href="#sign-out" className={resolveClass}>
+                  Sign out
+                </Menu.Item>
+              </div>
+            </Menu.Items>
+          </Transition>
         </Menu>
       </div>
     </div>

--- a/packages/@headlessui-react/pages/popover/popover.tsx
+++ b/packages/@headlessui-react/pages/popover/popover.tsx
@@ -41,38 +41,30 @@ export default function Home() {
     <div className="flex justify-center items-center space-x-12 p-12">
       <button>Previous</button>
 
-      <Popover.Group as="nav" ar-label="Mythical University" className="flex space-x-3">
+      <Popover.Group as="nav" aria-label="Mythical University" className="flex space-x-3">
         <Popover as="div" className="relative">
-          {({ open }) => (
-            <>
-              <Transition
-                as={Fragment}
-                show={open}
-                enter="transition ease-out duration-300 transform"
-                enterFrom="opacity-0"
-                enterTo="opacity-100"
-                leave="transition ease-in duration-300 transform"
-                leaveFrom="opacity-100"
-                leaveTo="opacity-0"
-              >
-                <Popover.Overlay
-                  static
-                  className="bg-opacity-75 bg-gray-500 fixed inset-0 z-20"
-                ></Popover.Overlay>
-              </Transition>
+          <Transition
+            as={Fragment}
+            enter="transition ease-out duration-300 transform"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="transition ease-in duration-300 transform"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <Popover.Overlay className="bg-opacity-75 bg-gray-500 fixed inset-0 z-20"></Popover.Overlay>
+          </Transition>
 
-              <Popover.Button className="px-3 py-2 bg-gray-300 border-2 border-transparent focus:outline-none focus:border-blue-900 relative z-30">
-                Normal
-              </Popover.Button>
-              <Popover.Panel className="absolute flex flex-col w-64 bg-gray-100 border-2 border-blue-900 z-30">
-                {links.map((link, i) => (
-                  <Link key={link} hidden={i === 2}>
-                    Normal - {link}
-                  </Link>
-                ))}
-              </Popover.Panel>
-            </>
-          )}
+          <Popover.Button className="px-3 py-2 bg-gray-300 border-2 border-transparent focus:outline-none focus:border-blue-900 relative z-30">
+            Normal
+          </Popover.Button>
+          <Popover.Panel className="absolute flex flex-col w-64 bg-gray-100 border-2 border-blue-900 z-30">
+            {links.map((link, i) => (
+              <Link key={link} hidden={i === 2}>
+                Normal - {link}
+              </Link>
+            ))}
+          </Popover.Panel>
         </Popover>
 
         <Popover as="div" className="relative">

--- a/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../test-utils/accessibility-assertions'
 import { click, press, Keys } from '../../test-utils/interactions'
 import { PropsOf } from '../../types'
+import { Transition } from '../transitions/transition'
 
 jest.mock('../../hooks/use-id')
 
@@ -95,7 +96,6 @@ describe('Rendering', () => {
       'should complain when an `onClose` prop is provided without an `open` prop',
       suppressConsoleLogs(async () => {
         expect(() =>
-          // @ts-expect-error
           render(<Dialog as="div" onClose={() => {}} />)
         ).toThrowErrorMatchingInlineSnapshot(
           `"You provided an \`onClose\` prop to the \`Dialog\`, but forgot an \`open\` prop."`
@@ -350,6 +350,44 @@ describe('Rendering', () => {
       })
     )
   })
+})
+
+describe('Composition', () => {
+  it(
+    'should be possible to open the Dialog via a Transition component',
+    suppressConsoleLogs(async () => {
+      render(
+        <Transition show={true}>
+          <Dialog onClose={console.log}>
+            <Dialog.Description>{JSON.stringify}</Dialog.Description>
+            <TabSentinel />
+          </Dialog>
+        </Transition>
+      )
+
+      assertDialog({ state: DialogState.Visible })
+      assertDialogDescription({
+        state: DialogState.Visible,
+        textContent: JSON.stringify({ open: true }),
+      })
+    })
+  )
+
+  it(
+    'should be possible to close the Dialog via a Transition component',
+    suppressConsoleLogs(async () => {
+      render(
+        <Transition show={false}>
+          <Dialog onClose={console.log}>
+            <Dialog.Description>{JSON.stringify}</Dialog.Description>
+            <TabSentinel />
+          </Dialog>
+        </Transition>
+      )
+
+      assertDialog({ state: DialogState.InvisibleUnmounted })
+    })
+  )
 })
 
 describe('Keyboard interactions', () => {

--- a/packages/@headlessui-react/src/internal/open-closed.tsx
+++ b/packages/@headlessui-react/src/internal/open-closed.tsx
@@ -1,0 +1,29 @@
+import React, {
+  createContext,
+  useContext,
+
+  // Types
+  ReactNode,
+  ReactElement,
+} from 'react'
+
+let Context = createContext<State | null>(null)
+Context.displayName = 'OpenClosedContext'
+
+export enum State {
+  Open,
+  Closed,
+}
+
+export function useOpenClosed() {
+  return useContext(Context)
+}
+
+interface Props {
+  value: State
+  children: ReactNode
+}
+
+export function OpenClosedProvider({ value, children }: Props): ReactElement {
+  return <Context.Provider value={value}>{children}</Context.Provider>
+}

--- a/packages/@headlessui-vue/examples/src/components/dialog/dialog.vue
+++ b/packages/@headlessui-vue/examples/src/components/dialog/dialog.vue
@@ -8,7 +8,7 @@
   </button>
 
   <TransitionRoot :show="isOpen" as="template">
-    <Dialog :open="isOpen" @close="setIsOpen" static>
+    <Dialog @close="setIsOpen">
       <div class="fixed z-10 inset-0 overflow-y-auto">
         <div
           class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
@@ -74,7 +74,7 @@
                         permanently removed. This action cannot be undone.
                       </p>
                       <div class="relative inline-block text-left mt-10">
-                        <Menu v-slot="{ open }">
+                        <Menu>
                           <span class="rounded-md shadow-sm">
                             <MenuButton
                               ref="trigger"
@@ -95,9 +95,16 @@
                             </MenuButton>
                           </span>
 
-                          <Portal v-if="open">
+                              <TransitionRoot
+                                enter="transition duration-300 ease-out"
+                                enterFrom="transform scale-95 opacity-0"
+                                enterTo="transform scale-100 opacity-100"
+                                leave="transition duration-75 ease-out"
+                                leaveFrom="transform scale-100 opacity-100"
+                                leaveTo="transform scale-95 opacity-0"
+                              >
+                          <Portal>
                             <MenuItems
-                              static
                               ref="container"
                               class="z-20 w-56 mt-2 origin-top-right bg-white border border-gray-200 divide-y divide-gray-100 rounded-md shadow-lg outline-none"
                             >
@@ -135,6 +142,7 @@
                               </div>
                             </MenuItems>
                           </Portal>
+                              </TransitionRoot>
                         </Menu>
                       </div>
                     </div>

--- a/packages/@headlessui-vue/examples/src/components/disclosure/disclosure.vue
+++ b/packages/@headlessui-vue/examples/src/components/disclosure/disclosure.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="flex justify-center w-screen h-full p-12 bg-gray-50">
+    <div class="w-full max-w-xs mx-auto">
+      <Disclosure>
+        <DisclosureButton>Trigger</DisclosureButton>
+
+        <TransitionRoot
+          enter="transition duration-1000 ease-out"
+          enterFrom="transform scale-95 opacity-0"
+          enterTo="transform scale-100 opacity-100"
+          leave="transition duration-1000 ease-out"
+          leaveFrom="transform scale-100 opacity-100"
+          leaveTo="transform scale-95 opacity-0"
+        >
+          <DisclosurePanel class="p-4 bg-white mt-4">Content</DisclosurePanel>
+        </TransitionRoot>
+      </Disclosure>
+    </div>
+  </div>
+</template>
+
+<script>
+import { Disclosure, DisclosureButton, DisclosurePanel, TransitionRoot } from '@headlessui/vue'
+
+export default {
+  components: {
+    Disclosure,
+    DisclosureButton,
+    DisclosurePanel,
+    TransitionRoot,
+  },
+}
+</script>

--- a/packages/@headlessui-vue/examples/src/routes.json
+++ b/packages/@headlessui-vue/examples/src/routes.json
@@ -95,6 +95,17 @@
     ]
   },
   {
+    "name": "Disclosure",
+    "path": "/disclosure",
+    "children": [
+      {
+        "name": "Disclosure",
+        "path": "/disclosure/disclosure",
+        "component": "./components/disclosure/disclosure.vue"
+      }
+    ]
+  },
+  {
     "name": "Dialog",
     "path": "/dialog",
     "children": [

--- a/packages/@headlessui-vue/src/components/description/description.ts
+++ b/packages/@headlessui-vue/src/components/description/description.ts
@@ -11,6 +11,7 @@ import {
   // Types
   ComputedRef,
   InjectionKey,
+  Ref,
 } from 'vue'
 
 import { useId } from '../../hooks/use-id'
@@ -20,7 +21,7 @@ import { render } from '../../utils/render'
 
 let DescriptionContext = Symbol('DescriptionContext') as InjectionKey<{
   register(value: string): () => void
-  slot: Record<string, any>
+  slot: Ref<Record<string, any>>
   name: string
   props: Record<string, any>
 }>
@@ -34,11 +35,11 @@ function useDescriptionContext() {
 }
 
 export function useDescriptions({
-  slot = {},
+  slot = ref({}),
   name = 'Description',
   props = {},
 }: {
-  slot?: Record<string, unknown>
+  slot?: Ref<Record<string, unknown>>
   name?: string
   props?: Record<string, unknown>
 } = {}): ComputedRef<string | undefined> {
@@ -70,7 +71,7 @@ export let Description = defineComponent({
     as: { type: [Object, String], default: 'p' },
   },
   render() {
-    let { name = 'Description', slot = {}, props = {} } = this.context
+    let { name = 'Description', slot = ref({}), props = {} } = this.context
     let passThroughProps = this.$props
     let propsWeControl = {
       ...Object.entries(props).reduce(
@@ -82,7 +83,7 @@ export let Description = defineComponent({
 
     return render({
       props: { ...passThroughProps, ...propsWeControl },
-      slot,
+      slot: slot.value,
       attrs: this.$attrs,
       slots: this.$slots,
       name,

--- a/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
@@ -2,6 +2,7 @@ import { defineComponent, ref, nextTick, h } from 'vue'
 import { render } from '../../test-utils/vue-testing-library'
 
 import { Dialog, DialogOverlay, DialogTitle, DialogDescription } from './dialog'
+import { TransitionRoot } from '../transitions/transition'
 import { suppressConsoleLogs } from '../../test-utils/suppress-console-logs'
 import {
   DialogState,
@@ -427,6 +428,52 @@ describe('Rendering', () => {
       })
     )
   })
+})
+
+describe('Composition', () => {
+  it(
+    'should be possible to open the Dialog via a Transition component',
+    suppressConsoleLogs(async () => {
+      renderTemplate({
+        components: { TransitionRoot },
+        template: `
+          <TransitionRoot show>
+            <Dialog @close="() => {}">
+              <DialogDescription v-slot="data">{{JSON.stringify(data)}}</DialogDescription>
+              <TabSentinel />
+            </Dialog>
+          </Transition>
+        `,
+      })
+
+      await new Promise<void>(nextTick)
+
+      assertDialog({ state: DialogState.Visible })
+      assertDialogDescription({
+        state: DialogState.Visible,
+        textContent: JSON.stringify({ open: true }),
+      })
+    })
+  )
+
+  it(
+    'should be possible to close the Dialog via a Transition component',
+    suppressConsoleLogs(async () => {
+      renderTemplate({
+        components: { TransitionRoot },
+        template: `
+          <TransitionRoot :show="false">
+            <Dialog @close="() => {}">
+              <DialogDescription v-slot="data">{{JSON.stringify(data)}}</DialogDescription>
+              <TabSentinel />
+            </Dialog>
+          </Transition>
+        `,
+      })
+
+      assertDialog({ state: DialogState.InvisibleUnmounted })
+    })
+  )
 })
 
 describe('Keyboard interactions', () => {

--- a/packages/@headlessui-vue/src/internal/open-closed.ts
+++ b/packages/@headlessui-vue/src/internal/open-closed.ts
@@ -1,0 +1,23 @@
+import {
+  inject,
+  provide,
+
+  // Types
+  InjectionKey,
+  Ref,
+} from 'vue'
+
+let Context = Symbol('Context') as InjectionKey<Ref<State>>
+
+export enum State {
+  Open,
+  Closed,
+}
+
+export function useOpenClosed() {
+  return inject(Context, null)
+}
+
+export function useOpenClosedProvider(value: Ref<State>) {
+  provide(Context, value)
+}


### PR DESCRIPTION
It might not be immediately obvious what this does, but essentially it allows us to communicate between our components without the need of being explicit. For example, here is a before:

```js
import { Menu, Transition } from "@headlessui/react";

function MyDropdown() {
  return (
    <Menu>
      {({ open }) => (
        <>
          <Menu.Button>More</Menu.Button>

          {/*
            Use the Transition component + open render prop to add transitions.
          */}
          <Transition
            show={open}
            enter="transition duration-100 ease-out"
            enterFrom="transform scale-95 opacity-0"
            enterTo="transform scale-100 opacity-100"
            leave="transition duration-75 ease-out"
            leaveFrom="transform scale-100 opacity-100"
            leaveTo="transform scale-95 opacity-0"
          >
            {/* Don't forget to mark your Menu.Items as static! */}
            <Menu.Items static>
              <Menu.Item>{/* ... */}</Menu.Item>
              {/* ... */}
            </Menu.Items>
          </Transition>
        </>
      )}
    </Menu>
  );
}
```

This is great, it all still works, but we can also simplify it to this:

```js
import { Menu, Transition } from "@headlessui/react";

function MyDropdown() {
  return (
    <Menu>
      <Menu.Button>More</Menu.Button>

      {/* Use the Transition component. */}
      <Transition
        enter="transition duration-100 ease-out"
        enterFrom="transform scale-95 opacity-0"
        enterTo="transform scale-100 opacity-100"
        leave="transition duration-75 ease-out"
        leaveFrom="transform scale-100 opacity-100"
        leaveTo="transform scale-95 opacity-0"
      >
        <Menu.Items>
          <Menu.Item>{/* ... */}</Menu.Item>
          {/* ... */}
        </Menu.Items>
      </Transition>
    </Menu>
  );
}
```

A few things to notice:

1. No need to use a render function to destructure the `open` prop.
2. This means that we don't have to introduce a fragment.
3. We don't need to control the `show` prop on the Transition component.
4. We don't need the `static` prop on the `Menu.Items`.

If you have components that work together with other components / libraries then you can still control all of this.

---

Relying on a shared context allows us to not be coupled to other components. This in turns means that once we start working on the build output and tree-shakings that we don't have to worry about all these interconnected components.