### PR TITLE
fix: missing peerDep on react-dom (yarn pnp)

### DIFF
--- a/packages/@headlessui-react/package.json
+++ b/packages/@headlessui-react/package.json
@@ -30,7 +30,8 @@
     "lint": "../../scripts/lint.sh"
   },
   "peerDependencies": {
-    "react": ">=16"
+    "react": ">=16",
+    "react-dom": ">=16"
   },
   "devDependencies": {
     "@types/react": "^16.14.2",


### PR DESCRIPTION
Fix a missing dep on react-dom as it's imported in the portal component (`import { createPortal } from 'react-dom'`)

This fixes warnings or error with yarn 2 pnp.

```
(node:45763) [MODULE_NOT_FOUND] Error: @headlessui/react tried to access react-dom, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
```



