### PR TITLE
Add missing :open prop to Dialog example

### DIFF
--- a/packages/@headlessui-vue/examples/src/components/dialog/dialog.vue
+++ b/packages/@headlessui-vue/examples/src/components/dialog/dialog.vue
@@ -8,7 +8,7 @@
   </button>
 
   <TransitionRoot :show="isOpen" as="template">
-    <Dialog @close="setIsOpen">
+    <Dialog :open="isOpen" @close="setIsOpen">
       <div class="fixed z-10 inset-0 overflow-y-auto">
         <div
           class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"


### PR DESCRIPTION
It will complain if the prop is not present

> Uncaught (in promise) Error: You forgot to provide an `open` prop to the `Dialog`.

![image](https://user-images.githubusercontent.com/1721611/117926898-fbb48280-b2e8-11eb-8d45-9681d4a90491.png)
