### PR TITLE
fix(vue): remove className prop

### DIFF
--- a/packages/@headlessui-vue/examples/src/components/Home.vue
+++ b/packages/@headlessui-vue/examples/src/components/Home.vue
@@ -1,6 +1,6 @@
 <template>
-  <div className="container my-24">
-    <div className="prose">
+  <div class="container my-24">
+    <div class="prose">
       <h2>Examples</h2>
       <Examples :examples="examples" />
     </div>

--- a/packages/@headlessui-vue/examples/src/components/dialog/dialog.vue
+++ b/packages/@headlessui-vue/examples/src/components/dialog/dialog.vue
@@ -116,27 +116,27 @@
                               </div>
 
                               <div class="py-1">
-                                <MenuItem as="a" href="#account-settings" :className="resolveClass">
+                                <MenuItem as="a" href="#account-settings" :class="resolveClass">
                                   Account settings
                                 </MenuItem>
-                                <MenuItem as="a" href="#support" :className="resolveClass">
+                                <MenuItem as="a" href="#support" :class="resolveClass">
                                   Support
                                 </MenuItem>
                                 <MenuItem
                                   as="a"
                                   disabled
                                   href="#new-feature"
-                                  :className="resolveClass"
+                                  :class="resolveClass"
                                 >
                                   New feature (soon)
                                 </MenuItem>
-                                <MenuItem as="a" href="#license" :className="resolveClass">
+                                <MenuItem as="a" href="#license" :class="resolveClass">
                                   License
                                 </MenuItem>
                               </div>
 
                               <div class="py-1">
-                                <MenuItem as="a" href="#sign-out" :className="resolveClass">
+                                <MenuItem as="a" href="#sign-out" :class="resolveClass">
                                   Sign out
                                 </MenuItem>
                               </div>

--- a/packages/@headlessui-vue/examples/src/components/listbox/listbox.vue
+++ b/packages/@headlessui-vue/examples/src/components/listbox/listbox.vue
@@ -39,7 +39,7 @@
                   v-for="person in people"
                   :key="person.id"
                   :value="person"
-                  :className="resolveListboxOptionClassName"
+                  :class="resolveListboxOptionClassName"
                   v-slot="{ active, selected }"
                 >
                   <span

--- a/packages/@headlessui-vue/examples/src/components/listbox/multiple-elements.vue
+++ b/packages/@headlessui-vue/examples/src/components/listbox/multiple-elements.vue
@@ -39,7 +39,7 @@
                   v-for="person in people"
                   :key="person.id"
                   :value="person"
-                  :className="resolveListboxOptionClassName"
+                  :class="resolveListboxOptionClassName"
                   v-slot="{ active, selected }"
                 >
                   <span
@@ -125,7 +125,7 @@
                   v-for="person in people"
                   :key="person.id"
                   :value="person"
-                  :className="resolveListboxOptionClassName"
+                  :class="resolveListboxOptionClassName"
                   v-slot="{ active, selected }"
                 >
                   <span

--- a/packages/@headlessui-vue/examples/src/components/menu/menu-with-popper.vue
+++ b/packages/@headlessui-vue/examples/src/components/menu/menu-with-popper.vue
@@ -29,19 +29,19 @@
             </div>
 
             <div class="py-1">
-              <MenuItem as="a" href="#account-settings" :className="resolveClass">
+              <MenuItem as="a" href="#account-settings" :class="resolveClass">
                 Account settings
               </MenuItem>
               <MenuItem v-slot="data">
                 <a href="#support" :class="resolveClass(data)">Support</a>
               </MenuItem>
-              <MenuItem as="a" disabled href="#new-feature" :className="resolveClass">
+              <MenuItem as="a" disabled href="#new-feature" :class="resolveClass">
                 New feature (soon)
               </MenuItem>
-              <MenuItem as="a" href="#license" :className="resolveClass">License</MenuItem>
+              <MenuItem as="a" href="#license" :class="resolveClass">License</MenuItem>
             </div>
             <div class="py-1">
