### PR TITLE
Enable tree shaking in Vue package

### DIFF
--- a/packages/@headlessui-vue/package.json
+++ b/packages/@headlessui-vue/package.json
@@ -4,12 +4,13 @@
   "description": "A set of completely unstyled, fully accessible UI components for Vue 3, designed to integrate beautifully with Tailwind CSS.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
-  "module": "dist/headlessui.esm.js",
+  "module": "dist/index.esm.js",
   "license": "MIT",
   "files": [
     "README.md",
     "dist"
   ],
+  "sideEffects": false,
   "engines": {
     "node": ">=10"
   },

--- a/packages/@headlessui-vue/tsdx.config.js
+++ b/packages/@headlessui-vue/tsdx.config.js
@@ -3,8 +3,13 @@ const globals = {
 }
 
 module.exports = {
-  rollup(config) {
+  rollup(config, opts) {
     for (let key in globals) config.output.globals[key] = globals[key]
+    if (opts.format === 'esm') {
+      config = { ...config, preserveModules: true }
+      config.output = { ...config.output, dir: 'dist/', entryFileNames: '[name].esm.js' }
+      delete config.output.file
+    }
     return config
   },
 }


### PR DESCRIPTION
Inspired by https://github.com/tailwindlabs/headlessui/pull/602, which introduced the same changes in the React package.

Currently tree shaking with webpack is not possible, as webpack cannot determine that the modules are sife-effect free and  the modules are not preserved in the output build from rollup.

This PR makes the necessary changes in order to let webpack benefit from tree shaking when building other apps. 