### PR TITLE
React Menu.Item only closes after async onClick is finished

### DIFF
--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -531,11 +531,16 @@ function Item<TTag extends ElementType = typeof DEFAULT_ITEM_TAG>(
   }, [bag, id])
 
   let handleClick = useCallback(
-    (event: MouseEvent) => {
+    async (event: MouseEvent) => {
       if (disabled) return event.preventDefault()
+
+      let onClickResult: any = undefined
+      if (onClick) onClickResult = await onClick(event)
+
       dispatch({ type: ActionTypes.CloseMenu })
       disposables().nextFrame(() => state.buttonRef.current?.focus({ preventScroll: true }))
-      if (onClick) return onClick(event)
+
+      return onClickResult
     },
     [dispatch, state.buttonRef, disabled, onClick]
   )


### PR DESCRIPTION
This PR is created to solve #152.

`Menu.Item` only closes after async `onClick` is finished.

For example: Item A will close as soon as when you click on it, Item B will close after `somePromise()` is resolved.

```javascript
<Menu>
  <Menu.Button>More</Menu.Button>
  <Menu.Items>
    <Menu.Item>
      <span>A</span>
    </Menu.Item>
    <Menu.Item onClick={async e=>{await somePromise()}}>
      <span>B</span>
    </Menu.Item>
  </Menu.Items>
</Menu>
```

I'm not familiar with Vue, so unfortunately I can't provide a Vue implementation.