### PR TITLE
Add Vue emit types

### DIFF
--- a/packages/@headlessui-vue/src/components/dialog/dialog.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.ts
@@ -74,7 +74,7 @@ export let Dialog = defineComponent({
     open: { type: [Boolean, String], default: Missing },
     initialFocus: { type: Object as PropType<HTMLElement | null>, default: null },
   },
-  emits: ['close'],
+  emits: { close: (_value: false) => true },
   render() {
     let propsWeControl = {
       // Manually passthrough the attributes, because Vue can't automatically pass

--- a/packages/@headlessui-vue/src/components/listbox/listbox.ts
+++ b/packages/@headlessui-vue/src/components/listbox/listbox.ts
@@ -75,7 +75,7 @@ function useListboxContext(component: string) {
 
 export let Listbox = defineComponent({
   name: 'Listbox',
-  emits: ['update:modelValue'],
+  emits: { 'update:modelValue': (_value: any) => true },
   props: {
     as: { type: [Object, String], default: 'template' },
     disabled: { type: [Boolean], default: false },

--- a/packages/@headlessui-vue/src/components/radio-group/radio-group.ts
+++ b/packages/@headlessui-vue/src/components/radio-group/radio-group.ts
@@ -60,7 +60,7 @@ function useRadioGroupContext(component: string) {
 
 export let RadioGroup = defineComponent({
   name: 'RadioGroup',
-  emits: ['update:modelValue'],
+  emits: { 'update:modelValue': (_value: any) => true },
   props: {
     as: { type: [Object, String], default: 'div' },
     disabled: { type: [Boolean], default: false },

--- a/packages/@headlessui-vue/src/components/switch/switch.ts
+++ b/packages/@headlessui-vue/src/components/switch/switch.ts
@@ -57,7 +57,7 @@ export let SwitchGroup = defineComponent({
 
 export let Switch = defineComponent({
   name: 'Switch',
-  emits: ['update:modelValue'],
+  emits: { 'update:modelValue': (_value: boolean) => true },
   props: {
     as: { type: [Object, String], default: 'button' },
     modelValue: { type: Boolean, default: false },

--- a/packages/@headlessui-vue/src/components/transitions/transition.ts
+++ b/packages/@headlessui-vue/src/components/transitions/transition.ts
@@ -145,7 +145,12 @@ export let TransitionChild = defineComponent({
     leaveFrom: { type: [String], default: '' },
     leaveTo: { type: [String], default: '' },
   },
-  emits: ['beforeEnter', 'afterEnter', 'beforeLeave', 'afterLeave'],
+  emits: {
+    beforeEnter: () => true,
+    afterEnter: () => true,
+    beforeLeave: () => true,
+    afterLeave: () => true,
+  },
   render() {
     if (this.renderAsRoot) {
       return h(
@@ -357,7 +362,12 @@ export let TransitionRoot = defineComponent({
     leaveFrom: { type: [String], default: '' },
     leaveTo: { type: [String], default: '' },
   },
-  emits: ['beforeEnter', 'afterEnter', 'beforeLeave', 'afterLeave'],
+  emits: {
+    beforeEnter: () => true,
+    afterEnter: () => true,
+    beforeLeave: () => true,
+    afterLeave: () => true,
+  },
   render() {
     let { show, appear, unmount, ...passThroughProps } = this.$props
     let sharedProps = { unmount }


### PR DESCRIPTION
This PR changes `emits` in the Vue components to use the object syntax, which allows specifying the type(s) of the thing(s) you are emitting. This accomplishes two things. The less interesting one is that the types are checked within the components itself, so you don't accidentally emit the wrong type. The other and more significant is that if you use a tool which typechecks Vue templates such as vue-tsc, it will check that the callback you use as an event listener in the parent conforms to what's being emitted. E.g. if you do `@update:modelValue=functionThatTakesAString` on a `Switch`, you'll get a type error because we've declared that `Switch` emits a boolean.

I went a bit back and forth on whether I should use `any` or `unknown` for `ListBox` and `Radio Group`. I landed on `any` because I think `unknown` is likely to be unergonomic. In almost all cases you'll probably use these components in a way where the same type is always being emitted and with `unknown` you'll have to always cast it to that type. You can't cast inside Vue templates because Typescript syntax isn't allowed, so you're forced to create a function in the script section just to do the cast. `any` is a bit less safe but it avoids these issues. It's still an improvement on the current situation because we declare that only one value is emitted, so a callback with multiple arguments would be flagged.

The reason all of them are arrow functions that just return true is that this syntax allows for runtime validation of emits. Returning true just says that the emit is valid.