### PR TITLE
add enableScrollLock prop to dialog component

### DIFF
--- a/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
@@ -266,6 +266,42 @@ describe('Rendering', () => {
         expect(document.documentElement.style.overflow).toBe('hidden')
       })
     )
+
+    it(
+      'should not add a scroll lock to the html tag',
+      suppressConsoleLogs(async () => {
+        function Example() {
+          let [isOpen, setIsOpen] = useState(false)
+
+          return (
+            <>
+              <button id="trigger" onClick={() => setIsOpen(v => !v)}>
+                Trigger
+              </button>
+
+              <Dialog enableScrollLock={false} open={isOpen} onClose={setIsOpen}>
+                <input id="a" type="text" />
+                <input id="b" type="text" />
+                <input id="c" type="text" />
+              </Dialog>
+            </>
+          )
+        }
+
+        render(<Example />)
+
+        // No overflow yet
+        expect(document.documentElement.style.overflow).toBe('')
+
+        let btn = document.getElementById('trigger')
+
+        // Open the dialog
+        await click(btn)
+
+        // Expect overflow
+        expect(document.documentElement.style.overflow).toBe('')
+      })
+    )
   })
 
   describe('Dialog.Overlay', () => {

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -112,10 +112,12 @@ let DialogRoot = forwardRefWithAs(function Dialog<
       open?: boolean
       onClose(value: boolean): void
       initialFocus?: MutableRefObject<HTMLElement | null>
+      enableScrollLock?: boolean
     },
   ref: Ref<HTMLDivElement>
 ) {
-  let { open, onClose, initialFocus, ...rest } = props
+  let { open, onClose, initialFocus, enableScrollLock, ...rest } = props
+  enableScrollLock = enableScrollLock === false ? false : true
   let [nestedDialogCount, setNestedDialogCount] = useState(0)
 
   let usesOpenClosedState = useOpenClosed()
@@ -228,6 +230,7 @@ let DialogRoot = forwardRefWithAs(function Dialog<
 
   // Scroll lock
   useEffect(() => {
+    if (!enableScrollLock) return
     if (dialogState !== DialogStates.Open) return
     if (hasParentDialog) return
 
@@ -243,7 +246,7 @@ let DialogRoot = forwardRefWithAs(function Dialog<
       document.documentElement.style.overflow = overflow
       document.documentElement.style.paddingRight = paddingRight
     }
-  }, [dialogState, hasParentDialog])
+  }, [enableScrollLock, dialogState, hasParentDialog])
 
   // Trigger close when the FocusTrap gets hidden
   useEffect(() => {


### PR DESCRIPTION
Support an additional property to the `Dialog` component named `enableScrollLock`. If this property is not set, it will default to `true` (maintaining backward compatibility), but if it is set to `false`, it will inhibit changing the `overflow` and `paddingRight` settings on the of the `body` tag's style.

This has been the number one requested user-experience change to my application which utilizes the `Dialog` component. In some cases, it is helpful to be able to scroll the page below the dialog.