### PR TITLE
Fix `hover` scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Forward the `ref` to all components ([#1116](https://github.com/tailwindlabs/headlessui/pull/1116))
 - Ensure links are triggered inside `Popover Panel` components ([#1153](https://github.com/tailwindlabs/headlessui/pull/1153))
 - Improve SSR for `Tab` component ([#1155](https://github.com/tailwindlabs/headlessui/pull/1155))
+- Fix `hover` scroll ([#1161](https://github.com/tailwindlabs/headlessui/pull/1161))
 
 ## [Unreleased - @headlessui/vue]
 
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure that you can close the combobox initially ([#1148](https://github.com/tailwindlabs/headlessui/pull/1148))
 - Fix Dialog usage in Tabs ([#1149](https://github.com/tailwindlabs/headlessui/pull/1149))
 - Ensure links are triggered inside `Popover Panel` components ([#1153](https://github.com/tailwindlabs/headlessui/pull/1153))
+- Fix `hover` scroll ([#1161](https://github.com/tailwindlabs/headlessui/pull/1161))
 
 ## [@headlessui/react@v1.5.0] - 2022-02-17
 

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -166,7 +166,12 @@ let reducers: {
     let matchIdx = matchingOption ? state.options.indexOf(matchingOption) : -1
 
     if (matchIdx === -1 || matchIdx === state.activeOptionIndex) return { ...state, searchQuery }
-    return { ...state, searchQuery, activeOptionIndex: matchIdx }
+    return {
+      ...state,
+      searchQuery,
+      activeOptionIndex: matchIdx,
+      activationTrigger: ActivationTrigger.Other,
+    }
   },
   [ActionTypes.ClearSearch](state) {
     if (state.disabled) return state
@@ -208,6 +213,7 @@ let reducers: {
         // fix this, we will find the correct (new) index position.
         return nextOptions.indexOf(currentActiveOption)
       })(),
+      activationTrigger: ActivationTrigger.Other,
     }
   },
 }
@@ -696,7 +702,7 @@ let Option = forwardRefWithAs(function Option<
       document.getElementById(id)?.scrollIntoView?.({ block: 'nearest' })
     })
     return d.dispose
-  }, [id, active, state.listboxState, /* We also want to trigger this when the position of the active item changes so that we can re-trigger the scrollIntoView */ state.activeOptionIndex])
+  }, [id, active, state.listboxState, state.activationTrigger, /* We also want to trigger this when the position of the active item changes so that we can re-trigger the scrollIntoView */ state.activeOptionIndex])
 
   let handleClick = useCallback(
     (event: { preventDefault: Function }) => {

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -39,6 +39,11 @@ enum ListboxStates {
   Closed,
 }
 
+enum ActiveOptionTrigger {
+  mouse,
+  auto,
+}
+
 type ListboxOptionDataRef = MutableRefObject<{
   textValue?: string
   disabled: boolean
@@ -59,6 +64,7 @@ interface StateDefinition {
   options: { id: string; dataRef: ListboxOptionDataRef }[]
   searchQuery: string
   activeOptionIndex: number | null
+  activeOptionTrigger: ActiveOptionTrigger
 }
 
 enum ActionTypes {
@@ -81,8 +87,17 @@ type Actions =
   | { type: ActionTypes.OpenListbox }
   | { type: ActionTypes.SetDisabled; disabled: boolean }
   | { type: ActionTypes.SetOrientation; orientation: StateDefinition['orientation'] }
-  | { type: ActionTypes.GoToOption; focus: Focus.Specific; id: string }
-  | { type: ActionTypes.GoToOption; focus: Exclude<Focus, Focus.Specific> }
+  | ({ type: ActionTypes.GoToOption } & (
+      | {
+          focus: Focus.Specific
+          id: string
+          trigger: ActiveOptionTrigger
+        }
+      | {
+          focus: Exclude<Focus, Focus.Specific>
+          trigger?: undefined
+        }
+    ))
   | { type: ActionTypes.Search; value: string }
   | { type: ActionTypes.ClearSearch }
   | { type: ActionTypes.RegisterOption; id: string; dataRef: ListboxOptionDataRef }
@@ -124,7 +139,12 @@ let reducers: {
     })
 
     if (state.searchQuery === '' && state.activeOptionIndex === activeOptionIndex) return state
-    return { ...state, searchQuery: '', activeOptionIndex }
+    return {
+      ...state,
+      searchQuery: '',
+      activeOptionIndex,
+      activeOptionTrigger: action.trigger ?? ActiveOptionTrigger.auto,
+    }
   },
   [ActionTypes.Search]: (state, action) => {
     if (state.disabled) return state
@@ -249,6 +269,7 @@ let ListboxRoot = forwardRefWithAs(function Listbox<
     options: [],
     searchQuery: '',
     activeOptionIndex: null,
+    activeOptionTrigger: ActiveOptionTrigger.auto,
   } as StateDefinition)
   let [{ listboxState, propsRef, optionsRef, buttonRef }, dispatch] = reducerBag
 
@@ -667,13 +688,19 @@ let Option = forwardRefWithAs(function Option<
   useIsoMorphicEffect(() => {
     if (state.listboxState !== ListboxStates.Open) return
     if (!selected) return
-    dispatch({ type: ActionTypes.GoToOption, focus: Focus.Specific, id })
+    dispatch({
+      type: ActionTypes.GoToOption,
+      focus: Focus.Specific,
+      id,
+      trigger: ActiveOptionTrigger.auto,
+    })
     document.getElementById(id)?.focus?.()
   }, [state.listboxState])
 
   useIsoMorphicEffect(() => {
     if (state.listboxState !== ListboxStates.Open) return
     if (!active) return
+    if (state.activeOptionTrigger === ActiveOptionTrigger.mouse) return
     let d = disposables()
     d.requestAnimationFrame(() => {
       document.getElementById(id)?.scrollIntoView?.({ block: 'nearest' })
@@ -693,13 +720,23 @@ let Option = forwardRefWithAs(function Option<
 
   let handleFocus = useCallback(() => {
     if (disabled) return dispatch({ type: ActionTypes.GoToOption, focus: Focus.Nothing })
-    dispatch({ type: ActionTypes.GoToOption, focus: Focus.Specific, id })
+    dispatch({
+      type: ActionTypes.GoToOption,
+      focus: Focus.Specific,
+      id,
+      trigger: ActiveOptionTrigger.auto,
+    })
   }, [disabled, id, dispatch])
 
   let handleMove = useCallback(() => {
     if (disabled) return
     if (active) return
-    dispatch({ type: ActionTypes.GoToOption, focus: Focus.Specific, id })
+    dispatch({
+      type: ActionTypes.GoToOption,
+      focus: Focus.Specific,
+      id,
+      trigger: ActiveOptionTrigger.mouse,
+    })
   }, [disabled, active, id, dispatch])
 
   let handleLeave = useCallback(() => {

--- a/packages/@headlessui-react/src/components/popover/popover.test.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.test.tsx
@@ -1862,7 +1862,7 @@ describe('Keyboard interactions', () => {
         assertActiveElement(getPopoverButton())
 
         // Verify that we got redirected to the href
-        expect(window.location.hash).toEqual('#closed')
+        expect(document.location.hash).toEqual('#closed')
       })
     )
   })

--- a/packages/@headlessui-vue/src/components/popover/popover.test.ts
+++ b/packages/@headlessui-vue/src/components/popover/popover.test.ts
@@ -2025,7 +2025,7 @@ describe('Keyboard interactions', () => {
         assertActiveElement(getPopoverButton())
 
         // Verify that we got redirected to the href
-        expect(window.location.hash).toEqual('#closed')
+        expect(document.location.hash).toEqual('#closed')
       })
     )
   })

--- a/packages/playground-vue/src/components/listbox/listbox.vue
+++ b/packages/playground-vue/src/components/listbox/listbox.vue
@@ -39,34 +39,36 @@
                   v-for="person in people"
                   :key="person.id"
                   :value="person"
-                  :className="resolveListboxOptionClassName"
+                  as="template"
                   :disabled="person.disabled"
                   v-slot="{ active, selected }"
                 >
-                  <span
-                    :class="
-                      classNames('block truncate', selected ? 'font-semibold' : 'font-normal')
-                    "
-                  >
-                    {{ person.name }}
-                  </span>
-                  <span
-                    v-if="selected"
-                    :class="
-                      classNames(
-                        'absolute inset-y-0 right-0 flex items-center pr-4',
-                        active ? 'text-white' : 'text-indigo-600'
-                      )
-                    "
-                  >
-                    <svg class="h-5 w-5" viewbox="0 0 20 20" fill="currentColor">
-                      <path
-                        fillRule="evenodd"
-                        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </span>
+                  <li :class="resolveListboxOptionClassName({ active, selected })">
+                    <span
+                      :class="
+                        classNames('block truncate', selected ? 'font-semibold' : 'font-normal')
+                      "
+                    >
+                      {{ person.name }}
+                    </span>
+                    <span
+                      v-if="selected"
+                      :class="
+                        classNames(
+                          'absolute inset-y-0 right-0 flex items-center pr-4',
+                          active ? 'text-white' : 'text-indigo-600'
+                        )
+                      "
+                    >
+                      <svg class="h-5 w-5" viewbox="0 0 20 20" fill="currentColor">
+                        <path
+                          fillRule="evenodd"
+                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
+                    </span>
+                  </li>
                 </ListboxOption>
               </ListboxOptions>
             </div>
@@ -78,7 +80,7 @@
 </template>
 
 <script>
-import { defineComponent, h, ref, onMounted, watchEffect, watch } from 'vue'
+import { ref } from 'vue'
 import {
   Listbox,
   ListboxLabel,


### PR DESCRIPTION
This PR is a continuation of #1058.

This will make sure that the scroll into view only happens if the active item/option gets activated automatically (e.g.: active when opened) or when it gets activated via the keyboard.
If the item/option gets activated via the mouse then we don't want to scroll into view because this feels a bit janky and fights against your scrollwheel.

Closes: #1058
Fixes: #769
