### PR TITLE
Ignore non-option roles

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -741,6 +741,52 @@ describe('Rendering composition', () => {
       getComboboxOptions().forEach((option) => assertComboboxOption(option, { tag: 'button' }))
     })
   )
+
+  it(
+    'should mark all the elements between Combobox.Options and Combobox.Option with role none',
+    suppressConsoleLogs(async () => {
+      render(
+        <Combobox value="test" onChange={console.log}>
+          <Combobox.Input onChange={NOOP} />
+          <Combobox.Button />
+          <div className="outer">
+            <Combobox.Options>
+              <div className="inner py-1">
+                <Combobox.Option value="a">Option A</Combobox.Option>
+                <Combobox.Option value="b">Option B</Combobox.Option>
+              </div>
+              <div className="inner py-1">
+                <Combobox.Option value="c">Option C</Combobox.Option>
+                <Combobox.Option value="d">
+                  <div>
+                    <div className="outer">Option D</div>
+                  </div>
+                </Combobox.Option>
+              </div>
+              <div className="inner py-1">
+                <form className="inner">
+                  <Combobox.Option value="e">Option E</Combobox.Option>
+                </form>
+              </div>
+            </Combobox.Options>
+          </div>
+        </Combobox>
+      )
+
+      // Open combobox
+      await click(getComboboxButton())
+
+      expect.hasAssertions()
+
+      document.querySelectorAll('.outer').forEach((element) => {
+        expect(element).not.toHaveAttribute('role', 'none')
+      })
+
+      document.querySelectorAll('.inner').forEach((element) => {
+        expect(element).toHaveAttribute('role', 'none')
+      })
+    })
+  )
 })
 
 describe('Composition', () => {

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -35,6 +35,7 @@ import { useWindowEvent } from '../../hooks/use-window-event'
 import { useOpenClosed, State, OpenClosedProvider } from '../../internal/open-closed'
 import { useResolveButtonType } from '../../hooks/use-resolve-button-type'
 import { useLatestValue } from '../../hooks/use-latest-value'
+import { useTreeWalker } from '../../hooks/use-tree-walker'
 
 enum ComboboxStates {
   Open,
@@ -732,6 +733,19 @@ let Options = forwardRefWithAs(function Options<
 
     return state.comboboxState === ComboboxStates.Open
   })()
+
+  useTreeWalker({
+    container: state.optionsRef.current,
+    enabled: state.comboboxState === ComboboxStates.Open,
+    accept(node) {
+      if (node.getAttribute('role') === 'option') return NodeFilter.FILTER_REJECT
+      if (node.hasAttribute('role')) return NodeFilter.FILTER_SKIP
+      return NodeFilter.FILTER_ACCEPT
+    },
+    walk(node) {
+      node.setAttribute('role', 'none')
+    },
+  })
 
   let labelledby = useComputed(
     () => state.labelRef.current?.id ?? state.buttonRef.current?.id,

--- a/packages/@headlessui-vue/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.test.tsx
@@ -779,6 +779,55 @@ describe('Rendering composition', () => {
       getComboboxOptions().forEach((option) => assertComboboxOption(option, { tag: 'button' }))
     })
   )
+
+  it(
+    'should mark all the elements between Combobox.Options and Combobox.Option with role none',
+    suppressConsoleLogs(async () => {
+      renderTemplate({
+        template: html`
+          <Combobox v-model="value">
+            <ComboboxInput />
+            <ComboboxButton />
+            <div class="outer">
+              <ComboboxOptions>
+                <div class="inner py-1">
+                  <ComboboxOption value="a">Option A</ComboboxOption>
+                  <ComboboxOption value="b">Option B</ComboboxOption>
+                </div>
+                <div class="inner py-1">
+                  <ComboboxOption value="c">Option C</ComboboxOption>
+                  <ComboboxOption value="d">
+                    <div>
+                      <div class="outer">Option D</div>
+                    </div>
+                  </ComboboxOption>
+                </div>
+                <div class="inner py-1">
+                  <form class="inner">
+                    <ComboboxOption value="e">Option E</ComboboxOption>
+                  </form>
+                </div>
+              </ComboboxOptions>
+            </div>
+          </Combobox>
+        `,
+        setup: () => ({ value: ref(null) }),
+      })
+
+      // Open combobox
+      await click(getComboboxButton())
+
+      expect.hasAssertions()
+
+      document.querySelectorAll('.outer').forEach((element) => {
+        expect(element).not.toHaveAttribute('role', 'none')
+      })
+
+      document.querySelectorAll('.inner').forEach((element) => {
+        expect(element).toHaveAttribute('role', 'none')
+      })
+    })
+  )
 })
 
 describe('Composition', () => {

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -25,6 +25,7 @@ import { useWindowEvent } from '../../hooks/use-window-event'
 import { useOpenClosed, State, useOpenClosedProvider } from '../../internal/open-closed'
 import { match } from '../../utils/match'
 import { useResolveButtonType } from '../../hooks/use-resolve-button-type'
+import { useTreeWalker } from '../../hooks/use-tree-walker'
 
 enum ComboboxStates {
   Open,
@@ -528,6 +529,19 @@ export let ComboboxOptions = defineComponent({
       }
 
       return api.comboboxState.value === ComboboxStates.Open
+    })
+
+    useTreeWalker({
+      container: computed(() => dom(api.optionsRef)),
+      enabled: computed(() => api.comboboxState.value === ComboboxStates.Open),
+      accept(node) {
+        if (node.getAttribute('role') === 'option') return NodeFilter.FILTER_REJECT
+        if (node.hasAttribute('role')) return NodeFilter.FILTER_SKIP
+        return NodeFilter.FILTER_ACCEPT
+      },
+      walk(node) {
+        node.setAttribute('role', 'none')
+      },
     })
 
     return () => {

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -34,7 +34,7 @@ enum ComboboxStates {
 type ComboboxOptionDataRef = Ref<{ disabled: boolean; value: unknown }>
 type StateDefinition = {
   // State
-  ComboboxState: Ref<ComboboxStates>
+  comboboxState: Ref<ComboboxStates>
   value: ComputedRef<unknown>
 
   labelRef: Ref<HTMLLabelElement | null>
@@ -84,7 +84,7 @@ export let Combobox = defineComponent({
     modelValue: { type: [Object, String, Number, Boolean] },
   },
   setup(props, { slots, attrs, emit }) {
-    let ComboboxState = ref<StateDefinition['ComboboxState']['value']>(ComboboxStates.Closed)
+    let comboboxState = ref<StateDefinition['comboboxState']['value']>(ComboboxStates.Closed)
     let labelRef = ref<StateDefinition['labelRef']['value']>(null)
     let inputRef = ref<StateDefinition['inputRef']['value']>(null) as StateDefinition['inputRef']
     let buttonRef = ref<StateDefinition['buttonRef']['value']>(null) as StateDefinition['buttonRef']
@@ -97,7 +97,7 @@ export let Combobox = defineComponent({
     let value = computed(() => props.modelValue)
 
     let api = {
-      ComboboxState,
+      comboboxState,
       value,
       inputRef,
       labelRef,
@@ -109,18 +109,18 @@ export let Combobox = defineComponent({
       inputPropsRef: ref<{ displayValue?: (item: unknown) => string }>({ displayValue: undefined }),
       closeCombobox() {
         if (props.disabled) return
-        if (ComboboxState.value === ComboboxStates.Closed) return
-        ComboboxState.value = ComboboxStates.Closed
+        if (comboboxState.value === ComboboxStates.Closed) return
+        comboboxState.value = ComboboxStates.Closed
         activeOptionIndex.value = null
       },
       openCombobox() {
         if (props.disabled) return
-        if (ComboboxState.value === ComboboxStates.Open) return
-        ComboboxState.value = ComboboxStates.Open
+        if (comboboxState.value === ComboboxStates.Open) return
+        comboboxState.value = ComboboxStates.Open
       },
       goToOption(focus: Focus, id?: string) {
         if (props.disabled) return
-        if (ComboboxState.value === ComboboxStates.Closed) return
+        if (comboboxState.value === ComboboxStates.Closed) return
 
         let nextActiveOptionIndex = calculateActiveIndex(
           focus === Focus.Specific
@@ -209,7 +209,7 @@ export let Combobox = defineComponent({
       let target = event.target as HTMLElement
       let active = document.activeElement
 
-      if (ComboboxState.value !== ComboboxStates.Open) return
+      if (comboboxState.value !== ComboboxStates.Open) return
 
       if (dom(inputRef)?.contains(target)) return
       if (dom(buttonRef)?.contains(target)) return
@@ -229,7 +229,7 @@ export let Combobox = defineComponent({
     provide(ComboboxContext, api)
     useOpenClosedProvider(
       computed(() =>
-        match(ComboboxState.value, {
+        match(comboboxState.value, {
           [ComboboxStates.Open]: State.Open,
           [ComboboxStates.Closed]: State.Closed,
         })
@@ -237,7 +237,7 @@ export let Combobox = defineComponent({
     )
 
     return () => {
-      let slot = { open: ComboboxState.value === ComboboxStates.Open, disabled: props.disabled }
+      let slot = { open: comboboxState.value === ComboboxStates.Open, disabled: props.disabled }
       return render({
         props: omit(props, ['modelValue', 'onUpdate:modelValue', 'disabled', 'horizontal']),
         slot,
@@ -264,7 +264,7 @@ export let ComboboxLabel = defineComponent({
 
     return () => {
       let slot = {
-        open: api.ComboboxState.value === ComboboxStates.Open,
+        open: api.comboboxState.value === ComboboxStates.Open,
         disabled: api.disabled.value,
       }
 
@@ -294,7 +294,7 @@ export let ComboboxButton = defineComponent({
 
     function handleClick(event: MouseEvent) {
       if (api.disabled.value) return
-      if (api.ComboboxState.value === ComboboxStates.Open) {
+      if (api.comboboxState.value === ComboboxStates.Open) {
         api.closeCombobox()
       } else {
         event.preventDefault()
@@ -311,7 +311,7 @@ export let ComboboxButton = defineComponent({
         case Keys.ArrowDown:
           event.preventDefault()
           event.stopPropagation()
-          if (api.ComboboxState.value === ComboboxStates.Closed) {
+          if (api.comboboxState.value === ComboboxStates.Closed) {
             api.openCombobox()
             // TODO: We can't do this outside next frame because the options aren't rendered yet
             // But doing this in next frame results in a flicker because the dom mutations are async here
@@ -332,7 +332,7 @@ export let ComboboxButton = defineComponent({
         case Keys.ArrowUp:
           event.preventDefault()
           event.stopPropagation()
-          if (api.ComboboxState.value === ComboboxStates.Closed) {
+          if (api.comboboxState.value === ComboboxStates.Closed) {
             api.openCombobox()
             nextTick(() => {
               if (!api.value.value) {
@@ -359,7 +359,7 @@ export let ComboboxButton = defineComponent({
 
     return () => {
       let slot = {
-        open: api.ComboboxState.value === ComboboxStates.Open,
+        open: api.comboboxState.value === ComboboxStates.Open,
         disabled: api.disabled.value,
       }
       let propsWeControl = {
@@ -371,7 +371,7 @@ export let ComboboxButton = defineComponent({
         'aria-controls': dom(api.optionsRef)?.id,
         'aria-expanded': api.disabled.value
           ? undefined
-          : api.ComboboxState.value === ComboboxStates.Open,
+          : api.comboboxState.value === ComboboxStates.Open,
         'aria-labelledby': api.labelRef.value ? [dom(api.labelRef)?.id, id].join(' ') : undefined,
         disabled: api.disabled.value === true ? true : undefined,
         onKeydown: handleKeydown,
@@ -422,7 +422,7 @@ export let ComboboxInput = defineComponent({
         case Keys.ArrowDown:
           event.preventDefault()
           event.stopPropagation()
-          return match(api.ComboboxState.value, {
+          return match(api.comboboxState.value, {
             [ComboboxStates.Open]: () => api.goToOption(Focus.Next),
             [ComboboxStates.Closed]: () => {
               api.openCombobox()
@@ -437,7 +437,7 @@ export let ComboboxInput = defineComponent({
         case Keys.ArrowUp:
           event.preventDefault()
           event.stopPropagation()
-          return match(api.ComboboxState.value, {
+          return match(api.comboboxState.value, {
             [ComboboxStates.Open]: () => api.goToOption(Focus.Previous),
             [ComboboxStates.Closed]: () => {
               api.openCombobox()
@@ -480,7 +480,7 @@ export let ComboboxInput = defineComponent({
     }
 
     return () => {
-      let slot = { open: api.ComboboxState.value === ComboboxStates.Open }
+      let slot = { open: api.comboboxState.value === ComboboxStates.Open }
       let propsWeControl = {
         'aria-activedescendant':
           api.activeOptionIndex.value === null
@@ -527,11 +527,11 @@ export let ComboboxOptions = defineComponent({
         return usesOpenClosedState.value === State.Open
       }
 
-      return api.ComboboxState.value === ComboboxStates.Open
+      return api.comboboxState.value === ComboboxStates.Open
     })
 
     return () => {
-      let slot = { open: api.ComboboxState.value === ComboboxStates.Open }
+      let slot = { open: api.comboboxState.value === ComboboxStates.Open }
       let propsWeControl = {
         'aria-activedescendant':
           api.activeOptionIndex.value === null
@@ -586,9 +586,9 @@ export let ComboboxOption = defineComponent({
 
     onMounted(() => {
       watch(
-        [api.ComboboxState, selected],
+        [api.comboboxState, selected],
         () => {
-          if (api.ComboboxState.value !== ComboboxStates.Open) return
+          if (api.comboboxState.value !== ComboboxStates.Open) return
           if (!selected.value) return
           api.goToOption(Focus.Specific, id)
         },
@@ -597,7 +597,7 @@ export let ComboboxOption = defineComponent({
     })
 
     watchEffect(() => {
-      if (api.ComboboxState.value !== ComboboxStates.Open) return
+      if (api.comboboxState.value !== ComboboxStates.Open) return
       if (!active.value) return
       nextTick(() => document.getElementById(id)?.scrollIntoView?.({ block: 'nearest' }))
     })


### PR DESCRIPTION
When you add elements between `Combobox.Options` and `Combobox.Option` then we will mark them using `role: none` if they don't have a `role` already.
This is similar behaviour to the `Menu` component and we probably want this behaviour for the `Listbox` itself.

