### PR TITLE
Add `<form>` compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Only activate the `Tab` on mouseup ([#1192](https://github.com/tailwindlabs/headlessui/pull/1192))
 - Ignore "outside click" on removed elements ([#1193](https://github.com/tailwindlabs/headlessui/pull/1193))
 
+### Added
+
+- Add `<form>` compatibility ([#1214](https://github.com/tailwindlabs/headlessui/pull/1214))
+
 ## [Unreleased - @headlessui/vue]
 
 ### Fixed
@@ -40,6 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `Dialog` cycling ([#553](https://github.com/tailwindlabs/headlessui/pull/553))
 - Only activate the `Tab` on mouseup ([#1192](https://github.com/tailwindlabs/headlessui/pull/1192))
 - Ignore "outside click" on removed elements ([#1193](https://github.com/tailwindlabs/headlessui/pull/1193))
+
+### Added
+
+- Add `<form>` compatibility ([#1214](https://github.com/tailwindlabs/headlessui/pull/1214))
 
 ## [@headlessui/react@v1.5.0] - 2022-02-17
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -4392,3 +4392,169 @@ describe('Mouse interactions', () => {
     })
   )
 })
+
+describe('Form compatibility', () => {
+  it('should be possible to submit a form with a value', async () => {
+    let submits = jest.fn()
+
+    function Example() {
+      let [value, setValue] = useState(null)
+      return (
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            submits([...new FormData(event.currentTarget).entries()])
+          }}
+        >
+          <Combobox value={value} onChange={setValue} name="delivery">
+            <Combobox.Input onChange={console.log} />
+            <Combobox.Button>Trigger</Combobox.Button>
+            <Combobox.Label>Pizza Delivery</Combobox.Label>
+            <Combobox.Options>
+              <Combobox.Option value="pickup">Pickup</Combobox.Option>
+              <Combobox.Option value="home-delivery">Home delivery</Combobox.Option>
+              <Combobox.Option value="dine-in">Dine in</Combobox.Option>
+            </Combobox.Options>
+          </Combobox>
+          <button>Submit</button>
+        </form>
+      )
+    }
+
+    render(<Example />)
+
+    // Open combobox
+    await click(getComboboxButton())
+
+    // Submit the form
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([]) // no data
+
+    // Open combobox again
+    await click(getComboboxButton())
+
+    // Choose home delivery
+    await click(getByText('Home delivery'))
+
+    // Submit the form again
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([['delivery', 'home-delivery']])
+
+    // Open combobox again
+    await click(getComboboxButton())
+
+    // Choose pickup
+    await click(getByText('Pickup'))
+
+    // Submit the form again
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([['delivery', 'pickup']])
+  })
+
+  it('should be possible to submit a form with a complex value object', async () => {
+    let submits = jest.fn()
+    let options = [
+      {
+        id: 1,
+        value: 'pickup',
+        label: 'Pickup',
+        extra: { info: 'Some extra info' },
+      },
+      {
+        id: 2,
+        value: 'home-delivery',
+        label: 'Home delivery',
+        extra: { info: 'Some extra info' },
+      },
+      {
+        id: 3,
+        value: 'dine-in',
+        label: 'Dine in',
+        extra: { info: 'Some extra info' },
+      },
+    ]
+
+    function Example() {
+      let [value, setValue] = useState(options[0])
+
+      return (
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            submits([...new FormData(event.currentTarget).entries()])
+          }}
+        >
+          <Combobox value={value} onChange={setValue} name="delivery">
+            <Combobox.Input onChange={console.log} />
+            <Combobox.Button>Trigger</Combobox.Button>
+            <Combobox.Label>Pizza Delivery</Combobox.Label>
+            <Combobox.Options>
+              {options.map((option) => (
+                <Combobox.Option key={option.id} value={option}>
+                  {option.label}
+                </Combobox.Option>
+              ))}
+            </Combobox.Options>
+          </Combobox>
+          <button>Submit</button>
+        </form>
+      )
+    }
+
+    render(<Example />)
+
+    // Open combobox
+    await click(getComboboxButton())
+
+    // Submit the form
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([
+      ['delivery[id]', '1'],
+      ['delivery[value]', 'pickup'],
+      ['delivery[label]', 'Pickup'],
+      ['delivery[extra][info]', 'Some extra info'],
+    ])
+
+    // Open combobox
+    await click(getComboboxButton())
+
+    // Choose home delivery
+    await click(getByText('Home delivery'))
+
+    // Submit the form again
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([
+      ['delivery[id]', '2'],
+      ['delivery[value]', 'home-delivery'],
+      ['delivery[label]', 'Home delivery'],
+      ['delivery[extra][info]', 'Some extra info'],
+    ])
+
+    // Open combobox
+    await click(getComboboxButton())
+
+    // Choose pickup
+    await click(getByText('Pickup'))
+
+    // Submit the form again
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([
+      ['delivery[id]', '1'],
+      ['delivery[value]', 'pickup'],
+      ['delivery[label]', 'Pickup'],
+      ['delivery[extra][info]', 'Some extra info'],
+    ])
+  })
+})

--- a/packages/@headlessui-react/src/components/listbox/listbox.test.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.test.tsx
@@ -3953,3 +3953,167 @@ describe('Mouse interactions', () => {
     })
   )
 })
+
+describe('Form compatibility', () => {
+  it('should be possible to submit a form with a value', async () => {
+    let submits = jest.fn()
+
+    function Example() {
+      let [value, setValue] = useState(null)
+      return (
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            submits([...new FormData(event.currentTarget).entries()])
+          }}
+        >
+          <Listbox value={value} onChange={setValue} name="delivery">
+            <Listbox.Button>Trigger</Listbox.Button>
+            <Listbox.Label>Pizza Delivery</Listbox.Label>
+            <Listbox.Options>
+              <Listbox.Option value="pickup">Pickup</Listbox.Option>
+              <Listbox.Option value="home-delivery">Home delivery</Listbox.Option>
+              <Listbox.Option value="dine-in">Dine in</Listbox.Option>
+            </Listbox.Options>
+          </Listbox>
+          <button>Submit</button>
+        </form>
+      )
+    }
+
+    render(<Example />)
+
+    // Open listbox
+    await click(getListboxButton())
+
+    // Submit the form
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([]) // no data
+
+    // Open listbox again
+    await click(getListboxButton())
+
+    // Choose home delivery
+    await click(getByText('Home delivery'))
+
+    // Submit the form again
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([['delivery', 'home-delivery']])
+
+    // Open listbox again
+    await click(getListboxButton())
+
+    // Choose pickup
+    await click(getByText('Pickup'))
+
+    // Submit the form again
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([['delivery', 'pickup']])
+  })
+
+  it('should be possible to submit a form with a complex value object', async () => {
+    let submits = jest.fn()
+    let options = [
+      {
+        id: 1,
+        value: 'pickup',
+        label: 'Pickup',
+        extra: { info: 'Some extra info' },
+      },
+      {
+        id: 2,
+        value: 'home-delivery',
+        label: 'Home delivery',
+        extra: { info: 'Some extra info' },
+      },
+      {
+        id: 3,
+        value: 'dine-in',
+        label: 'Dine in',
+        extra: { info: 'Some extra info' },
+      },
+    ]
+
+    function Example() {
+      let [value, setValue] = useState(options[0])
+
+      return (
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            submits([...new FormData(event.currentTarget).entries()])
+          }}
+        >
+          <Listbox value={value} onChange={setValue} name="delivery">
+            <Listbox.Button>Trigger</Listbox.Button>
+            <Listbox.Label>Pizza Delivery</Listbox.Label>
+            <Listbox.Options>
+              {options.map((option) => (
+                <Listbox.Option key={option.id} value={option}>
+                  {option.label}
+                </Listbox.Option>
+              ))}
+            </Listbox.Options>
+          </Listbox>
+          <button>Submit</button>
+        </form>
+      )
+    }
+
+    render(<Example />)
+
+    // Open listbox
+    await click(getListboxButton())
+
+    // Submit the form
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([
+      ['delivery[id]', '1'],
+      ['delivery[value]', 'pickup'],
+      ['delivery[label]', 'Pickup'],
+      ['delivery[extra][info]', 'Some extra info'],
+    ])
+
+    // Open listbox
+    await click(getListboxButton())
+
+    // Choose home delivery
+    await click(getByText('Home delivery'))
+
+    // Submit the form again
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([
+      ['delivery[id]', '2'],
+      ['delivery[value]', 'home-delivery'],
+      ['delivery[label]', 'Home delivery'],
+      ['delivery[extra][info]', 'Some extra info'],
+    ])
+
+    // Open listbox
+    await click(getListboxButton())
+
+    // Choose pickup
+    await click(getByText('Pickup'))
+
+    // Submit the form again
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([
+      ['delivery[id]', '1'],
+      ['delivery[value]', 'pickup'],
+      ['delivery[label]', 'Pickup'],
+      ['delivery[extra][info]', 'Some extra info'],
+    ])
+  })
+})

