### PR TITLE
Add automated release workflows

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,0 +1,54 @@
+name: Release Dev
+
+on:
+  push:
+    branches: [develop]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Use cached node_modules
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            nodeModules-
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+        env:
+          CI: true
+
+      - name: Test
+        run: npm test
+        env:
+          CI: true
+
+      - name: Resolve version
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
+      - name: "Version based on commit: 0.0.0-dev.${{ steps.vars.outputs.sha_short }}"
+        run: yarn workspaces run version 0.0.0-dev.${{ steps.vars.outputs.sha_short }}
+
+      - name: Publish
+        run: yarn workspaces run publish --tag dev
+        env:
+          CI: true
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -1,0 +1,54 @@
+name: Release Insiders
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Use cached node_modules
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            nodeModules-
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+        env:
+          CI: true
+
+      - name: Test
+        run: npm test
+        env:
+          CI: true
+
+      - name: Resolve version
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
+      - name: "Version based on commit: 0.0.0-next.${{ steps.vars.outputs.sha_short }}"
+        run: yarn workspaces run version 0.0.0-next.${{ steps.vars.outputs.sha_short }}
+
+      - name: Publish
+        run: yarn workspaces run publish --tag next
+        env:
+          CI: true
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/@headlessui-react/package.json
+++ b/packages/@headlessui-react/package.json
@@ -28,7 +28,9 @@
     "prepublishOnly": "npm run build",
     "test": "../../scripts/test.sh",
     "build": "../../scripts/build.sh",
-    "lint": "../../scripts/lint.sh"
+    "lint": "../../scripts/lint.sh",
+    "version": "../../scripts/version.sh",
+    "publish": "../../scripts/publish.sh"
   },
   "peerDependencies": {
     "react": "^16 || ^17 || ^18",

--- a/packages/@headlessui-vue/package.json
+++ b/packages/@headlessui-vue/package.json
@@ -28,7 +28,9 @@
     "build": "../../scripts/build.sh",
     "watch": "../../scripts/watch.sh",
     "test": "../../scripts/test.sh",
-    "lint": "../../scripts/lint.sh"
+    "lint": "../../scripts/lint.sh",
+    "version": "../../scripts/version.sh",
+    "publish": "../../scripts/publish.sh"
   },
   "peerDependencies": {
     "vue": "^3.0.0"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+args=()
+
+# Passthrough arguments and flags
+args+=($@)
+
+# Execute
+npm publish "${args[@]}"

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+args=()
+
+# Prevent creating a commit / tag
+args+=("--no-git-tag-version")
+
+# Force it, because working directory could be dirty
+args+=("--force")
+
+# Passthrough arguments and flags
+args+=($@)
+
+# Execute
+npm version "${args[@]}"


### PR DESCRIPTION
Whenever we push a commit to the develop branch, a new version should be released to npm using the `dev` tag.
Whenever we push a commit to the main branch, a new version should be released to npm using the `next` tag.

This allows me to post the following message on every PR/issue that has been merged/fixed.

```
This should be fixed, and will be available in the next release.

You can already try it using:
- `npm install @headlessui/react@dev` or `yarn add @headlessui/react@dev`.
- `npm install @headlessui/vue@dev` or `yarn add @headlessui/vue@dev`.
```

I used this message before, but then I manually published those version to npm.

---

This might take multiple tries...