### PR TITLE
Make Listbox types consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve types for the `open` prop in the `Dialog` component ([#550](https://github.com/tailwindlabs/headlessui/pull/550))
 - Improve `aria-expanded` logic ([#592](https://github.com/tailwindlabs/headlessui/pull/592))
 - Remove undocumented `:className` prop ([#607](https://github.com/tailwindlabs/headlessui/pull/607))
+- Improve types for `Listbox` component ([#576](https://github.com/tailwindlabs/headlessui/pull/576))
 
 ## [Unreleased - Vue]
 

--- a/packages/@headlessui-vue/src/components/listbox/listbox.ts
+++ b/packages/@headlessui-vue/src/components/listbox/listbox.ts
@@ -470,7 +470,7 @@ export let ListboxOption = defineComponent({
   name: 'ListboxOption',
   props: {
     as: { type: [Object, String], default: 'li' },
-    value: { type: [Object, String] },
+    value: { type: [Object, String, Number, Boolean] },
     disabled: { type: Boolean, default: false },
     class: { type: [String, Function], required: false },
   },


### PR DESCRIPTION
This makes the ListboxOption value type consistent with the Listbox modelValue type, which I think makes sense. I ran into an issue with this using a number for the ListboxOption value.