### PR TITLE
Export useMenuContext

### DIFF
--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -142,9 +142,9 @@ let reducers: {
 let MenuContext = createContext<[StateDefinition, Dispatch<Actions>] | null>(null)
 MenuContext.displayName = 'MenuContext'
 
-function useMenuContext(component: string) {
+export function useMenuContext(component?: string) {
   let context = useContext(MenuContext)
-  if (context === null) {
+  if (component !== undefined && context === null) {
     let err = new Error(`<${component} /> is missing a parent <${Menu.name} /> component.`)
     if (Error.captureStackTrace) Error.captureStackTrace(err, useMenuContext)
     throw err


### PR DESCRIPTION
These are facts:

- Context menus exist
- Hover menus exist (though whether or not they are a good practice is debatable)
- Other types of menus exist that aren't dropdowns or aren't triggered by a left click on a button

If you try to fight me on this, I will just close the PR and continue using my fork. **This is required functionality.** There is absolutely no reason that it should be completely impossible to open a menu by doing anything other than pressing a button. **There are valid use cases that you haven't thought of, and this library is currently making them impossible.**

I should not have to copy and paste code from Headless UI into my codebase, I should not have to make forks thinking that these issues will never be solved, and I should not have to make strongly-worded PRs. This is an incredibly bad image for the project and the organization.

Making PRs should be a friendly and fun process but my experience with contributing to your repositories has been nothing but bad. In general, the hostility that tailwindlabs has towards outside contribution is extremely offputting. If I had known this would be so hard for me and everyone else, I would have used another UI library. But right now, I need this functionality, and if you don't accept it I will have to use my fork forever, just like with heroicons.

Please at least take a step in the right direction and merge this PR so that others can benefit from this fix.

Fixes #130
Fixes #146
Fixes #894  