### PR TITLE
Ensure that you can use Transition Child components in more scenario's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased - React]
 
-- Nothing yet!
+### Added 
+
+- Ensure that you can use `Transition.Child` when using implicit Transitions ([#503](https://github.com/tailwindlabs/headlessui/pull/503))
 
 ## [Unreleased - Vue]
 
-- Nothing yet!
+### Added 
+
+- Ensure that you can use `TransitionChild` when using implicit Transitions ([#503](https://github.com/tailwindlabs/headlessui/pull/503))
 
 ## [@headlessui/react@v1.2.0] - 2021-05-10
 

--- a/packages/@headlessui-react/src/components/menu/menu.test.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.test.tsx
@@ -496,6 +496,60 @@ describe('Composition', () => {
       ])
     })
   )
+
+  it(
+    'should be possible to wrap the Menu.Items with a Transition.Child component',
+    suppressConsoleLogs(async () => {
+      let orderFn = jest.fn()
+      render(
+        <Menu>
+          <Menu.Button>Trigger</Menu.Button>
+          <Debug name="Menu" fn={orderFn} />
+          <Transition.Child>
+            <Debug name="Transition" fn={orderFn} />
+            <Menu.Items>
+              <Menu.Item as="a">
+                {data => (
+                  <>
+                    {JSON.stringify(data)}
+                    <Debug name="Menu.Item" fn={orderFn} />
+                  </>
+                )}
+              </Menu.Item>
+            </Menu.Items>
+          </Transition.Child>
+        </Menu>
+      )
+
+      assertMenuButton({
+        state: MenuState.InvisibleUnmounted,
+        attributes: { id: 'headlessui-menu-button-1' },
+      })
+      assertMenu({ state: MenuState.InvisibleUnmounted })
+
+      await click(getMenuButton())
+
+      assertMenuButton({
+        state: MenuState.Visible,
+        attributes: { id: 'headlessui-menu-button-1' },
+      })
+      assertMenu({
+        state: MenuState.Visible,
+        textContent: JSON.stringify({ active: false, disabled: false }),
+      })
+
+      await click(getMenuButton())
+
+      // Verify that we tracked the `mounts` and `unmounts` in the correct order
+      expect(orderFn.mock.calls).toEqual([
+        ['Mounting - Menu'],
+        ['Mounting - Transition'],
+        ['Mounting - Menu.Item'],
+        ['Unmounting - Transition'],
+        ['Unmounting - Menu.Item'],
+      ])
+    })
+  )
 })
 
 describe('Keyboard interactions', () => {

--- a/packages/@headlessui-react/src/components/transitions/transition.tsx
+++ b/packages/@headlessui-react/src/components/transitions/transition.tsx
@@ -400,5 +400,16 @@ export function Transition<TTag extends ElementType = typeof DEFAULT_TRANSITION_
   )
 }
 
-Transition.Child = TransitionChild
+Transition.Child = function Child<TTag extends ElementType = typeof DEFAULT_TRANSITION_CHILD_TAG>(
+  props: TransitionChildProps<TTag>
+) {
+  let hasTransitionContext = useContext(TransitionContext) !== null
+  let hasOpenClosedContext = useOpenClosed() !== null
+
+  return !hasTransitionContext && hasOpenClosedContext ? (
+    <Transition {...props} />
+  ) : (
+    <TransitionChild {...props} />
+  )
+}
 Transition.Root = Transition

--- a/packages/@headlessui-vue/src/internal/open-closed.ts
+++ b/packages/@headlessui-vue/src/internal/open-closed.ts
@@ -14,6 +14,10 @@ export enum State {
   Closed,
 }
 
+export function hasOpenClosed() {
+  return useOpenClosed() !== null
+}
+
 export function useOpenClosed() {
   return inject(Context, null)
 }


### PR DESCRIPTION
When you are using the implicit variants of the components, for example
when you are using a Transition component inside a Menu component then
it might look weird in Vue.

The Vue code could look like this:

```
<Menu>
  <TransitionRoot>
    <MenuItems>...</MenuItems>
  </TransitionRoot>
<Menu>
```

However, `TransitionRoot` doesn't make much sense here because it sits
in the middle of 2 components, and it is also not controlled by an
explicit `show` prop.

This commit will allows you to use a `TransitionChild` instead (in fact,
both work).

We basically now do a few things, when you are using a TransitionChild:

- Do we have a parent `TransitionRoot`? Yes -> Use it
- Do we have an open closed state? Yes -> Render a TransitionRoot in
  between behind the scenes.
- Throw the error we were throwing before!