-              <MenuItem as="a" href="#sign-out" :className="resolveClass">Sign out</MenuItem>
+              <MenuItem as="a" href="#sign-out" :class="resolveClass">Sign out</MenuItem>
             </div>
           </MenuItems>
         </teleport>

--- a/packages/@headlessui-vue/examples/src/components/menu/menu-with-transition-and-popper.vue
+++ b/packages/@headlessui-vue/examples/src/components/menu/menu-with-transition-and-popper.vue
@@ -36,19 +36,19 @@
               </div>
 
               <div class="py-1">
-                <MenuItem as="a" :className="resolveClass" href="#account-settings">
+                <MenuItem as="a" :class="resolveClass" href="#account-settings">
                   Account settings
                 </MenuItem>
                 <MenuItem v-slot="data">
                   <a href="#support" :class="resolveClass(data)">Support</a>
                 </MenuItem>
-                <MenuItem as="a" :className="resolveClass" disabled href="#new-feature">
+                <MenuItem as="a" :class="resolveClass" disabled href="#new-feature">
                   New feature (soon)
                 </MenuItem>
-                <MenuItem as="a" :className="resolveClass" href="#license">License</MenuItem>
+                <MenuItem as="a" :class="resolveClass" href="#license">License</MenuItem>
               </div>
               <div class="py-1">
-                <MenuItem as="a" :className="resolveClass" href="#sign-out">Sign out</MenuItem>
+                <MenuItem as="a" :class="resolveClass" href="#sign-out">Sign out</MenuItem>
               </div>
             </MenuItems>
           </transition>

--- a/packages/@headlessui-vue/examples/src/components/menu/menu-with-transition.vue
+++ b/packages/@headlessui-vue/examples/src/components/menu/menu-with-transition.vue
@@ -34,17 +34,17 @@
             </div>
 
             <div class="py-1">
-              <MenuItem as="a" href="#account-settings" :className="resolveClass">
+              <MenuItem as="a" href="#account-settings" :class="resolveClass">
                 Account settings
               </MenuItem>
-              <MenuItem as="a" href="#support" :className="resolveClass">Support</MenuItem>
-              <MenuItem as="a" disabled href="#new-feature" :className="resolveClass">
+              <MenuItem as="a" href="#support" :class="resolveClass">Support</MenuItem>
+              <MenuItem as="a" disabled href="#new-feature" :class="resolveClass">
                 New feature (soon)
               </MenuItem>
-              <MenuItem as="a" href="#license" :className="resolveClass">License</MenuItem>
+              <MenuItem as="a" href="#license" :class="resolveClass">License</MenuItem>
             </div>
             <div class="py-1">
-              <MenuItem as="a" href="#sign-out" :className="resolveClass">Sign out</MenuItem>
+              <MenuItem as="a" href="#sign-out" :class="resolveClass">Sign out</MenuItem>
             </div>
           </MenuItems>
         </transition>

--- a/packages/@headlessui-vue/examples/src/components/menu/multiple-elements.vue
+++ b/packages/@headlessui-vue/examples/src/components/menu/multiple-elements.vue
@@ -26,17 +26,17 @@
           </div>
 
           <div class="py-1">
-            <MenuItem as="a" :className="resolveClass" href="#account-settings"
+            <MenuItem as="a" :class="resolveClass" href="#account-settings"
               >Account settings</MenuItem
             >
-            <MenuItem as="a" :className="resolveClass" href="#support">Support</MenuItem>
-            <MenuItem as="a" :className="resolveClass" disabled href="#new-feature"
+            <MenuItem as="a" :class="resolveClass" href="#support">Support</MenuItem>
+            <MenuItem as="a" :class="resolveClass" disabled href="#new-feature"
               >New feature (soon)</MenuItem
             >
-            <MenuItem as="a" :className="resolveClass" href="#license">License</MenuItem>
+            <MenuItem as="a" :class="resolveClass" href="#license">License</MenuItem>
           </div>
           <div class="py-1">
