### PR TITLE
Fix off-by-one frame issue causing flicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve overal codebase, use modern tech like `esbuild` and TypeScript 4! ([#1055](https://github.com/tailwindlabs/headlessui/pull/1055))
 - Improve build files ([#1078](https://github.com/tailwindlabs/headlessui/pull/1078))
 - Ensure typeahead stays on same item if it still matches ([#1098](https://github.com/tailwindlabs/headlessui/pull/1098))
+- Fix off-by-one frame issue causing flicker ([#1111](https://github.com/tailwindlabs/headlessui/pull/1111))
 
 ### Added
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -856,7 +856,9 @@ function Option<
     if (state.comboboxState !== ComboboxStates.Open) return
     if (!active) return
     let d = disposables()
-    d.nextFrame(() => document.getElementById(id)?.scrollIntoView?.({ block: 'nearest' }))
+    d.requestAnimationFrame(() => {
+      document.getElementById(id)?.scrollIntoView?.({ block: 'nearest' })
+    })
     return d.dispose
   }, [id, active, state.comboboxState])
 

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -666,7 +666,9 @@ function Option<
     if (state.listboxState !== ListboxStates.Open) return
     if (!active) return
     let d = disposables()
-    d.nextFrame(() => document.getElementById(id)?.scrollIntoView?.({ block: 'nearest' }))
+    d.requestAnimationFrame(() => {
+      document.getElementById(id)?.scrollIntoView?.({ block: 'nearest' })
+    })
     return d.dispose
   }, [id, active, state.listboxState])
 

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -535,7 +535,9 @@ function Item<TTag extends ElementType = typeof DEFAULT_ITEM_TAG>(
     if (state.menuState !== MenuStates.Open) return
     if (!active) return
     let d = disposables()
-    d.nextFrame(() => document.getElementById(id)?.scrollIntoView?.({ block: 'nearest' }))
+    d.requestAnimationFrame(() => {
+      document.getElementById(id)?.scrollIntoView?.({ block: 'nearest' })
+    })
     return d.dispose
   }, [id, active, state.menuState])
 


### PR DESCRIPTION
Right now when you press arrow up/down/etc… and change the active item we wait for two rAF call backs. This has the affect of waiting after two full paints have finished. This results in, for the react version of the Combobox, a period of 1 frame where the active item has changed and re-rendered but the scroll hasn't happened yet.

Now, it is common to have to wait 2 rAF frames for the DOM to have updated in React because of a Chrome (and possibly Safari) bug with animations. However, in this case we're not waiting for animations to start, just scrolling. As far as I know the DOM *should* be updated by the end of the first cal to rAF but perhaps we should check if the element exists and schedule another one if it doesn't?

I'd also be curious to see if this behavior is a problem in React 18 because it does automatic batching of updates so it's possible that the timing would end up being correct. Not sure though — because I don't know much about the new fanciness in React 18.