### PR TITLE
Provide event to Dialog `onClose` callback.

### DIFF
--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -15,6 +15,7 @@ import React, {
   KeyboardEvent as ReactKeyboardEvent,
   MutableRefObject,
   Ref,
+  SyntheticEvent,
   useState,
 } from 'react'
 
@@ -66,7 +67,7 @@ let DialogContext = createContext<
   | [
       {
         dialogState: DialogStates
-        close(): void
+        close(event?: Event | SyntheticEvent): void
         setTitleId(id: string | null): void
       },
       StateDefinition
@@ -111,7 +112,7 @@ let DialogRoot = forwardRefWithAs(function Dialog<
   props: Props<TTag, DialogRenderPropArg, DialogPropsWeControl> &
     PropsForFeatures<typeof DialogRenderFeatures> & {
       open?: boolean
-      onClose(value: boolean): void
+      onClose(value: boolean, event?: Event | SyntheticEvent): void
       initialFocus?: MutableRefObject<HTMLElement | null>
     },
   ref: Ref<HTMLDivElement>
@@ -178,7 +179,7 @@ let DialogRoot = forwardRefWithAs(function Dialog<
     descriptionId: null,
   } as StateDefinition)
 
-  let close = useCallback(() => onClose(false), [onClose])
+  let close = useCallback((event?: Event | SyntheticEvent) => onClose(false, event), [onClose])
 
   let setTitleId = useCallback(
     (id: string | null) => dispatch({ type: ActionTypes.SetTitleId, id }),
@@ -214,7 +215,7 @@ let DialogRoot = forwardRefWithAs(function Dialog<
     if (hasNestedDialogs) return
     if (internalDialogRef.current?.contains(target)) return
 
-    close()
+    close(event)
   })
 
   // Scroll lock
@@ -290,7 +291,7 @@ let DialogRoot = forwardRefWithAs(function Dialog<
       if (hasNestedDialogs) return
       event.preventDefault()
       event.stopPropagation()
-      close()
+      close(event)
     },
   }
   let passthroughProps = rest
@@ -359,7 +360,7 @@ let Overlay = forwardRefWithAs(function Overlay<
       if (isDisabledReactIssue7711(event.currentTarget)) return event.preventDefault()
       event.preventDefault()
       event.stopPropagation()
-      close()
+      close(event)
     },
     [close]
   )


### PR DESCRIPTION
This will give Dialog consumers additional context
when deciding whether to prevent closing the dialog.

An example for where this is useful is when an action is
triggered from a dialog that results in a transient notification
(e.g., a snackbar) that includes dismiss and/or action buttons.
Clicking on a button inside the notification should not close the
dialog, even if the notification itself is not a child of the
dialog in the DOM.

This also makes scenarios like #621 easier.