--- a/packages/@headlessui-react/src/components/switch/switch.test.tsx
+++ b/packages/@headlessui-react/src/components/switch/switch.test.tsx
@@ -8,6 +8,7 @@ import {
   getSwitch,
   assertActiveElement,
   getSwitchLabel,
+  getByText,
 } from '../../test-utils/accessibility-assertions'
 import { press, click, Keys } from '../../test-utils/interactions'
 
@@ -393,5 +394,85 @@ describe('Mouse interactions', () => {
 
     // Ensure state is still off
     assertSwitch({ state: SwitchState.Off })
+  })
+})
+
+describe('Form compatibility', () => {
+  it('should be possible to submit a form with an boolean value', async () => {
+    let submits = jest.fn()
+
+    function Example() {
+      let [state, setState] = useState(false)
+      return (
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            submits([...new FormData(event.currentTarget).entries()])
+          }}
+        >
+          <Switch.Group>
+            <Switch checked={state} onChange={setState} name="notifications" />
+            <Switch.Label>Enable notifications</Switch.Label>
+          </Switch.Group>
+          <button>Submit</button>
+        </form>
+      )
+    }
+
+    render(<Example />)
+
+    // Submit the form
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([]) // no data
+
+    // Toggle
+    await click(getSwitchLabel())
+
+    // Submit the form again
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([['notifications', 'on']])
+  })
+
+  it('should be possible to submit a form with a provided string value', async () => {
+    let submits = jest.fn()
+
+    function Example() {
+      let [state, setState] = useState(false)
+      return (
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            submits([...new FormData(event.currentTarget).entries()])
+          }}
+        >
+          <Switch.Group>
+            <Switch checked={state} onChange={setState} name="fruit" value="apple" />
+            <Switch.Label>Apple</Switch.Label>
+          </Switch.Group>
+          <button>Submit</button>
+        </form>
+      )
+    }
+
+    render(<Example />)
+
+    // Submit the form
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([]) // no data
+
+    // Toggle
+    await click(getSwitchLabel())
+
+    // Submit the form again
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([['fruit', 'apple']])
   })
 })

