### PR TITLE
Handle `Dialog` clicks on removed elements

### DIFF
--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -211,7 +211,7 @@ let DialogRoot = forwardRefWithAs(function Dialog<
 
     if (dialogState !== DialogStates.Open) return
     if (hasNestedDialogs) return
-    if (!document.body.contains(target)) return
+    if (!document.documentElement.contains(target)) return
     if (internalDialogRef.current?.contains(target)) return
 
     close()

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -211,6 +211,7 @@ let DialogRoot = forwardRefWithAs(function Dialog<
 
     if (dialogState !== DialogStates.Open) return
     if (hasNestedDialogs) return
+    if (!document.body.contains(target)) return
     if (internalDialogRef.current?.contains(target)) return
 
     close()


### PR DESCRIPTION
We ran into an issue when rendering a [`CodeMirror`](https://codemirror.net/) editor inside of a  `Dialog` because under certain conditions, a click on the `CodeMirror` causes the entire `Dialog` to close. Under the hood, the `CodeMirror` editor performs re-renders by overwriting the existing DOM elements when they are changed (f.e. if you click a gutter toggle to fold a section of code, this causes the toggle to get replaced with a new toggle in the opposite open/closed state). Since this element is removed from the DOM before the `Dialog`'s `mousedown` event fires, the `event.target` will no longer be contained in the `Dialog` which causes the `Dialog` to mistakenly close.

To handle this, I've added a check for whether the `event.target` is still mounted. If it is not, then the `mousedown` event is ignored.