### PR TITLE
Use `ownerDocument` instead of `document`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ignore "outside click" on removed elements ([#1193](https://github.com/tailwindlabs/headlessui/pull/1193))
 - Remove `focus()` from Listbox Option ([#1218](https://github.com/tailwindlabs/headlessui/pull/1218))
 - Improve some internal code ([#1221](https://github.com/tailwindlabs/headlessui/pull/1221))
+- Use `ownerDocument` instead of `document` ([#1158](https://github.com/tailwindlabs/headlessui/pull/1158))
 
 ### Added
 
@@ -49,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove `focus()` from Listbox Option ([#1218](https://github.com/tailwindlabs/headlessui/pull/1218))
 - Improve some internal code ([#1221](https://github.com/tailwindlabs/headlessui/pull/1221))
 - Don’t drop initial character when searching in Combobox ([#1223](https://github.com/tailwindlabs/headlessui/pull/1223))
+- Use `ownerDocument` instead of `document` ([#1158](https://github.com/tailwindlabs/headlessui/pull/1158))
 
 ### Added
 

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -36,6 +36,7 @@ import { useResolveButtonType } from '../../hooks/use-resolve-button-type'
 import { useOutsideClick } from '../../hooks/use-outside-click'
 import { VisuallyHidden } from '../../internal/visually-hidden'
 import { objectToFormEntries } from '../../utils/form'
+import { getOwnerDocument } from '../../utils/owner'
 
 enum ListboxStates {
   Open,
@@ -559,7 +560,7 @@ let Options = forwardRefWithAs(function Options<
     let container = state.optionsRef.current
     if (!container) return
     if (state.listboxState !== ListboxStates.Open) return
-    if (container === document.activeElement) return
+    if (container === getOwnerDocument(container)?.activeElement) return
 
     container.focus({ preventScroll: true })
   }, [state.listboxState, state.optionsRef])
@@ -704,7 +705,7 @@ let Option = forwardRefWithAs(function Option<
   let active =
     state.activeOptionIndex !== null ? state.options[state.activeOptionIndex].id === id : false
   let selected = state.propsRef.current.value === value
-  let internalOptionRef = useRef<HTMLElement | null>(null)
+  let internalOptionRef = useRef<HTMLLIElement | null>(null)
   let optionRef = useSyncRefs(ref, internalOptionRef)
 
   useIsoMorphicEffect(() => {

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -35,6 +35,7 @@ import { useOutsideClick } from '../../hooks/use-outside-click'
 import { useTreeWalker } from '../../hooks/use-tree-walker'
 import { useOpenClosed, State, OpenClosedProvider } from '../../internal/open-closed'
 import { useResolveButtonType } from '../../hooks/use-resolve-button-type'
+import { useOwnerDocument } from '../../hooks/use-owner'
 
 enum MenuStates {
   Open,
@@ -398,6 +399,7 @@ let Items = forwardRefWithAs(function Items<TTag extends ElementType = typeof DE
 ) {
   let [state, dispatch] = useMenuContext('Menu.Items')
   let itemsRef = useSyncRefs(state.itemsRef, ref)
+  let ownerDocument = useOwnerDocument(state.itemsRef)
 
   let id = `headlessui-menu-items-${useId()}`
   let searchDisposables = useDisposables()
@@ -415,10 +417,10 @@ let Items = forwardRefWithAs(function Items<TTag extends ElementType = typeof DE
     let container = state.itemsRef.current
     if (!container) return
     if (state.menuState !== MenuStates.Open) return
-    if (container === document.activeElement) return
+    if (container === ownerDocument?.activeElement) return
 
     container.focus({ preventScroll: true })
-  }, [state.menuState, state.itemsRef])
+  }, [state.menuState, state.itemsRef, ownerDocument])
 
   useTreeWalker({
     container: state.itemsRef.current,
@@ -501,7 +503,7 @@ let Items = forwardRefWithAs(function Items<TTag extends ElementType = typeof DE
           break
       }
     },
-    [dispatch, searchDisposables, state]
+    [dispatch, searchDisposables, state, ownerDocument]
   )
 
   let handleKeyUp = useCallback((event: ReactKeyboardEvent<HTMLButtonElement>) => {

--- a/packages/@headlessui-react/src/components/radio-group/radio-group.tsx
+++ b/packages/@headlessui-react/src/components/radio-group/radio-group.tsx
@@ -28,6 +28,7 @@ import { useTreeWalker } from '../../hooks/use-tree-walker'
 import { useSyncRefs } from '../../hooks/use-sync-refs'
 import { VisuallyHidden } from '../../internal/visually-hidden'
 import { objectToFormEntries } from '../../utils/form'
+import { getOwnerDocument } from '../../utils/owner'
 
 interface Option {
   id: string
@@ -174,6 +175,8 @@ let RadioGroupRoot = forwardRefWithAs(function RadioGroup<
       let container = internalRadioGroupRef.current
       if (!container) return
 
+      let ownerDocument = getOwnerDocument(container)
+
       let all = options
         .filter((option) => option.propsRef.current.disabled === false)
         .map((radio) => radio.element.current) as HTMLElement[]
@@ -189,7 +192,7 @@ let RadioGroupRoot = forwardRefWithAs(function RadioGroup<
 
             if (result === FocusResult.Success) {
               let activeOption = options.find(
-                (option) => option.element.current === document.activeElement
+                (option) => option.element.current === ownerDocument?.activeElement
               )
               if (activeOption) triggerChange(activeOption.propsRef.current.value)
             }
@@ -206,7 +209,7 @@ let RadioGroupRoot = forwardRefWithAs(function RadioGroup<
 
             if (result === FocusResult.Success) {
               let activeOption = options.find(
-                (option) => option.element.current === document.activeElement
+                (option) => option.element.current === ownerDocument?.activeElement
               )
               if (activeOption) triggerChange(activeOption.propsRef.current.value)
             }
@@ -219,7 +222,7 @@ let RadioGroupRoot = forwardRefWithAs(function RadioGroup<
             event.stopPropagation()
 
             let activeOption = options.find(
-              (option) => option.element.current === document.activeElement
+              (option) => option.element.current === ownerDocument?.activeElement
             )
             if (activeOption) triggerChange(activeOption.propsRef.current.value)
           }

--- a/packages/@headlessui-react/src/hooks/use-event-listener.ts
+++ b/packages/@headlessui-react/src/hooks/use-event-listener.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react'
+
+import { useLatestValue } from './use-latest-value'
+
+export function useEventListener<TType extends keyof WindowEventMap>(
+  element: HTMLElement | Document | Window | EventTarget | null | undefined,
+  type: TType,
+  listener: (event: WindowEventMap[TType]) => any,
+  options?: boolean | AddEventListenerOptions
+) {
+  let listenerRef = useLatestValue(listener)
+
+  useEffect(() => {
+    element = element ?? window
+
+    function handler(event: WindowEventMap[TType]) {
+      listenerRef.current(event)
+    }
+
+    element.addEventListener(type, handler as any, options)
+    return () => element!.removeEventListener(type, handler as any, options)
+  }, [element, type, options])
+}

--- a/packages/@headlessui-react/src/hooks/use-inert-others.ts
+++ b/packages/@headlessui-react/src/hooks/use-inert-others.ts
@@ -1,4 +1,5 @@
 import { MutableRefObject } from 'react'
+import { getOwnerDocument } from '../utils/owner'
 import { useIsoMorphicEffect } from './use-iso-morphic-effect'
 
 let interactables = new Set<HTMLElement>()
@@ -29,6 +30,8 @@ export function useInertOthers<TElement extends HTMLElement>(
     if (!container.current) return
 
     let element = container.current
+    let ownerDocument = getOwnerDocument(element)
+    if (!ownerDocument) return
 
     // Mark myself as an interactable element
     interactables.add(element)
@@ -42,7 +45,7 @@ export function useInertOthers<TElement extends HTMLElement>(
     }
 
     // Collect direct children of the body
-    document.querySelectorAll('body > *').forEach((child) => {
+    ownerDocument.querySelectorAll('body > *').forEach((child) => {
       if (!(child instanceof HTMLElement)) return // Skip non-HTMLElements
 
       // Skip the interactables, and the parents of the interactables
@@ -71,7 +74,7 @@ export function useInertOthers<TElement extends HTMLElement>(
       // will become inert as well.
       if (interactables.size > 0) {
         // Collect direct children of the body
-        document.querySelectorAll('body > *').forEach((child) => {
+        ownerDocument!.querySelectorAll('body > *').forEach((child) => {
           if (!(child instanceof HTMLElement)) return // Skip non-HTMLElements
 
           // Skip already inert parents

--- a/packages/@headlessui-react/src/hooks/use-owner.ts
+++ b/packages/@headlessui-react/src/hooks/use-owner.ts
@@ -1,0 +1,6 @@
+import { useMemo } from 'react'
+import { getOwnerDocument } from '../utils/owner'
+
+export function useOwnerDocument(...args: Parameters<typeof getOwnerDocument>) {
+  return useMemo(() => getOwnerDocument(...args), [...args])
+}

--- a/packages/@headlessui-react/src/hooks/use-sync-refs.ts
+++ b/packages/@headlessui-react/src/hooks/use-sync-refs.ts
@@ -1,5 +1,11 @@
 import { useRef, useEffect, useCallback } from 'react'
 
+let Optional = Symbol()
+
+export function optionalRef<T>(cb: (ref: T) => void, isOptional = true) {
+  return Object.assign(cb, { [Optional]: isOptional })
+}
+
 export function useSyncRefs<TType>(
   ...refs: (React.MutableRefObject<TType | null> | ((instance: TType) => void) | null)[]
 ) {
@@ -20,5 +26,12 @@ export function useSyncRefs<TType>(
     [cache]
   )
 
-  return refs.every((ref) => ref == null) ? undefined : syncRefs
+  return refs.every(
+    (ref) =>
+      ref == null ||
+      // @ts-expect-error
+      ref?.[Optional]
+  )
+    ? undefined
+    : syncRefs
 }

--- a/packages/@headlessui-react/src/hooks/use-tree-walker.ts
+++ b/packages/@headlessui-react/src/hooks/use-tree-walker.ts
@@ -1,5 +1,6 @@
 import { useRef, useEffect } from 'react'
 import { useIsoMorphicEffect } from './use-iso-morphic-effect'
+import { getOwnerDocument } from '../utils/owner'
 
 type AcceptNode = (
   node: HTMLElement
@@ -30,13 +31,20 @@ export function useTreeWalker({
   useIsoMorphicEffect(() => {
     if (!container) return
     if (!enabled) return
+    let ownerDocument = getOwnerDocument(container)
+    if (!ownerDocument) return
 
     let accept = acceptRef.current
     let walk = walkRef.current
 
     let acceptNode = Object.assign((node: HTMLElement) => accept(node), { acceptNode: accept })
-    // @ts-expect-error This `false` is a simple small fix for older browsers
-    let walker = document.createTreeWalker(container, NodeFilter.SHOW_ELEMENT, acceptNode, false)
+    let walker = ownerDocument.createTreeWalker(
+      container,
+      NodeFilter.SHOW_ELEMENT,
+      acceptNode,
+      // @ts-expect-error This `false` is a simple small fix for older browsers
+      false
+    )
 
     while (walker.nextNode()) walk(walker.currentNode as HTMLElement)
   }, [container, enabled, acceptRef, walkRef])

--- a/packages/@headlessui-react/src/hooks/use-window-event.ts
+++ b/packages/@headlessui-react/src/hooks/use-window-event.ts
@@ -1,16 +1,17 @@
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
+
+import { useLatestValue } from './use-latest-value'
 
 export function useWindowEvent<TType extends keyof WindowEventMap>(
   type: TType,
-  listener: (this: Window, ev: WindowEventMap[TType]) => any,
+  listener: (ev: WindowEventMap[TType]) => any,
   options?: boolean | AddEventListenerOptions
 ) {
-  let listenerRef = useRef(listener)
-  listenerRef.current = listener
+  let listenerRef = useLatestValue(listener)
 
   useEffect(() => {
     function handler(event: WindowEventMap[TType]) {
-      listenerRef.current.call(window, event)
+      listenerRef.current(event)
     }
 
     window.addEventListener(type, handler, options)

--- a/packages/@headlessui-react/src/utils/focus-management.ts
+++ b/packages/@headlessui-react/src/utils/focus-management.ts
@@ -1,4 +1,5 @@
 import { match } from './match'
+import { getOwnerDocument } from './owner'
 
 // Credit:
 //  - https://stackoverflow.com/a/30753870
@@ -79,7 +80,7 @@ export function isFocusableElement(
   element: HTMLElement,
   mode: FocusableMode = FocusableMode.Strict
 ) {
-  if (element === document.body) return false
+  if (element === getOwnerDocument(element)?.body) return false
 
   return match(mode, {
     [FocusableMode.Strict]() {
@@ -121,10 +122,16 @@ export function sortByDomNode<T>(
 }
 
 export function focusIn(container: HTMLElement | HTMLElement[], focus: Focus) {
+  let ownerDocument = Array.isArray(container)
+    ? container.length > 0
+      ? container[0].ownerDocument
+      : document
+    : container.ownerDocument
+
   let elements = Array.isArray(container)
     ? sortByDomNode(container)
     : getFocusableElements(container)
-  let active = document.activeElement as HTMLElement
+  let active = ownerDocument.activeElement as HTMLElement
 
   let direction = (() => {
     if (focus & (Focus.First | Focus.Next)) return Direction.Next
@@ -167,7 +174,7 @@ export function focusIn(container: HTMLElement | HTMLElement[], focus: Focus) {
 
     // Try the next one in line
     offset += direction
-  } while (next !== document.activeElement)
+  } while (next !== ownerDocument.activeElement)
 
   // This is a little weird, but let me try and explain: There are a few scenario's
   // in chrome for example where a focused `<a>` tag does not get the default focus

--- a/packages/@headlessui-react/src/utils/owner.ts
+++ b/packages/@headlessui-react/src/utils/owner.ts
@@ -1,0 +1,13 @@
+import { MutableRefObject } from 'react'
+
+export function getOwnerDocument<T extends Element | MutableRefObject<Element | null>>(
+  element: T | null | undefined
+) {
+  if (typeof window === 'undefined') return null
+  if (element instanceof Node) return element.ownerDocument
+  if (element?.hasOwnProperty('current')) {
+    if (element.current instanceof Node) return element.current.ownerDocument
+  }
+
+  return document
+}

--- a/packages/@headlessui-vue/src/components/portal/portal.ts
+++ b/packages/@headlessui-vue/src/components/portal/portal.ts
@@ -12,19 +12,27 @@ import {
   // Types
   InjectionKey,
   PropType,
+  computed,
 } from 'vue'
 import { render } from '../../utils/render'
 import { usePortalRoot } from '../../internal/portal-force-root'
+import { getOwnerDocument } from '../../utils/owner'
 
 // ---
 
-function getPortalRoot() {
-  let existingRoot = document.getElementById('headlessui-portal-root')
+function getPortalRoot(contextElement?: Element | null) {
+  let ownerDocument = getOwnerDocument(contextElement)
+  if (!ownerDocument) {
+    throw new Error(
+      `[Headless UI]: Cannot find ownerDocument for contextElement: ${contextElement}`
+    )
+  }
+  let existingRoot = ownerDocument.getElementById('headlessui-portal-root')
   if (existingRoot) return existingRoot
 
-  let root = document.createElement('div')
+  let root = ownerDocument.createElement('div')
   root.setAttribute('id', 'headlessui-portal-root')
-  return document.body.appendChild(root)
+  return ownerDocument.body.appendChild(root)
 }
 
 export let Portal = defineComponent({
@@ -33,13 +41,16 @@ export let Portal = defineComponent({
     as: { type: [Object, String], default: 'div' },
   },
   setup(props, { slots, attrs }) {
+    let element = ref<HTMLElement | null>(null)
+    let ownerDocument = computed(() => getOwnerDocument(element))
+
     let forcePortalRoot = usePortalRoot()
     let groupContext = inject(PortalGroupContext, null)
     let myTarget = ref(
       forcePortalRoot === true
-        ? getPortalRoot()
+        ? getPortalRoot(element.value)
         : groupContext === null
-        ? getPortalRoot()
+        ? getPortalRoot(element.value)
         : groupContext.resolveTarget()
     )
 
@@ -49,10 +60,8 @@ export let Portal = defineComponent({
       myTarget.value = groupContext.resolveTarget()
     })
 
-    let element = ref(null)
-
     onUnmounted(() => {
-      let root = document.getElementById('headlessui-portal-root')
+      let root = ownerDocument.value?.getElementById('headlessui-portal-root')
       if (!root) return
       if (myTarget.value !== root) return
 

--- a/packages/@headlessui-vue/src/components/radio-group/radio-group.ts
+++ b/packages/@headlessui-vue/src/components/radio-group/radio-group.ts
@@ -25,6 +25,7 @@ import { Description, useDescriptions } from '../description/description'
 import { useTreeWalker } from '../../hooks/use-tree-walker'
 import { VisuallyHidden } from '../../internal/visually-hidden'
 import { objectToFormEntries } from '../../utils/form'
+import { getOwnerDocument } from '../../utils/owner'
 
 interface Option {
   id: string
@@ -147,7 +148,7 @@ export let RadioGroup = defineComponent({
 
             if (result === FocusResult.Success) {
               let activeOption = options.value.find(
-                (option) => option.element === document.activeElement
+                (option) => option.element === getOwnerDocument(radioGroupRef)?.activeElement
               )
               if (activeOption) api.change(activeOption.propsRef.value)
             }
@@ -164,7 +165,7 @@ export let RadioGroup = defineComponent({
 
             if (result === FocusResult.Success) {
               let activeOption = options.value.find(
-                (option) => option.element === document.activeElement
+                (option) => option.element === getOwnerDocument(option.element)?.activeElement
               )
               if (activeOption) api.change(activeOption.propsRef.value)
             }
@@ -177,7 +178,7 @@ export let RadioGroup = defineComponent({
             event.stopPropagation()
 
             let activeOption = options.value.find(
-              (option) => option.element === document.activeElement
+              (option) => option.element === getOwnerDocument(option.element)?.activeElement
             )
             if (activeOption) api.change(activeOption.propsRef.value)
           }

--- a/packages/@headlessui-vue/src/hooks/use-event-listener.ts
+++ b/packages/@headlessui-vue/src/hooks/use-event-listener.ts
@@ -1,0 +1,17 @@
+import { watchEffect } from 'vue'
+
+export function useEventListener<TType extends keyof WindowEventMap>(
+  element: HTMLElement | Document | Window | EventTarget | null | undefined,
+  type: TType,
+  listener: (event: WindowEventMap[TType]) => any,
+  options?: boolean | AddEventListenerOptions
+) {
+  if (typeof window === 'undefined') return
+
+  watchEffect((onInvalidate) => {
+    element = element ?? window
+
+    element.addEventListener(type, listener as any, options)
+    onInvalidate(() => element!.removeEventListener(type, listener as any, options))
+  })
+}

--- a/packages/@headlessui-vue/src/hooks/use-inert-others.ts
+++ b/packages/@headlessui-vue/src/hooks/use-inert-others.ts
@@ -5,6 +5,7 @@ import {
   // Types
   Ref,
 } from 'vue'
+import { getOwnerDocument } from '../utils/owner'
 
 // TODO: Figure out a nice way to attachTo document.body in the tests without automagically inserting a div with data-v-app
 let CHILDREN_SELECTOR = process.env.NODE_ENV === 'test' ? '[data-v-app=""] > *' : 'body > *'
@@ -37,6 +38,8 @@ export function useInertOthers<TElement extends HTMLElement>(
     if (!container.value) return
 
     let element = container.value
+    let ownerDocument = getOwnerDocument(element)
+    if (!ownerDocument) return
 
     // Mark myself as an interactable element
     interactables.add(element)
@@ -50,7 +53,7 @@ export function useInertOthers<TElement extends HTMLElement>(
     }
 
     // Collect direct children of the body
-    document.querySelectorAll(CHILDREN_SELECTOR).forEach((child) => {
+    ownerDocument.querySelectorAll(CHILDREN_SELECTOR).forEach((child) => {
       if (!(child instanceof HTMLElement)) return // Skip non-HTMLElements
 
       // Skip the interactables, and the parents of the interactables
@@ -79,7 +82,7 @@ export function useInertOthers<TElement extends HTMLElement>(
       // will become inert as well.
       if (interactables.size > 0) {
         // Collect direct children of the body
-        document.querySelectorAll(CHILDREN_SELECTOR).forEach((child) => {
+        ownerDocument!.querySelectorAll(CHILDREN_SELECTOR).forEach((child) => {
           if (!(child instanceof HTMLElement)) return // Skip non-HTMLElements
 
           // Skip already inert parents

--- a/packages/@headlessui-vue/src/hooks/use-tree-walker.ts
+++ b/packages/@headlessui-vue/src/hooks/use-tree-walker.ts
@@ -1,4 +1,5 @@
 import { watchEffect, ComputedRef } from 'vue'
+import { getOwnerDocument } from '../utils/owner'
 
 type AcceptNode = (
   node: HTMLElement
@@ -22,10 +23,17 @@ export function useTreeWalker({
     let root = container.value
     if (!root) return
     if (enabled !== undefined && !enabled.value) return
+    let ownerDocument = getOwnerDocument(container)
+    if (!ownerDocument) return
 
     let acceptNode = Object.assign((node: HTMLElement) => accept(node), { acceptNode: accept })
-    // @ts-expect-error This `false` is a simple small fix for older browsers
-    let walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, acceptNode, false)
+    let walker = ownerDocument.createTreeWalker(
+      root,
+      NodeFilter.SHOW_ELEMENT,
+      acceptNode,
+      // @ts-expect-error This `false` is a simple small fix for older browsers
+      false
+    )
 
     while (walker.nextNode()) walk(walker.currentNode as HTMLElement)
   })

--- a/packages/@headlessui-vue/src/hooks/use-window-event.ts
+++ b/packages/@headlessui-vue/src/hooks/use-window-event.ts
@@ -9,9 +9,6 @@ export function useWindowEvent<TType extends keyof WindowEventMap>(
 
   watchEffect((onInvalidate) => {
     window.addEventListener(type, listener, options)
-
-    onInvalidate(() => {
-      window.removeEventListener(type, listener, options)
-    })
+    onInvalidate(() => window.removeEventListener(type, listener, options))
   })
 }

--- a/packages/@headlessui-vue/src/utils/dom.ts
+++ b/packages/@headlessui-vue/src/utils/dom.ts
@@ -1,8 +1,6 @@
 import { Ref, ComponentPublicInstance } from 'vue'
 
-export function dom<T extends HTMLElement | ComponentPublicInstance>(
-  ref?: Ref<T | null>
-): T | null {
+export function dom<T extends Element | ComponentPublicInstance>(ref?: Ref<T | null>): T | null {
   if (ref == null) return null
   if (ref.value == null) return null
 

--- a/packages/@headlessui-vue/src/utils/focus-management.ts
+++ b/packages/@headlessui-vue/src/utils/focus-management.ts
@@ -1,4 +1,5 @@
 import { match } from './match'
+import { getOwnerDocument } from './owner'
 
 // Credit:
 //  - https://stackoverflow.com/a/30753870
@@ -72,7 +73,7 @@ export function isFocusableElement(
   element: HTMLElement,
   mode: FocusableMode = FocusableMode.Strict
 ) {
-  if (element === document.body) return false
+  if (element === getOwnerDocument(element)?.body) return false
 
   return match(mode, {
     [FocusableMode.Strict]() {
@@ -114,10 +115,17 @@ export function sortByDomNode<T>(
 }
 
 export function focusIn(container: HTMLElement | HTMLElement[], focus: Focus) {
+  let ownerDocument =
+    (Array.isArray(container)
+      ? container.length > 0
+        ? container[0].ownerDocument
+        : document
+      : container?.ownerDocument) ?? document
+
   let elements = Array.isArray(container)
     ? sortByDomNode(container)
     : getFocusableElements(container)
-  let active = document.activeElement as HTMLElement
+  let active = ownerDocument.activeElement as HTMLElement
 
   let direction = (() => {
     if (focus & (Focus.First | Focus.Next)) return Direction.Next
@@ -160,7 +168,7 @@ export function focusIn(container: HTMLElement | HTMLElement[], focus: Focus) {
 
     // Try the next one in line
     offset += direction
-  } while (next !== document.activeElement)
+  } while (next !== ownerDocument.activeElement)
 
   // This is a little weird, but let me try and explain: There are a few scenario's
   // in chrome for example where a focused `<a>` tag does not get the default focus

--- a/packages/@headlessui-vue/src/utils/owner.ts
+++ b/packages/@headlessui-vue/src/utils/owner.ts
@@ -1,0 +1,15 @@
+import { Ref } from 'vue'
+import { dom } from './dom'
+
+export function getOwnerDocument<T extends Element | Ref<Element | null>>(
+  element: T | null | undefined
+) {
+  if (typeof window === 'undefined') return null
+  if (element instanceof Node) return element.ownerDocument
+  if (element?.hasOwnProperty('value')) {
+    let domElement = dom(element)
+    if (domElement) return domElement.ownerDocument
+  }
+
+  return document
+}


### PR DESCRIPTION
We are currently relying on `window` and `document`, but those are not always the correct instances. When you are in an iframe or opened a new window, there is a different owner. You can get this owner by using `node.ownerDocument`

In this PR we will use the correct `ownerDocument`. In addition, we will also use the correct `window` which can be found via `el.ownerDocument.defaultView`

Fixes: #966
