### PR TITLE
Feat: Dialog Options

### DIFF
--- a/packages/@headlessui-react/package.json
+++ b/packages/@headlessui-react/package.json
@@ -45,9 +45,9 @@
     "@testing-library/react": "^11.2.3",
     "@types/react": "^16.14.2",
     "@types/react-dom": "^16.9.10",
+    "esbuild": "^0.11.18",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
-    "snapshot-diff": "^0.8.1",
-    "esbuild": "^0.11.18"
+    "snapshot-diff": "^0.8.1"
   }
 }

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -66,6 +66,7 @@ let DialogContext = createContext<
       {
         dialogState: DialogStates
         close(): void
+        shouldCloseOnClickOutside: boolean
         setTitleId(id: string | null): void
       },
       StateDefinition
@@ -286,8 +287,8 @@ let DialogRoot = forwardRefWithAs(function Dialog<
   let id = `headlessui-dialog-${useId()}`
 
   let contextBag = useMemo<ContextType<typeof DialogContext>>(
-    () => [{ dialogState, close, setTitleId }, state],
-    [dialogState, state, close, setTitleId]
+    () => [{ dialogState, close, setTitleId, shouldCloseOnClickOutside }, state],
+    [dialogState, state, close, setTitleId, shouldCloseOnClickOutside]
   )
 
   let slot = useMemo<DialogRenderPropArg>(
@@ -362,13 +363,14 @@ type OverlayPropsWeControl = 'id' | 'aria-hidden' | 'onClick'
 let Overlay = forwardRefWithAs(function Overlay<
   TTag extends ElementType = typeof DEFAULT_OVERLAY_TAG
 >(props: Props<TTag, OverlayRenderPropArg, OverlayPropsWeControl>, ref: Ref<HTMLDivElement>) {
-  let [{ dialogState, close }] = useDialogContext('Dialog.Overlay')
+  let [{ dialogState, shouldCloseOnClickOutside, close }] = useDialogContext('Dialog.Overlay')
   let overlayRef = useSyncRefs(ref)
 
   let id = `headlessui-dialog-overlay-${useId()}`
 
   let handleClick = useCallback(
     (event: ReactMouseEvent) => {
+      if (!shouldCloseOnClickOutside) return
       if (event.target !== event.currentTarget) return
       if (isDisabledReactIssue7711(event.currentTarget)) return event.preventDefault()
       event.preventDefault()

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -113,10 +113,20 @@ let DialogRoot = forwardRefWithAs(function Dialog<
       onClose(value: boolean): void
       initialFocus?: MutableRefObject<HTMLElement | null>
       __demoMode?: boolean
+      shouldCloseOnClickOutside?: boolean
+      shouldCloseOnEsc?: boolean
     },
   ref: Ref<HTMLDivElement>
 ) {
-  let { open, onClose, initialFocus, __demoMode = false, ...rest } = props
+  let {
+    open,
+    onClose,
+    initialFocus,
+    __demoMode = false,
+    shouldCloseOnClickOutside = true,
+    shouldCloseOnEsc = true,
+    ...rest
+  } = props
   let [nestedDialogCount, setNestedDialogCount] = useState(0)
 
   let usesOpenClosedState = useOpenClosed()
@@ -210,6 +220,7 @@ let DialogRoot = forwardRefWithAs(function Dialog<
   useWindowEvent('mousedown', (event) => {
     let target = event.target as HTMLElement
 
+    if (!shouldCloseOnClickOutside) return
     if (dialogState !== DialogStates.Open) return
     if (hasNestedDialogs) return
     if (internalDialogRef.current?.contains(target)) return
@@ -219,6 +230,7 @@ let DialogRoot = forwardRefWithAs(function Dialog<
 
   // Handle `Escape` to close
   useWindowEvent('keydown', (event) => {
+    if (!shouldCloseOnEsc) return
     if (event.key !== Keys.Escape) return
     if (dialogState !== DialogStates.Open) return
     if (hasNestedDialogs) return


### PR DESCRIPTION
# Summary
- Add options for dialogs closing

- `shouldCloseOnEsc`
  - this controls dialogs closes when the user clicks ESC.
- `shouldCloseOnClickOutside`
  - this controls dialogs closes when the user clicks outside of the dialog.

(Additionally, I don't have much experience with the Vue framework yet.)

