### PR TITLE
Support tree-shaking

### DIFF
--- a/packages/@headlessui-react/package.json
+++ b/packages/@headlessui-react/package.json
@@ -4,12 +4,13 @@
   "description": "A set of completely unstyled, fully accessible UI components for React, designed to integrate beautifully with Tailwind CSS.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
-  "module": "dist/headlessui.esm.js",
+  "module": "dist/index.esm.js",
   "license": "MIT",
   "files": [
     "README.md",
     "dist"
   ],
+  "sideEffects": false,
   "engines": {
     "node": ">=10"
   },

--- a/packages/@headlessui-react/tsdx.config.js
+++ b/packages/@headlessui-react/tsdx.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  rollup(config, opts) {
+    if (opts.format === 'esm') {
+      config = { ...config, preserveModules: true }
+      config.output = { ...config.output, dir: 'dist/', entryFileNames: '[name].esm.js' }
+      delete config.output.file
+    }
+    return config
+  },
+}


### PR DESCRIPTION
## Support tree-shaking by enabling preserveModules

In order to enable tree-shaking, we need to specify `sideEffects: true`,
unfortunately, after experiments, it turned out not to be enough and I had to enable `preserveModules`, which webpack seems to be able to use to properly remove unused code, that part was Inspired by https://github.com/formium/tsdx/issues/276

I first noticed that headless-ui is not being tree-shaked in lighthouse:
<img width="864" alt="Screenshot 2021-06-09 at 00 20 42" src="https://user-images.githubusercontent.com/2538374/121252044-9b4d3c80-c8b8-11eb-8b8d-e0ac29904fe3.png">

After adding the changes in this PR the packages is no longer showing up as unused:
<img width="886" alt="Screenshot 2021-06-09 at 00 20 59" src="https://user-images.githubusercontent.com/2538374/121252107-b029d000-c8b8-11eb-9a2b-2b1a4569cf9f.png">

I also ran @next/bundle-analyzer
Before:
<img width="536" alt="Screenshot 2021-06-09 at 00 06 42" src="https://user-images.githubusercontent.com/2538374/121252154-bd46bf00-c8b8-11eb-9fc3-bc924a9f6246.png">

After:
<img width="772" alt="Screenshot 2021-06-09 at 00 07 25" src="https://user-images.githubusercontent.com/2538374/121252155-bddf5580-c8b8-11eb-8ac0-4cb760779b73.png">

Also, before / after results from Chrome:
<img width="501" alt="Screenshot 2021-06-09 at 00 26 52" src="https://user-images.githubusercontent.com/2538374/121252864-92109f80-c8b9-11eb-9fbf-93d139a89f2a.png">
<img width="495" alt="Screenshot 2021-06-09 at 00 27 12" src="https://user-images.githubusercontent.com/2538374/121252868-92a93600-c8b9-11eb-9bef-0e9ad33711a7.png">

