### PR TITLE
Add resolveComponent to render function (Vue3)

### DIFF
--- a/packages/@headlessui-vue/src/utils/render.ts
+++ b/packages/@headlessui-vue/src/utils/render.ts
@@ -1,4 +1,4 @@
-import { h, cloneVNode, Slots } from 'vue'
+import { h, cloneVNode, Slots, resolveComponent } from 'vue'
 import { match } from './match'
 
 export enum Features {
@@ -121,8 +121,10 @@ function _render({
 
     return children
   }
+  
+  let component = resolveComponent(as)
 
-  return h(as, passThroughProps, children)
+  return h(component || as, passThroughProps, children)
 }
 
 export function omit<T extends Record<any, any>>(object: T, keysToOmit: string[] = []) {

--- a/packages/@headlessui-vue/src/utils/render.ts
+++ b/packages/@headlessui-vue/src/utils/render.ts
@@ -122,9 +122,11 @@ function _render({
     return children
   }
   
-  let component = resolveComponent(as)
+  let component = as;
+  
+  try { component = resolveComponent(as) } catch(e) {}
 
-  return h(component || as, passThroughProps, children)
+  return h(component, passThroughProps, children)
 }
 
 export function omit<T extends Record<any, any>>(object: T, keysToOmit: string[] = []) {


### PR DESCRIPTION
## Background

As described in the [vue3 docs](https://v3.vuejs.org/guide/render-function.html#creating-component-vnodes), registered components need to be resolved using `resolveComponent` when used in the `h` render method.

## Example

Given the case that a `ui-button` component is registered, the button can be used as a `MenuButton`:

```vue
<MenuButton as="ui-button">Foo</MenuButton>
```