--- a/packages/@headlessui-react/src/internal/visually-hidden.tsx
+++ b/packages/@headlessui-react/src/internal/visually-hidden.tsx
@@ -1,0 +1,30 @@
+import { ElementType, Ref } from 'react'
+import { Props } from '../types'
+import { forwardRefWithAs, render } from '../utils/render'
+
+let DEFAULT_VISUALLY_HIDDEN_TAG = 'div' as const
+
+export let VisuallyHidden = forwardRefWithAs(function VisuallyHidden<
+  TTag extends ElementType = typeof DEFAULT_VISUALLY_HIDDEN_TAG
+>(props: Props<TTag>, ref: Ref<HTMLElement>) {
+  return render({
+    props: {
+      ...props,
+      ref,
+      style: {
+        position: 'absolute',
+        width: 1,
+        height: 1,
+        padding: 0,
+        margin: -1,
+        overflow: 'hidden',
+        clip: 'rect(0, 0, 0, 0)',
+        whiteSpace: 'nowrap',
+        borderWidth: '0',
+      },
+    },
+    slot: {},
+    defaultTag: DEFAULT_VISUALLY_HIDDEN_TAG,
+    name: 'VisuallyHidden',
+  })
+})

--- a/packages/@headlessui-react/src/utils/form.test.ts
+++ b/packages/@headlessui-react/src/utils/form.test.ts
@@ -1,0 +1,25 @@
+import { objectToFormEntries } from './form'
+
+it.each([
+  [{ a: 'b' }, [['a', 'b']]],
+  [
+    [1, 2, 3],
+    [
+      ['0', '1'],
+      ['1', '2'],
+      ['2', '3'],
+    ],
+  ],
+  [
+    { id: 1, admin: true, name: { first: 'Jane', last: 'Doe', nickname: { preferred: 'JDoe' } } },
+    [
+      ['id', '1'],
+      ['admin', '1'],
+      ['name[first]', 'Jane'],
+      ['name[last]', 'Doe'],
+      ['name[nickname][preferred]', 'JDoe'],
+    ],
+  ],
+])('should encode an input of %j to an form data output', (input, output) => {
+  expect(objectToFormEntries(input)).toEqual(output)
+})

--- a/packages/@headlessui-react/src/utils/form.ts
+++ b/packages/@headlessui-react/src/utils/form.ts
@@ -1,0 +1,37 @@
+type Entries = [string, string][]
+
+export function objectToFormEntries(
+  source: Record<string, any> = {},
+  parentKey: string | null = null,
+  entries: Entries = []
+): Entries {
+  for (let [key, value] of Object.entries(source)) {
+    append(entries, composeKey(parentKey, key), value)
+  }
+
+  return entries
+}
+
+function composeKey(parent: string | null, key: string): string {
+  return parent ? parent + '[' + key + ']' : key
+}
+
+function append(entries: Entries, key: string, value: any): void {
+  if (Array.isArray(value)) {
+    for (let [subkey, subvalue] of value.entries()) {
+      append(entries, composeKey(key, subkey.toString()), subvalue)
+    }
+  } else if (value instanceof Date) {
+    entries.push([key, value.toISOString()])
+  } else if (typeof value === 'boolean') {
+    entries.push([key, value ? '1' : '0'])
+  } else if (typeof value === 'string') {
+    entries.push([key, value])
+  } else if (typeof value === 'number') {
+    entries.push([key, `${value}`])
+  } else if (value === null || value === undefined) {
+    entries.push([key, ''])
+  } else {
+    objectToFormEntries(value, key, entries)
+  }
+}

