### PR TITLE
set `useCapture=true` for click outside and escape to close

### DIFF
--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -206,25 +206,33 @@ let DialogRoot = forwardRefWithAs(function Dialog<
   useInertOthers(internalDialogRef, hasNestedDialogs ? enabled : false)
 
   // Handle outside click
-  useWindowEvent('mousedown', event => {
-    let target = event.target as HTMLElement
+  useWindowEvent(
+    'mousedown',
+    (event: MouseEvent) => {
+      let target = event.target as HTMLElement
 
-    if (dialogState !== DialogStates.Open) return
-    if (hasNestedDialogs) return
-    if (internalDialogRef.current?.contains(target)) return
+      if (dialogState !== DialogStates.Open) return
+      if (hasNestedDialogs) return
+      if (internalDialogRef.current?.contains(target)) return
 
-    close()
-  })
+      close()
+    },
+    true
+  )
 
   // Handle `Escape` to close
-  useWindowEvent('keydown', event => {
-    if (event.key !== Keys.Escape) return
-    if (dialogState !== DialogStates.Open) return
-    if (hasNestedDialogs) return
-    event.preventDefault()
-    event.stopPropagation()
-    close()
-  })
+  useWindowEvent(
+    'keydown',
+    (event: KeyboardEvent) => {
+      if (event.key !== Keys.Escape) return
+      if (dialogState !== DialogStates.Open) return
+      if (hasNestedDialogs) return
+      event.preventDefault()
+      event.stopPropagation()
+      close()
+    },
+    true
+  )
 
   // Scroll lock
   useEffect(() => {

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -236,21 +236,25 @@ export function Listbox<TTag extends ElementType = typeof DEFAULT_LISTBOX_TAG, T
   ])
 
   // Handle outside click
-  useWindowEvent('mousedown', event => {
-    let target = event.target as HTMLElement
+  useWindowEvent(
+    'mousedown',
+    (event: MouseEvent) => {
+      let target = event.target as HTMLElement
 
-    if (listboxState !== ListboxStates.Open) return
+      if (listboxState !== ListboxStates.Open) return
 
-    if (buttonRef.current?.contains(target)) return
-    if (optionsRef.current?.contains(target)) return
+      if (buttonRef.current?.contains(target)) return
+      if (optionsRef.current?.contains(target)) return
 
-    dispatch({ type: ActionTypes.CloseListbox })
+      dispatch({ type: ActionTypes.CloseListbox })
 
-    if (!isFocusableElement(target, FocusableMode.Loose)) {
-      event.preventDefault()
-      buttonRef.current?.focus()
-    }
-  })
+      if (!isFocusableElement(target, FocusableMode.Loose)) {
+        event.preventDefault()
+        buttonRef.current?.focus()
+      }
+    },
+    true
+  )
 
   let slot = useMemo<ListboxRenderPropArg>(
     () => ({ open: listboxState === ListboxStates.Open, disabled }),

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -177,21 +177,25 @@ export function Menu<TTag extends ElementType = typeof DEFAULT_MENU_TAG>(
   let [{ menuState, itemsRef, buttonRef }, dispatch] = reducerBag
 
   // Handle outside click
-  useWindowEvent('mousedown', event => {
-    let target = event.target as HTMLElement
+  useWindowEvent(
+    'mousedown',
+    (event: MouseEvent) => {
+      let target = event.target as HTMLElement
 
-    if (menuState !== MenuStates.Open) return
+      if (menuState !== MenuStates.Open) return
 
-    if (buttonRef.current?.contains(target)) return
-    if (itemsRef.current?.contains(target)) return
+      if (buttonRef.current?.contains(target)) return
+      if (itemsRef.current?.contains(target)) return
 
-    dispatch({ type: ActionTypes.CloseMenu })
+      dispatch({ type: ActionTypes.CloseMenu })
 
-    if (!isFocusableElement(target, FocusableMode.Loose)) {
-      event.preventDefault()
-      buttonRef.current?.focus()
-    }
-  })
+      if (!isFocusableElement(target, FocusableMode.Loose)) {
+        event.preventDefault()
+        buttonRef.current?.focus()
+      }
+    },
+    true
+  )
 
   let slot = useMemo<MenuRenderPropArg>(() => ({ open: menuState === MenuStates.Open }), [
     menuState,

--- a/packages/@headlessui-react/src/components/popover/popover.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.tsx
@@ -217,21 +217,25 @@ export function Popover<TTag extends ElementType = typeof DEFAULT_POPOVER_TAG>(
   )
 
   // Handle outside click
-  useWindowEvent('mousedown', event => {
-    let target = event.target as HTMLElement
+  useWindowEvent(
+    'mousedown',
+    (event: MouseEvent) => {
+      let target = event.target as HTMLElement
 
-    if (popoverState !== PopoverStates.Open) return
+      if (popoverState !== PopoverStates.Open) return
 
-    if (button?.contains(target)) return
-    if (panel?.contains(target)) return
+      if (button?.contains(target)) return
+      if (panel?.contains(target)) return
 
-    dispatch({ type: ActionTypes.ClosePopover })
+      dispatch({ type: ActionTypes.ClosePopover })
 
-    if (!isFocusableElement(target, FocusableMode.Loose)) {
-      event.preventDefault()
-      button?.focus()
-    }
-  })
+      if (!isFocusableElement(target, FocusableMode.Loose)) {
+        event.preventDefault()
+        button?.focus()
+      }
+    },
+    true
+  )
 
   let close = useCallback(
     (focusableElement?: HTMLElement | MutableRefObject<HTMLElement | null>) => {

--- a/packages/@headlessui-vue/src/components/dialog/dialog.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.ts
@@ -193,26 +193,34 @@ export let Dialog = defineComponent({
     provide(DialogContext, api)
 
     // Handle outside click
-    useWindowEvent('mousedown', event => {
-      let target = event.target as HTMLElement
+    useWindowEvent(
+      'mousedown',
+      (event: MouseEvent) => {
+        let target = event.target as HTMLElement
 
-      if (dialogState.value !== DialogStates.Open) return
-      if (containers.value.size !== 1) return
-      if (contains(containers.value, target)) return
+        if (dialogState.value !== DialogStates.Open) return
+        if (containers.value.size !== 1) return
+        if (contains(containers.value, target)) return
 
-      api.close()
-      nextTick(() => target?.focus())
-    })
+        api.close()
+        nextTick(() => target?.focus())
+      },
+      true
+    )
 
     // Handle `Escape` to close
-    useWindowEvent('keydown', event => {
-      if (event.key !== Keys.Escape) return
-      if (dialogState.value !== DialogStates.Open) return
-      if (containers.value.size > 1) return // 1 is myself, otherwise other elements in the Stack
-      event.preventDefault()
-      event.stopPropagation()
-      api.close()
-    })
+    useWindowEvent(
+      'keydown', 
+      (event: KeyboardEvent) => {
+        if (event.key !== Keys.Escape) return
+        if (dialogState.value !== DialogStates.Open) return
+        if (containers.value.size > 1) return // 1 is myself, otherwise other elements in the Stack
+        event.preventDefault()
+        event.stopPropagation()
+        api.close()
+      },
+      true
+    )
 
     // Scroll lock
     watchEffect(onInvalidate => {

--- a/packages/@headlessui-vue/src/components/listbox/listbox.ts
+++ b/packages/@headlessui-vue/src/components/listbox/listbox.ts
@@ -186,17 +186,22 @@ export let Listbox = defineComponent({
       },
     }
 
-    useWindowEvent('mousedown', event => {
-      let target = event.target as HTMLElement
-      let active = document.activeElement
+    // Handle outside click
+    useWindowEvent(
+      'mousedown',
+      (event: MouseEvent) => {
+        let target = event.target as HTMLElement
+        let active = document.activeElement
 
-      if (listboxState.value !== ListboxStates.Open) return
-      if (dom(buttonRef)?.contains(target)) return
+        if (listboxState.value !== ListboxStates.Open) return
+        if (dom(buttonRef)?.contains(target)) return
 
-      if (!dom(optionsRef)?.contains(target)) api.closeListbox()
-      if (active !== document.body && active?.contains(target)) return // Keep focus on newly clicked/focused element
-      if (!event.defaultPrevented) dom(buttonRef)?.focus({ preventScroll: true })
-    })
+        if (!dom(optionsRef)?.contains(target)) api.closeListbox()
+        if (active !== document.body && active?.contains(target)) return // Keep focus on newly clicked/focused element
+        if (!event.defaultPrevented) dom(buttonRef)?.focus({ preventScroll: true })
+      },
+      true
+    )
 
     // @ts-expect-error Types of property 'dataRef' are incompatible.
     provide(ListboxContext, api)

--- a/packages/@headlessui-vue/src/components/menu/menu.ts
+++ b/packages/@headlessui-vue/src/components/menu/menu.ts
@@ -141,17 +141,22 @@ export let Menu = defineComponent({
       },
     }
 
-    useWindowEvent('mousedown', event => {
-      let target = event.target as HTMLElement
-      let active = document.activeElement
+    // Handle outside click
+    useWindowEvent(
+      'mousedown',
+      (event: MouseEvent) => {
+        let target = event.target as HTMLElement
+        let active = document.activeElement
 
-      if (menuState.value !== MenuStates.Open) return
-      if (dom(buttonRef)?.contains(target)) return
+        if (menuState.value !== MenuStates.Open) return
+        if (dom(buttonRef)?.contains(target)) return
 
-      if (!dom(itemsRef)?.contains(target)) api.closeMenu()
-      if (active !== document.body && active?.contains(target)) return // Keep focus on newly clicked/focused element
-      if (!event.defaultPrevented) dom(buttonRef)?.focus({ preventScroll: true })
-    })
+        if (!dom(itemsRef)?.contains(target)) api.closeMenu()
+        if (active !== document.body && active?.contains(target)) return // Keep focus on newly clicked/focused element
+        if (!event.defaultPrevented) dom(buttonRef)?.focus({ preventScroll: true })
+      },
+      true
+    )
 
     // @ts-expect-error Types of property 'dataRef' are incompatible.
     provide(MenuContext, api)

--- a/packages/@headlessui-vue/src/components/popover/popover.ts
+++ b/packages/@headlessui-vue/src/components/popover/popover.ts
@@ -175,21 +175,25 @@ export let Popover = defineComponent({
     )
 
     // Handle outside click
-    useWindowEvent('mousedown', (event: MouseEvent) => {
-      let target = event.target as HTMLElement
+    useWindowEvent(
+      'mousedown',
+      (event: MouseEvent) => {
+        let target = event.target as HTMLElement
 
-      if (popoverState.value !== PopoverStates.Open) return
+        if (popoverState.value !== PopoverStates.Open) return
 
-      if (dom(button)?.contains(target)) return
-      if (dom(panel)?.contains(target)) return
+        if (dom(button)?.contains(target)) return
+        if (dom(panel)?.contains(target)) return
 
-      api.closePopover()
+        api.closePopover()
 
-      if (!isFocusableElement(target, FocusableMode.Loose)) {
-        event.preventDefault()
-        dom(button)?.focus()
-      }
-    })
+        if (!isFocusableElement(target, FocusableMode.Loose)) {
+          event.preventDefault()
+          dom(button)?.focus()
+        }
+      },
+      true
+    )
 
     return () => {
       let slot = { open: popoverState.value === PopoverStates.Open, close: api.close }


### PR DESCRIPTION
Integrating this library with another library that stops all event propagation and bubbling on mouse click and keyboard events (e.g. canvas library that controls panning). End result is headlessui cannot close a component even if it's open since it uses `window` event listener. Setting `useCapture=true` avoids this problem since [capturing](https://javascript.info/bubbling-and-capturing) occurs before bubbling phase.