### PR TITLE
Temporarily target es2019 instead of es2020

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,7 +14,7 @@ tsc=$(yarn bin tsc)
 sharedOptions=()
 sharedOptions+=("--bundle")
 sharedOptions+=("--platform=browser")
-sharedOptions+=("--target=es2020")
+sharedOptions+=("--target=es2019")
 
 # Generate actual builds
 NODE_ENV=production  $esbuild $input --format=esm  --outfile=$outdir/$name.esm.js    --minify ${sharedOptions[@]} $@ &


### PR DESCRIPTION
The Headless UI docs require some bumps in packages because it currently
can't handle es2020 features like `??`. This temporary workaround should
fix this in the mean time.