--- a/packages/@headlessui-react/src/utils/render.ts
+++ b/packages/@headlessui-react/src/utils/render.ts
@@ -218,7 +218,7 @@ export function forwardRefWithAs<T extends { name: string; displayName?: string 
   })
 }
 
-function compact<T extends Record<any, any>>(object: T) {
+export function compact<T extends Record<any, any>>(object: T) {
   let clone = Object.assign({}, object)
   for (let key in clone) {
     if (clone[key] === undefined) delete clone[key]

--- a/packages/@headlessui-react/tsconfig.json
+++ b/packages/@headlessui-react/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["src", "types"],
   "compilerOptions": {
     "module": "esnext",
-    "lib": ["dom", "esnext"],
+    "lib": ["dom", "esnext", "dom.iterable"],
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,

--- a/packages/@headlessui-vue/src/components/focus-trap/focus-trap.ts
+++ b/packages/@headlessui-vue/src/components/focus-trap/focus-trap.ts
@@ -1,8 +1,6 @@
 import {
   computed,
   defineComponent,
-  onMounted,
-  onUnmounted,
   ref,
 
   // Types

--- a/packages/@headlessui-vue/src/components/radio-group/radio-group.test.ts
+++ b/packages/@headlessui-vue/src/components/radio-group/radio-group.test.ts
@@ -1135,3 +1135,148 @@ describe('Mouse interactions', () => {
     expect(changeFn).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('Form compatibility', () => {
+  it('should be possible to submit a form with a value', async () => {
+    let submits = jest.fn()
+
+    renderTemplate({
+      template: html`
+        <form @submit="handleSubmit">
+          <RadioGroup v-model="deliveryMethod" name="delivery">
+            <RadioGroupLabel>Pizza Delivery</RadioGroupLabel>
+            <RadioGroupOption value="pickup">Pickup</RadioGroupOption>
+            <RadioGroupOption value="home-delivery">Home delivery</RadioGroupOption>
+            <RadioGroupOption value="dine-in">Dine in</RadioGroupOption>
+          </RadioGroup>
+          <button>Submit</button>
+        </form>
+      `,
+      setup() {
+        let deliveryMethod = ref(null)
+        return {
+          deliveryMethod,
+          handleSubmit(event: SubmitEvent) {
+            event.preventDefault()
+
+            submits([...new FormData(event.currentTarget as HTMLFormElement).entries()])
+          },
+        }
+      },
+    })
+
+    // Submit the form
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([]) // no data
+
+    // Choose home delivery
+    await click(getByText('Home delivery'))
+
+    // Submit the form again
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([['delivery', 'home-delivery']])
+
+    // Choose pickup
+    await click(getByText('Pickup'))
+
+    // Submit the form again
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([['delivery', 'pickup']])
+  })
+
+  it('should be possible to submit a form with a complex value object', async () => {
+    let submits = jest.fn()
+
+    renderTemplate({
+      template: html`
+        <form @submit="handleSubmit">
+          <RadioGroup v-model="deliveryMethod" name="delivery">
+            <RadioGroupLabel>Pizza Delivery</RadioGroupLabel>
+            <RadioGroupOption v-for="option in options" :key="option.id" :value="option"
+              >{{ option.label }}</RadioGroupOption
+            >
+          </RadioGroup>
+          <button>Submit</button>
+        </form>
+      `,
+      setup() {
+        let options = ref([
+          {
+            id: 1,
+            value: 'pickup',
+            label: 'Pickup',
+            extra: { info: 'Some extra info' },
+          },
+          {
+            id: 2,
+            value: 'home-delivery',
+            label: 'Home delivery',
+            extra: { info: 'Some extra info' },
+          },
+          {
+            id: 3,
+            value: 'dine-in',
+            label: 'Dine in',
+            extra: { info: 'Some extra info' },
+          },
+        ])
+        let deliveryMethod = ref(options.value[0])
+
+        return {
+          deliveryMethod,
+          options,
+          handleSubmit(event: SubmitEvent) {
+            event.preventDefault()
+
+            submits([...new FormData(event.currentTarget as HTMLFormElement).entries()])
+          },
+        }
+      },
+    })
+
+    // Submit the form
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([
+      ['delivery[id]', '1'],
+      ['delivery[value]', 'pickup'],
+      ['delivery[label]', 'Pickup'],
+      ['delivery[extra][info]', 'Some extra info'],
+    ])
+
+    // Choose home delivery
+    await click(getByText('Home delivery'))
+
+    // Submit the form again
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([
+      ['delivery[id]', '2'],
+      ['delivery[value]', 'home-delivery'],
+      ['delivery[label]', 'Home delivery'],
+      ['delivery[extra][info]', 'Some extra info'],
+    ])
+
+    // Choose pickup
+    await click(getByText('Pickup'))
+
+    // Submit the form again
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([
+      ['delivery[id]', '1'],
+      ['delivery[value]', 'pickup'],
+      ['delivery[label]', 'Pickup'],
+      ['delivery[extra][info]', 'Some extra info'],
+    ])
+  })
+})

--- a/packages/@headlessui-vue/src/components/switch/switch.test.tsx
+++ b/packages/@headlessui-vue/src/components/switch/switch.test.tsx
@@ -515,3 +515,87 @@ describe('Mouse interactions', () => {
     assertSwitch({ state: SwitchState.Off })
   })
 })
+
+describe('Form compatibility', () => {
+  it('should be possible to submit a form with an boolean value', async () => {
+    let submits = jest.fn()
+
+    renderTemplate({
+      template: html`
+        <form @submit="handleSubmit">
+          <SwitchGroup>
+            <Switch v-model="checked" name="notifications" />
+            <SwitchLabel>Enable notifications</SwitchLabel>
+          </SwitchGroup>
+          <button>Submit</button>
+        </form>
+      `,
+      setup() {
+        let checked = ref(false)
+        return {
+          checked,
+          handleSubmit(event: SubmitEvent) {
+            event.preventDefault()
+            submits([...new FormData(event.currentTarget as HTMLFormElement).entries()])
+          },
+        }
+      },
+    })
+
+    // Submit the form
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([]) // no data
+
+    // Toggle
+    await click(getSwitchLabel())
+
+    // Submit the form again
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([['notifications', 'on']])
+  })
+
+  it('should be possible to submit a form with a provided string value', async () => {
+    let submits = jest.fn()
+
+    renderTemplate({
+      template: html`
+        <form @submit="handleSubmit">
+          <SwitchGroup>
+            <Switch v-model="checked" name="fruit" value="apple" />
+            <SwitchLabel>Apple</SwitchLabel>
+          </SwitchGroup>
+          <button>Submit</button>
+        </form>
+      `,
+      setup() {
+        let checked = ref(false)
+        return {
+          checked,
+          handleSubmit(event: SubmitEvent) {
+            event.preventDefault()
+            submits([...new FormData(event.currentTarget as HTMLFormElement).entries()])
+          },
+        }
+      },
+    })
+
+    // Submit the form
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([]) // no data
+
+    // Toggle
+    await click(getSwitchLabel())
+
+    // Submit the form again
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([['fruit', 'apple']])
+  })
+})

--- a/packages/@headlessui-vue/src/internal/visually-hidden.ts
+++ b/packages/@headlessui-vue/src/internal/visually-hidden.ts
@@ -1,0 +1,34 @@
+import { defineComponent } from 'vue'
+import { render } from '../utils/render'
+
+export let VisuallyHidden = defineComponent({
+  name: 'VisuallyHidden',
+  props: {
+    as: { type: [Object, String], default: 'div' },
+  },
+  setup(props, { slots, attrs }) {
+    return () => {
+      let propsWeControl = {
+        style: {
+          position: 'absolute',
+          width: 1,
+          height: 1,
+          padding: 0,
+          margin: -1,
+          overflow: 'hidden',
+          clip: 'rect(0, 0, 0, 0)',
+          whiteSpace: 'nowrap',
+          borderWidth: '0',
+        },
+      }
+
+      return render({
+        props: { ...props, ...propsWeControl },
+        slot: {},
+        attrs,
+        slots,
+        name: 'VisuallyHidden',
+      })
+    }
+  },
+})

--- a/packages/@headlessui-vue/src/utils/form.test.ts
+++ b/packages/@headlessui-vue/src/utils/form.test.ts
@@ -1,0 +1,25 @@
+import { objectToFormEntries } from './form'
+
+it.each([
+  [{ a: 'b' }, [['a', 'b']]],
+  [
+    [1, 2, 3],
+    [
+      ['0', '1'],
+      ['1', '2'],
+      ['2', '3'],
+    ],
+  ],
+  [
+    { id: 1, admin: true, name: { first: 'Jane', last: 'Doe', nickname: { preferred: 'JDoe' } } },
+    [
+      ['id', '1'],
+      ['admin', '1'],
+      ['name[first]', 'Jane'],
+      ['name[last]', 'Doe'],
+      ['name[nickname][preferred]', 'JDoe'],
+    ],
+  ],
+])('should encode an input of %j to an form data output', (input, output) => {
+  expect(objectToFormEntries(input)).toEqual(output)
+})

--- a/packages/@headlessui-vue/src/utils/form.ts
+++ b/packages/@headlessui-vue/src/utils/form.ts
@@ -1,0 +1,37 @@
+type Entries = [string, string][]
+
+export function objectToFormEntries(
+  source: Record<string, any> = {},
+  parentKey: string | null = null,
+  entries: Entries = []
+): Entries {
+  for (let [key, value] of Object.entries(source)) {
+    append(entries, composeKey(parentKey, key), value)
+  }
+
+  return entries
+}
+
+function composeKey(parent: string | null, key: string): string {
+  return parent ? parent + '[' + key + ']' : key
+}
+
+function append(entries: Entries, key: string, value: any): void {
+  if (Array.isArray(value)) {
+    for (let [subkey, subvalue] of value.entries()) {
+      append(entries, composeKey(key, subkey.toString()), subvalue)
+    }
+  } else if (value instanceof Date) {
+    entries.push([key, value.toISOString()])
+  } else if (typeof value === 'boolean') {
+    entries.push([key, value ? '1' : '0'])
+  } else if (typeof value === 'string') {
+    entries.push([key, value])
+  } else if (typeof value === 'number') {
+    entries.push([key, `${value}`])
+  } else if (value === null || value === undefined) {
+    entries.push([key, ''])
+  } else {
+    objectToFormEntries(value, key, entries)
+  }
+}

--- a/packages/@headlessui-vue/src/utils/render.ts
+++ b/packages/@headlessui-vue/src/utils/render.ts
@@ -125,6 +125,14 @@ function _render({
   return h(as, passThroughProps, children)
 }
 
+export function compact<T extends Record<any, any>>(object: T) {
+  let clone = Object.assign({}, object)
+  for (let key in clone) {
+    if (clone[key] === undefined) delete clone[key]
+  }
+  return clone
+}
+
 export function omit<T extends Record<any, any>, Keys extends keyof T>(
   object: T,
   keysToOmit: readonly Keys[] = []

--- a/packages/@headlessui-vue/tsconfig.json
+++ b/packages/@headlessui-vue/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["src", "types"],
   "compilerOptions": {
     "module": "esnext",
-    "lib": ["dom", "esnext"],
+    "lib": ["dom", "esnext", "dom.iterable"],
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,

--- a/packages/playground-react/pages/combinations/form.tsx
+++ b/packages/playground-react/pages/combinations/form.tsx
@@ -1,0 +1,353 @@
+import { useState } from 'react'
+import { Switch, RadioGroup, Listbox, Combobox } from '@headlessui/react'
+import { classNames } from '../../utils/class-names'
+
+function Section({ title, children }) {
+  return (
+    <fieldset className="rounded-lg border bg-gray-200/20 p-3">
+      <legend className="rounded-md border bg-gray-100 px-2 text-sm uppercase">{title}</legend>
+      <div className="flex flex-col gap-3">{children}</div>
+    </fieldset>
+  )
+}
+
+let sizes = ['xs', 'sm', 'md', 'lg', 'xl']
+let people = [
+  { id: 1, name: { first: 'Alice' } },
+  { id: 2, name: { first: 'Bob' } },
+  { id: 3, name: { first: 'Charlie' } },
+]
+let locations = ['New York', 'London', 'Paris', 'Berlin']
+
+export default function App() {
+  let [result, setResult] = useState(() => (typeof window === 'undefined' ? [] : new FormData()))
+  let [notifications, setNotifications] = useState(false)
+  let [apple, setApple] = useState(false)
+  let [banana, setBanana] = useState(false)
+  let [size, setSize] = useState(sizes[(Math.random() * sizes.length) | 0])
+  let [person, setPerson] = useState(people[(Math.random() * people.length) | 0])
+  let [activeLocation, setActiveLocation] = useState(
+    locations[(Math.random() * locations.length) | 0]
+  )
+  let [query, setQuery] = useState('')
+
+  return (
+    <div className="py-8">
+      <form
+        className="mx-auto flex h-full max-w-4xl flex-col items-start justify-center gap-8 rounded-lg border bg-white p-6"
+        onSubmit={(event) => {
+          event.preventDefault()
+          setResult(new FormData(event.currentTarget))
+        }}
+      >
+        <div className="grid w-full grid-cols-[repeat(auto-fill,minmax(350px,1fr))] items-start gap-3">
+          <Section title="Switch">
+            <Section title="Single value">
+              <Switch.Group as="div" className="flex items-center justify-between space-x-4">
+                <Switch.Label>Enable notifications</Switch.Label>
+
+                <Switch
+                  as="button"
+                  checked={notifications}
+                  onChange={setNotifications}
+                  name="notifications"
+                  className={({ checked }) =>
+                    classNames(
+                      'focus:shadow-outline relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none',
+                      checked ? 'bg-indigo-600' : 'bg-gray-200'
+                    )
+                  }
+                >
+                  {({ checked }) => (
+                    <>
+                      <span
+                        className={classNames(
+                          'inline-block h-5 w-5 transform rounded-full bg-white transition duration-200 ease-in-out',
+                          checked ? 'translate-x-5' : 'translate-x-0'
+                        )}
+                      />
+                    </>
+                  )}
+                </Switch>
+              </Switch.Group>
+            </Section>
+
+            <Section title="Multiple values">
+              <Switch.Group as="div" className="flex items-center justify-between space-x-4">
+                <Switch.Label>Apple</Switch.Label>
+
+                <Switch
+                  as="button"
+                  checked={apple}
+                  onChange={setApple}
+                  name="fruit[]"
+                  value="apple"
+                  className={({ checked }) =>
+                    classNames(
+                      'focus:shadow-outline relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none',
+                      checked ? 'bg-indigo-600' : 'bg-gray-200'
+                    )
+                  }
+                >
+                  {({ checked }) => (
+                    <>
+                      <span
+                        className={classNames(
+                          'inline-block h-5 w-5 transform rounded-full bg-white transition duration-200 ease-in-out',
+                          checked ? 'translate-x-5' : 'translate-x-0'
+                        )}
+                      />
+                    </>
+                  )}
+                </Switch>
+              </Switch.Group>
+
+              <Switch.Group as="div" className="flex items-center justify-between space-x-4">
+                <Switch.Label>Banana</Switch.Label>
+                <Switch
+                  as="button"
+                  checked={banana}
+                  onChange={setBanana}
+                  name="fruit[]"
+                  value="banana"
+                  className={({ checked }) =>
+                    classNames(
+                      'focus:shadow-outline relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none',
+                      checked ? 'bg-indigo-600' : 'bg-gray-200'
+                    )
+                  }
+                >
+                  {({ checked }) => (
+                    <>
+                      <span
+                        className={classNames(
+                          'inline-block h-5 w-5 transform rounded-full bg-white transition duration-200 ease-in-out',
+                          checked ? 'translate-x-5' : 'translate-x-0'
+                        )}
+                      />
+                    </>
+                  )}
+                </Switch>
+              </Switch.Group>
+            </Section>
+          </Section>
+          <Section title="Radio Group">
+            <RadioGroup value={size} onChange={setSize} name="size">
+              <div className="flex -space-x-px rounded-md bg-white">
+                {sizes.map((size) => {
+                  return (
+                    <RadioGroup.Option
+                      key={size}
+                      value={size}
+                      className={({ active }) =>
+                        classNames(
+                          'relative flex w-20 border px-2 py-4 first:rounded-l-md last:rounded-r-md focus:outline-none',
+                          active ? 'z-10 border-indigo-200 bg-indigo-50' : 'border-gray-200'
+                        )
+                      }
+                    >
+                      {({ active, checked }) => (
+                        <div className="flex w-full items-center justify-between">
+                          <div className="ml-3 flex cursor-pointer flex-col">
+                            <span
+                              className={classNames(
+                                'block text-sm font-medium leading-5',
+                                active ? 'text-indigo-900' : 'text-gray-900'
+                              )}
+                            >
+                              {size}
+                            </span>
+                          </div>
+                          <div>
+                            {checked && (
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                className="h-5 w-5 text-indigo-500"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                                />
+                              </svg>
+                            )}
+                          </div>
+                        </div>
+                      )}
+                    </RadioGroup.Option>
+                  )
+                })}
+              </div>
+            </RadioGroup>
+          </Section>
+          <Section title="Listbox">
+            <div className="w-full space-y-1">
+              <Listbox value={person} onChange={setPerson} name="person">
+                <div className="relative">
+                  <span className="inline-block w-full rounded-md shadow-sm">
+                    <Listbox.Button className="focus:shadow-outline-blue relative w-full cursor-default rounded-md border border-gray-300 bg-white py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out focus:border-blue-300 focus:outline-none sm:text-sm sm:leading-5">
+                      <span className="block truncate">{person.name.first}</span>
+                      <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+                        <svg
+                          className="h-5 w-5 text-gray-400"
+                          viewBox="0 0 20 20"
+                          fill="none"
+                          stroke="currentColor"
+                        >
+                          <path
+                            d="M7 7l3-3 3 3m0 6l-3 3-3-3"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                        </svg>
+                      </span>
+                    </Listbox.Button>
+                  </span>
+
+                  <div className="absolute mt-1 w-full rounded-md bg-white shadow-lg">
+                    <Listbox.Options className="shadow-xs max-h-60 overflow-auto rounded-md py-1 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5">
+                      {people.map((person) => (
+                        <Listbox.Option
+                          key={person.id}
+                          value={person}
+                          className={({ active }) => {
+                            return classNames(
+                              'relative cursor-default select-none py-2 pl-3 pr-9 focus:outline-none',
+                              active ? 'bg-indigo-600 text-white' : 'text-gray-900'
+                            )
+                          }}
+                        >
+                          {({ active, selected }) => (
+                            <>
+                              <span
+                                className={classNames(
+                                  'block truncate',
+                                  selected ? 'font-semibold' : 'font-normal'
+                                )}
+                              >
+                                {person.name.first}
+                              </span>
+                              {selected && (
+                                <span
+                                  className={classNames(
+                                    'absolute inset-y-0 right-0 flex items-center pr-4',
+                                    active ? 'text-white' : 'text-indigo-600'
+                                  )}
+                                >
+                                  <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                                    <path
+                                      fillRule="evenodd"
+                                      d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                                      clipRule="evenodd"
+                                    />
+                                  </svg>
+                                </span>
+                              )}
+                            </>
+                          )}
+                        </Listbox.Option>
+                      ))}
+                    </Listbox.Options>
+                  </div>
+                </div>
+              </Listbox>
+            </div>
+          </Section>
+          <Section title="Combobox">
+            <div className="w-full space-y-1">
+              <Combobox
+                as="div"
+                name="location"
+                value={activeLocation}
+                onChange={(location) => setActiveLocation(location)}
+                className="w-full rounded border border-black/5 bg-white bg-clip-padding shadow-sm"
+              >
+                {({ open }) => {
+                  return (
+                    <div className="relative">
+                      <div className="flex w-full flex-col">
+                        <Combobox.Input
+                          onChange={(e) => setQuery(e.target.value)}
+                          className="w-full rounded-md border-none px-3 py-1 outline-none"
+                          placeholder="Search users..."
+                        />
+                        <div
+                          className={classNames(
+                            'flex border-t',
+                            activeLocation && !open ? 'border-transparent' : 'border-gray-200'
+                          )}
+                        >
+                          <div className="absolute mt-1 w-full rounded-md bg-white shadow-lg">
+                            <Combobox.Options className="shadow-xs max-h-60 overflow-auto rounded-md py-1 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5">
+                              {locations.map((location) => (
+                                <Combobox.Option
+                                  key={location}
+                                  value={location}
+                                  className={({ active }) => {
+                                    return classNames(
+                                      'relative  flex cursor-default select-none space-x-4 py-2 pl-3 pr-9 focus:outline-none',
+                                      active ? 'bg-indigo-600 text-white' : 'text-gray-900'
+                                    )
+                                  }}
+                                >
+                                  {({ active, selected }) => (
+                                    <>
+                                      <span
+                                        className={classNames(
+                                          'block truncate',
+                                          selected ? 'font-semibold' : 'font-normal'
+                                        )}
+                                      >
+                                        {location}
+                                      </span>
+                                      {active && (
+                                        <span
+                                          className={classNames(
+                                            'absolute inset-y-0 right-0 flex items-center pr-4',
+                                            active ? 'text-white' : 'text-indigo-600'
+                                          )}
+                                        >
+                                          <svg className="h-5 w-5" viewBox="0 0 25 24" fill="none">
+                                            <path
+                                              d="M11.25 8.75L14.75 12L11.25 15.25"
+                                              stroke="currentColor"
+                                              strokeWidth="1.5"
+                                              strokeLinecap="round"
+                                              strokeLinejoin="round"
+                                            />
+                                          </svg>
+                                        </span>
+                                      )}
+                                    </>
+                                  )}
+                                </Combobox.Option>
+                              ))}
+                            </Combobox.Options>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  )
+                }}
+              </Combobox>
+            </div>
+          </Section>
+        </div>
+
+        <button className="focus:shadow-outline-blue rounded-md border border-gray-300 bg-white px-4 py-2 text-base font-medium leading-6 text-gray-700 shadow-sm transition duration-150 ease-in-out hover:text-gray-500 focus:border-blue-300 focus:outline-none sm:text-sm sm:leading-5">
+          Submit
+        </button>
+
+        <div className="w-full border-t py-4">
+          <span>Form data (entries):</span>
+          <pre className="text-sm">{JSON.stringify([...result.entries()], null, 2)}</pre>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/packages/playground-react/tsconfig.json
+++ b/packages/playground-react/tsconfig.json
@@ -11,6 +11,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "node",
+    "downlevelIteration": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve"


### PR DESCRIPTION
This PR will add `<form>` compatibility.

We have a few form element related components:
- Combobox
- Listbox
- RadioGroup
- Switch

The issue is that you manually have to wire these components to form input if
you want them to be included when you submit your form.

This PR will make that a bit easier for you. On the component listed above, you
can now add a `name` prop, once you do that a hidden input field will be
rendered with the selected value.

---

If your data (for example the `value` of your `Listbox.Option`) is an object, then we will make sure to properly encode it. Here is an example:

```js
// Assuming we have a `name` of `person`
let value = ['Alice', 'Bob', 'Charlie']
```

Results in:
```html
<input type="hidden" name="person[]" value="Alice" />
<input type="hidden" name="person[]" value="Bob" />
<input type="hidden" name="person[]" value="Charlie" />
```

Note: the additional `[]` in the name attribute.

A more complex object (even deeply nested) can be encoded like this:
```js
// Assuming we have a `name` of `person`
let value = {
  id: 1,
  name: {
    first: 'Jane',
    last: 'Doe'
  }
}
```

Results in:
```html
<input type="hidden" name="person[id]" value="1" />
<input type="hidden" name="person[name][first]" value="Jane" />
<input type="hidden" name="person[name][last]" value="Doe" />
```

