### PR TITLE
Fix clicks in portals in React dialog triggering onClose callback

### DIFF
--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -101,6 +101,7 @@ type DialogPropsWeControl =
   | 'aria-describedby'
   | 'aria-labelledby'
   | 'onClick'
+  | 'onMouseDown'
 
 let DialogRenderFeatures = Features.RenderStrategy | Features.Static
 
@@ -205,6 +206,9 @@ let DialogRoot = forwardRefWithAs(function Dialog<
   )
   useInertOthers(internalDialogRef, hasNestedDialogs ? enabled : false)
 
+  // Used to detect mousedown events originating from elements within portals which are rendered in dialog
+  const mouseDownEventRef = useRef<MouseEvent>()
+
   // Handle outside click
   useWindowEvent('mousedown', event => {
     let target = event.target as HTMLElement
@@ -212,6 +216,7 @@ let DialogRoot = forwardRefWithAs(function Dialog<
     if (dialogState !== DialogStates.Open) return
     if (hasNestedDialogs) return
     if (internalDialogRef.current?.contains(target)) return
+    if (mouseDownEventRef.current === event) return
 
     close()
   })
@@ -290,6 +295,9 @@ let DialogRoot = forwardRefWithAs(function Dialog<
     'aria-describedby': describedby,
     onClick(event: ReactMouseEvent) {
       event.stopPropagation()
+    },
+    onMouseDown(event: React.MouseEvent) {
+      mouseDownEventRef.current = event.nativeEvent
     },
   }
   let passthroughProps = rest


### PR DESCRIPTION
When rendering portals inside a React Dialog (e.g. a dropdown using Popper.js), clicks inside that portal are detected as clicks outside die dialog and causing the dialog to be closed.

This PR is an attempt to fix that and treating elements inside portals as inside the dialog.

However, there are some problems which make me unsure whether this particular PR should really be merged:
1. The new `onMouseDown` prop the dialog owns is probably a breaking change which makes this difficult to release
2. If clicks on elements inside portals are detected as inside the dialog, they should also be able to receive focus

Let me know whether you think it makes sense for me to continue working on this and address the issues above or whether we should just close this. 😊 