### PR TITLE
Next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased - React]
+## [Unreleased - @headlessui/react]
 
 - Nothing yet!
 
-## [Unreleased - Vue]
+## [Unreleased - @headlessui/vue]
 
 - Nothing yet!
 
@@ -345,8 +345,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Everything!
 
-[unreleased - react]: https://github.com/tailwindlabs/headlessui/compare/@headlessui/react@v1.4.3...HEAD
-[unreleased - vue]: https://github.com/tailwindlabs/headlessui/compare/@headlessui/vue@v1.4.3...HEAD
+[unreleased - @headlessui/react]: https://github.com/tailwindlabs/headlessui/compare/@headlessui/react@v1.4.3...HEAD
+[unreleased - @headlessui/vue]: https://github.com/tailwindlabs/headlessui/compare/@headlessui/vue@v1.4.3...HEAD
 [@headlessui/react@v1.4.3]: https://github.com/tailwindlabs/headlessui/compare/@headlessui/react@v1.4.2...@headlessui/react@v1.4.3
 [@headlessui/vue@v1.4.3]: https://github.com/tailwindlabs/headlessui/compare/@headlessui/vue@v1.4.2...@headlessui/vue@v1.4.3
 [@headlessui/react@v1.4.2]: https://github.com/tailwindlabs/headlessui/compare/@headlessui/react@v1.4.1...@headlessui/react@v1.4.2


### PR DESCRIPTION
Edit: Going to directly work on the `main` branch so that it is a very similar workflow as working on our other repo's like https://github.com/tailwindlabs/tailwindcss

---

We just made 2 new releases:

- [@headlessui/react@v1.4.3](https://github.com/tailwindlabs/headlessui/releases/tag/%40headlessui%2Freact%40v1.4.3)
- [@headlessui/vue@v1.4.3](https://github.com/tailwindlabs/headlessui/releases/tag/%40headlessui%2Fvue%40v1.4.3)

Diffs:
- [`@headlessui/react@v1.4.2`...`@headlessui/react@v1.4.3`](https://github.com/tailwindlabs/headlessui/compare/@headlessui/react@v1.4.2...@headlessui/react@v1.4.3)
- [`@headlessui/vue@v1.4.2`...`@headlessui/vue@v1.4.3`](https://github.com/tailwindlabs/headlessui/compare/@headlessui/vue@v1.4.2...@headlessui/vue@v1.4.3)

Next diffs (unreleased):
- [`@headlessui/react@v1.4.3`...`HEAD`](https://github.com/tailwindlabs/headlessui/compare/@headlessui/react@v1.4.3...HEAD)
- [`@headlessui/vue@v1.4.3`...`HEAD`](https://github.com/tailwindlabs/headlessui/compare/@headlessui/vue@v1.4.3...HEAD)


This is a new placeholder PR for the next release.

---

Every commit that lands in the `develop` branch will be automatically be published to `npm`.
You can always try those by using:
- `npm install @headlessui/react@dev` or `yarn add @headlessui/react@dev`.
- `npm install @headlessui/vue@dev` or `yarn add @headlessui/vue@dev`.