-            <MenuItem as="a" :className="resolveClass" href="#sign-out">Sign out</MenuItem>
+            <MenuItem as="a" :class="resolveClass" href="#sign-out">Sign out</MenuItem>
           </div>
         </MenuItems>
       </Menu>
@@ -77,17 +77,17 @@
           </div>
 
           <div class="py-1">
-            <MenuItem as="a" :className="resolveClass" href="#account-settings"
+            <MenuItem as="a" :class="resolveClass" href="#account-settings"
               >Account settings</MenuItem
             >
-            <MenuItem as="a" :className="resolveClass" href="#support">Support</MenuItem>
-            <MenuItem as="a" :className="resolveClass" disabled href="#new-feature"
+            <MenuItem as="a" :class="resolveClass" href="#support">Support</MenuItem>
+            <MenuItem as="a" :class="resolveClass" disabled href="#new-feature"
               >New feature (soon)</MenuItem
             >
-            <MenuItem as="a" :className="resolveClass" href="#license">License</MenuItem>
+            <MenuItem as="a" :class="resolveClass" href="#license">License</MenuItem>
           </div>
           <div class="py-1">
-            <MenuItem as="a" :className="resolveClass" href="#sign-out">Sign out</MenuItem>
+            <MenuItem as="a" :class="resolveClass" href="#sign-out">Sign out</MenuItem>
           </div>
         </MenuItems>
       </Menu>

--- a/packages/@headlessui-vue/examples/src/components/radio-group/radio-group.vue
+++ b/packages/@headlessui-vue/examples/src/components/radio-group/radio-group.vue
@@ -13,7 +13,7 @@
             :key="id"
             :value="id"
             v-slot="{ active, checked }"
