### PR TITLE
Fix double `beforeEnter` due to SSR

### DIFF
--- a/packages/@headlessui-react/src/components/transitions/transition.tsx
+++ b/packages/@headlessui-react/src/components/transitions/transition.tsx
@@ -279,6 +279,7 @@ let TransitionChild = forwardRefWithAs(function TransitionChild<
   useIsoMorphicEffect(() => {
     let node = container.current
     if (!node) return
+    if (!ready) return
     if (skip) return
     if (show === prevShow.current) return
 
@@ -328,6 +329,7 @@ let TransitionChild = forwardRefWithAs(function TransitionChild<
     container,
     skip,
     show,
+    ready,
     enterClasses,
     enterFromClasses,
     enterToClasses,


### PR DESCRIPTION
Due to SSR and the hydration step, the transition code was already
called even if we were not ready yet. This caused an issue where the
`beforeEnter` callback got fired twice intead of once.

Fixes: #311
