### PR TITLE
Improve Vue reactivity & `disabled` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure that you can use `Transition.Child` when using implicit Transitions ([#503](https://github.com/tailwindlabs/headlessui/pull/503))
 
+### Fixes
+
+- Improve `disabled` and `tabindex` prop handling ([#512](https://github.com/tailwindlabs/headlessui/pull/512))
+
 ## [Unreleased - Vue]
 
 ### Added 
 
 - Ensure that you can use `TransitionChild` when using implicit Transitions ([#503](https://github.com/tailwindlabs/headlessui/pull/503))
+
+### Fixes
+
+- Improve `disabled` and `tabindex` prop handling ([#512](https://github.com/tailwindlabs/headlessui/pull/512))
+- Improve reactivity when destructuring from props ([#512](https://github.com/tailwindlabs/headlessui/pull/512))
 
 ## [@headlessui/react@v1.2.0] - 2021-05-10
 

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -660,9 +660,10 @@ function Option<
   let propsWeControl = {
     id,
     role: 'option',
-    tabIndex: -1,
+    tabIndex: disabled === true ? undefined : -1,
     'aria-disabled': disabled === true ? true : undefined,
     'aria-selected': selected === true ? true : undefined,
+    disabled: undefined, // Never forward the `disabled` prop
     onClick: handleClick,
     onFocus: handleFocus,
     onPointerMove: handleMove,

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -560,8 +560,9 @@ function Item<TTag extends ElementType = typeof DEFAULT_ITEM_TAG>(
   let propsWeControl = {
     id,
     role: 'menuitem',
-    tabIndex: -1,
+    tabIndex: disabled === true ? undefined : -1,
     'aria-disabled': disabled === true ? true : undefined,
+    disabled: undefined, // Never forward the `disabled` prop
     onClick: handleClick,
     onFocus: handleFocus,
     onPointerMove: handleMove,

--- a/packages/@headlessui-react/src/test-utils/accessibility-assertions.ts
+++ b/packages/@headlessui-react/src/test-utils/accessibility-assertions.ts
@@ -193,7 +193,7 @@ export function assertMenuItem(
 
     // Check that we have the correct values for certain attributes
     expect(item).toHaveAttribute('role', 'menuitem')
-    expect(item).toHaveAttribute('tabindex', '-1')
+    if (!item.getAttribute('aria-disabled')) expect(item).toHaveAttribute('tabindex', '-1')
 
     // Ensure menu button has the following attributes
     if (options) {
@@ -483,7 +483,7 @@ export function assertListboxOption(
 
     // Check that we have the correct values for certain attributes
     expect(item).toHaveAttribute('role', 'option')
-    expect(item).toHaveAttribute('tabindex', '-1')
+    if (!item.getAttribute('aria-disabled')) expect(item).toHaveAttribute('tabindex', '-1')
 
     // Ensure listbox button has the following attributes
     if (!options) return

--- a/packages/@headlessui-vue/examples/src/components/listbox/listbox.vue
+++ b/packages/@headlessui-vue/examples/src/components/listbox/listbox.vue
@@ -40,6 +40,7 @@
                   :key="person.id"
                   :value="person"
                   :className="resolveListboxOptionClassName"
+                  :disabled="person.disabled"
                   v-slot="{ active, selected }"
                 >
                   <span
@@ -98,7 +99,7 @@ export default {
       { id: 2, name: 'Arlene Mccoy' },
       { id: 3, name: 'Devon Webb' },
       { id: 4, name: 'Tom Cook' },
-      { id: 5, name: 'Tanya Fox' },
+      { id: 5, name: 'Tanya Fox', disabled: true },
       { id: 6, name: 'Hellen Schmidt' },
       { id: 7, name: 'Caroline Schultz' },
       { id: 8, name: 'Mason Heaney' },
@@ -112,10 +113,11 @@ export default {
       people,
       active,
       classNames,
-      resolveListboxOptionClassName({ active }) {
+      resolveListboxOptionClassName({ active, disabled }) {
         return classNames(
           'relative py-2 pl-3 cursor-default select-none pr-9 focus:outline-none',
-          active ? 'text-white bg-indigo-600' : 'text-gray-900'
+          active ? 'text-white bg-indigo-600' : 'text-gray-900',
+          disabled && 'bg-gray-50 text-gray-300'
         )
       },
     }

--- a/packages/@headlessui-vue/src/components/menu/menu.ts
+++ b/packages/@headlessui-vue/src/components/menu/menu.ts
@@ -418,7 +418,6 @@ export let MenuItem = defineComponent({
   setup(props, { slots, attrs }) {
     let api = useMenuContext('MenuItem')
     let id = `headlessui-menu-item-${useId()}`
-    let { disabled, class: defaultClass, className = defaultClass } = props
 
     let active = computed(() => {
       return api.activeItemIndex.value !== null
@@ -426,7 +425,7 @@ export let MenuItem = defineComponent({
         : false
     })
 
-    let dataRef = ref<MenuItemDataRef['value']>({ disabled, textValue: '' })
+    let dataRef = ref<MenuItemDataRef['value']>({ disabled: props.disabled, textValue: '' })
     onMounted(() => {
       let textValue = document
         .getElementById(id)
@@ -445,34 +444,35 @@ export let MenuItem = defineComponent({
     })
 
     function handleClick(event: MouseEvent) {
-      if (disabled) return event.preventDefault()
+      if (props.disabled) return event.preventDefault()
       api.closeMenu()
       nextTick(() => dom(api.buttonRef)?.focus({ preventScroll: true }))
     }
 
     function handleFocus() {
-      if (disabled) return api.goToItem(Focus.Nothing)
+      if (props.disabled) return api.goToItem(Focus.Nothing)
       api.goToItem(Focus.Specific, id)
     }
 
     function handleMove() {
-      if (disabled) return
+      if (props.disabled) return
       if (active.value) return
       api.goToItem(Focus.Specific, id)
     }
 
     function handleLeave() {
-      if (disabled) return
+      if (props.disabled) return
       if (!active.value) return
       api.goToItem(Focus.Nothing)
     }
 
     return () => {
+      let { disabled, class: defaultClass, className = defaultClass } = props
       let slot = { active: active.value, disabled }
       let propsWeControl = {
         id,
         role: 'menuitem',
-        tabIndex: -1,
+        tabIndex: disabled === true ? undefined : -1,
         class: resolvePropValue(className, slot),
         'aria-disabled': disabled === true ? true : undefined,
         onClick: handleClick,

--- a/packages/@headlessui-vue/src/components/popover/popover.ts
+++ b/packages/@headlessui-vue/src/components/popover/popover.ts
@@ -87,8 +87,6 @@ export let Popover = defineComponent({
     as: { type: [Object, String], default: 'div' },
   },
   setup(props, { slots, attrs }) {
-    let { ...passThroughProps } = props
-
     let buttonId = `headlessui-popover-button-${useId()}`
     let panelId = `headlessui-popover-panel-${useId()}`
 
@@ -178,7 +176,7 @@ export let Popover = defineComponent({
 
     return () => {
       let slot = { open: popoverState.value === PopoverStates.Open }
-      return render({ props: passThroughProps, slot, slots, attrs, name: 'Popover' })
+      return render({ props, slot, slots, attrs, name: 'Popover' })
     }
   },
 })

--- a/packages/@headlessui-vue/src/test-utils/accessibility-assertions.ts
+++ b/packages/@headlessui-vue/src/test-utils/accessibility-assertions.ts
@@ -193,7 +193,7 @@ export function assertMenuItem(
 
     // Check that we have the correct values for certain attributes
     expect(item).toHaveAttribute('role', 'menuitem')
-    expect(item).toHaveAttribute('tabindex', '-1')
+    if (!item.getAttribute('aria-disabled')) expect(item).toHaveAttribute('tabindex', '-1')
 
     // Ensure menu button has the following attributes
     if (options) {
@@ -483,7 +483,7 @@ export function assertListboxOption(
 
     // Check that we have the correct values for certain attributes
     expect(item).toHaveAttribute('role', 'option')
-    expect(item).toHaveAttribute('tabindex', '-1')
+    if (!item.getAttribute('aria-disabled')) expect(item).toHaveAttribute('tabindex', '-1')
 
     // Ensure listbox button has the following attributes
     if (!options) return

--- a/packages/@headlessui-vue/src/utils/render.ts
+++ b/packages/@headlessui-vue/src/utils/render.ts
@@ -125,7 +125,7 @@ function _render({
   return h(as, passThroughProps, children)
 }
 
-function omit<T extends Record<any, any>>(object: T, keysToOmit: string[] = []) {
+export function omit<T extends Record<any, any>>(object: T, keysToOmit: string[] = []) {
   let clone = Object.assign({}, object)
   for (let key of keysToOmit) {
     if (key in clone) delete clone[key]


### PR DESCRIPTION
In some places we were destructuring data from the incoming `props`. But this means that we also loose some reactivity along the way. This PR fixes that.

We also improved the `disabled` prop. It was failing because of 2 reasons:
1. Because of the reactivity issue, we lost "updates" to this prop.
2. We always had a `tabindex: -1`, but that is now conditionally applied based on the incoming `disabled` prop.

Fixes: #508 
Fixes: #509 
Fixes: #483