-            :className="
+            :class="
               ({ active }) =>
                 classNames(
                   // Rounded corners

--- a/packages/@headlessui-vue/examples/src/components/switch/switch.vue
+++ b/packages/@headlessui-vue/examples/src/components/switch/switch.vue
@@ -3,7 +3,7 @@
     <SwitchGroup as="div" class="flex items-center space-x-4">
       <SwitchLabel>Enable notifications</SwitchLabel>
 
-      <Switch as="button" v-model="state" :className="resolveSwitchClass" v-slot="{ checked }">
+      <Switch as="button" v-model="state" :class="resolveSwitchClass" v-slot="{ checked }">
         <span
           class="inline-block w-5 h-5 transition duration-200 ease-in-out transform bg-white rounded-full"
           :class="{ 'translate-x-5': checked, 'translate-x-0': !checked }"

--- a/packages/@headlessui-vue/src/components/listbox/listbox.test.tsx
+++ b/packages/@headlessui-vue/src/components/listbox/listbox.test.tsx
@@ -480,20 +480,20 @@ describe('Rendering', () => {
 
 describe('Rendering composition', () => {
   it(
-    'should be possible to conditionally render classNames (aka className can be a function?!)',
+    'should be possible to conditionally render classes (aka class can be a function?!)',
     suppressConsoleLogs(async () => {
       renderTemplate({
         template: html`
           <Listbox v-model="value">
             <ListboxButton>Trigger</ListboxButton>
             <ListboxOptions>
-              <ListboxOption value="a" :className="JSON.stringify">
+              <ListboxOption value="a" :class="JSON.stringify">
                 Option A
               </ListboxOption>
-              <ListboxOption value="b" disabled :className="JSON.stringify">
+              <ListboxOption value="b" disabled :class="JSON.stringify">
                 Option B
               </ListboxOption>
-              <ListboxOption value="c" className="no-special-treatment">
+              <ListboxOption value="c" class="no-special-treatment">
                 Option C
               </ListboxOption>
             </ListboxOptions>
@@ -513,7 +513,7 @@ describe('Rendering composition', () => {
 
       let options = getListboxOptions()
 
-      // Verify correct classNames
+      // Verify correct classes
       expect('' + options[0].classList).toEqual(
         JSON.stringify({ active: false, selected: false, disabled: false })
       )
@@ -528,7 +528,7 @@ describe('Rendering composition', () => {
       // Make the first option active
       await press(Keys.ArrowDown)
 
-      // Verify the classNames
+      // Verify the classes
       expect('' + options[0].classList).toEqual(
         JSON.stringify({ active: true, selected: false, disabled: false })
       )
@@ -543,7 +543,7 @@ describe('Rendering composition', () => {
       // Let's go down, this should go to the third option since the second option is disabled!
       await press(Keys.ArrowDown)
 
-      // Verify the classNames
+      // Verify the classes
       expect('' + options[0].classList).toEqual(
         JSON.stringify({ active: false, selected: false, disabled: false })
       )

--- a/packages/@headlessui-vue/src/components/listbox/listbox.ts
+++ b/packages/@headlessui-vue/src/components/listbox/listbox.ts
@@ -467,12 +467,11 @@ export let ListboxOption = defineComponent({
     value: { type: [Object, String] },
     disabled: { type: Boolean, default: false },
     class: { type: [String, Function], required: false },
-    className: { type: [String, Function], required: false },
   },
   setup(props, { slots, attrs }) {
     let api = useListboxContext('ListboxOption')
     let id = `headlessui-listbox-option-${useId()}`
-    let { disabled, class: defaultClass, className = defaultClass, value } = props
+    let { disabled, class: defaultClass, value } = props
 
     let active = computed(() => {
       return api.activeOptionIndex.value !== null
@@ -543,7 +542,7 @@ export let ListboxOption = defineComponent({
         id,
         role: 'option',
         tabIndex: -1,
-        class: resolvePropValue(className, slot),
+        class: resolvePropValue(defaultClass, slot),
         'aria-disabled': disabled === true ? true : undefined,
         'aria-selected': selected.value === true ? selected.value : undefined,
         onClick: handleClick,

--- a/packages/@headlessui-vue/src/components/menu/menu.test.tsx
+++ b/packages/@headlessui-vue/src/components/menu/menu.test.tsx
@@ -622,13 +622,13 @@ describe('Rendering', () => {
 })
 
 describe('Rendering composition', () => {
-  it('should be possible to conditionally render classNames (aka className can be a function?!)', async () => {
+  it('should be possible to conditionally render classes (aka class can be a function?!)', async () => {
     renderTemplate(jsx`
       <Menu>
         <MenuButton>Trigger</MenuButton>
         <MenuItems>
-          <MenuItem as="a" :className="JSON.stringify">Item A</MenuItem>
-          <MenuItem as="a" disabled :className="JSON.stringify">Item B</MenuItem>
+          <MenuItem as="a" :class="JSON.stringify">Item A</MenuItem>
+          <MenuItem as="a" disabled :class="JSON.stringify">Item B</MenuItem>
           <MenuItem as="a" class="no-special-treatment">Item C</MenuItem>
         </MenuItems>
       </Menu>
@@ -645,7 +645,7 @@ describe('Rendering composition', () => {
 
     let items = getMenuItems()
 
-    // Verify correct classNames
+    // Verify correct classes
     expect('' + items[0].classList).toEqual(JSON.stringify({ active: false, disabled: false }))
     expect('' + items[1].classList).toEqual(JSON.stringify({ active: false, disabled: true }))
     expect('' + items[2].classList).toEqual('no-special-treatment')
@@ -656,7 +656,7 @@ describe('Rendering composition', () => {
     // Make the first item active
     await press(Keys.ArrowDown)
 
-    // Verify the classNames
+    // Verify the classes
     expect('' + items[0].classList).toEqual(JSON.stringify({ active: true, disabled: false }))
     expect('' + items[1].classList).toEqual(JSON.stringify({ active: false, disabled: true }))
     expect('' + items[2].classList).toEqual('no-special-treatment')
@@ -667,7 +667,7 @@ describe('Rendering composition', () => {
     // Let's go down, this should go to the third item since the second item is disabled!
     await press(Keys.ArrowDown)
 
-    // Verify the classNames
+    // Verify the classes
     expect('' + items[0].classList).toEqual(JSON.stringify({ active: false, disabled: false }))
     expect('' + items[1].classList).toEqual(JSON.stringify({ active: false, disabled: true }))
     expect('' + items[2].classList).toEqual('no-special-treatment')

--- a/packages/@headlessui-vue/src/components/menu/menu.ts
+++ b/packages/@headlessui-vue/src/components/menu/menu.ts
@@ -413,12 +413,11 @@ export let MenuItem = defineComponent({
     as: { type: [Object, String], default: 'template' },
     disabled: { type: Boolean, default: false },
     class: { type: [String, Function], required: false },
-    className: { type: [String, Function], required: false },
   },
   setup(props, { slots, attrs }) {
     let api = useMenuContext('MenuItem')
     let id = `headlessui-menu-item-${useId()}`
-    let { disabled, class: defaultClass, className = defaultClass } = props
+    let { disabled, class: defaultClass } = props
 
     let active = computed(() => {
       return api.activeItemIndex.value !== null
@@ -473,7 +472,7 @@ export let MenuItem = defineComponent({
         id,
         role: 'menuitem',
         tabIndex: -1,
-        class: resolvePropValue(className, slot),
+        class: resolvePropValue(defaultClass, slot),
         'aria-disabled': disabled === true ? true : undefined,
         onClick: handleClick,
         onFocus: handleFocus,

--- a/packages/@headlessui-vue/src/components/radio-group/radio-group.ts
+++ b/packages/@headlessui-vue/src/components/radio-group/radio-group.ts
@@ -234,14 +234,12 @@ export let RadioGroupOption = defineComponent({
     value: { type: [Object, String, Number, Boolean] },
     disabled: { type: Boolean, default: false },
     class: { type: [String, Function], required: false },
-    className: { type: [String, Function], required: false },
   },
   render() {
     let {
       value,
       disabled,
       class: defaultClass,
-      className = defaultClass,
       ...passThroughProps
     } = this.$props
 
@@ -255,7 +253,7 @@ export let RadioGroupOption = defineComponent({
       id: this.id,
       ref: 'el',
       role: 'radio',
-      class: resolvePropValue(className, slot),
+      class: resolvePropValue(defaultClass, slot),
       'aria-checked': this.checked ? 'true' : 'false',
       'aria-labelledby': this.labelledby,
       'aria-describedby': this.describedby,

--- a/packages/@headlessui-vue/src/components/switch/switch.ts
+++ b/packages/@headlessui-vue/src/components/switch/switch.ts
@@ -63,11 +63,10 @@ export let Switch = defineComponent({
     as: { type: [Object, String], default: 'button' },
     modelValue: { type: Boolean, default: false },
     class: { type: [String, Function], required: false },
-    className: { type: [String, Function], required: false },
   },
   render() {
     let api = inject(GroupContext, null)
-    let { class: defaultClass, className = defaultClass } = this.$props
+    let { class: defaultClass } = this.$props
 
     let slot = { checked: this.$props.modelValue }
     let propsWeControl = {
@@ -75,7 +74,7 @@ export let Switch = defineComponent({
       ref: api === null ? undefined : api.switchRef,
       role: 'switch',
       tabIndex: 0,
-      class: resolvePropValue(className, slot),
+      class: resolvePropValue(defaultClass, slot),
       'aria-checked': this.$props.modelValue,
       'aria-labelledby': this.labelledby,
       'aria-describedby': this.describedby,


### PR DESCRIPTION
Since Vue v3.1 the Virtual DOM tree no longer accepts "className" as a valid property to a render function. Providing this as a prop pollutes a VNode and is not considered Vue3 best practice, as a result, headlessui components were not initially rendering with a class prop.

Fixes #603 and other related class issues.