### PR TITLE
FocusTrap: warn instead of throw Error when there is no focusable element

### DIFF
--- a/packages/@headlessui-react/src/components/focus-trap/focus-trap.test.tsx
+++ b/packages/@headlessui-react/src/components/focus-trap/focus-trap.test.tsx
@@ -63,16 +63,20 @@ it('should focus the initialFocus element inside the FocusTrap even if another e
 })
 
 it(
-  'should error when there is no focusable element inside the FocusTrap',
+  'should warn when there is no focusable element inside the FocusTrap',
   suppressConsoleLogs(() => {
-    expect(() => {
-      render(
+    const consoleWarn = jest.fn()
+    console.warn = consoleWarn
+    function Example() {
+      return (
         <FocusTrap>
           <span>Nothing to see here...</span>
         </FocusTrap>
       )
-    }).toThrowErrorMatchingInlineSnapshot(
-      `"There are no focusable elements inside the <FocusTrap />"`
+    }
+    render(<Example />)
+    expect(consoleWarn.mock.calls[0][0]).toBe(
+      'There are no focusable elements inside the <FocusTrap />'
     )
   })
 )

--- a/packages/@headlessui-react/src/hooks/use-focus-trap.ts
+++ b/packages/@headlessui-react/src/hooks/use-focus-trap.ts
@@ -89,7 +89,7 @@ export function useFocusTrap(
       focusElement(initialFocus.current)
     } else {
       if (focusIn(container.current, Focus.First) === FocusResult.Error) {
-        throw new Error('There are no focusable elements inside the <FocusTrap />')
+        console.warn('There are no focusable elements inside the <FocusTrap />')
       }
     }
 


### PR DESCRIPTION
Hello there 👋

I've created this pull request to show you possible solution to the issue #407. 

As I proposed - instead of throwing Error, when there is no focusable element in the FocusTrap, just use `console.warn`.

Closes #407 