### PR TITLE
Don’t drop initial character when searching in Combobox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ignore "outside click" on removed elements ([#1193](https://github.com/tailwindlabs/headlessui/pull/1193))
 - Remove `focus()` from Listbox Option ([#1218](https://github.com/tailwindlabs/headlessui/pull/1218))
 - Improve some internal code ([#1221](https://github.com/tailwindlabs/headlessui/pull/1221))
+- Don’t drop initial character when searching in Combobox ([#1223](https://github.com/tailwindlabs/headlessui/pull/1223))
 
 ### Added
 

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -261,9 +261,24 @@ export let Combobox = defineComponent({
       api.closeCombobox()
     })
 
-    watch([api.value, api.inputRef, api.comboboxState], () => api.syncInputValue(), {
+    watch([api.value, api.inputRef], () => api.syncInputValue(), {
       immediate: true,
     })
+
+    // Only sync the input value on close as typing into the input will trigger it to open
+    // causing a resync of the input value with the currently stored, stale value that is
+    // one character behind since the input's value has just been updated by the browser
+    watch(
+      api.comboboxState,
+      (state) => {
+        if (state === ComboboxStates.Closed) {
+          api.syncInputValue()
+        }
+      },
+      {
+        immediate: true,
+      }
+    )
 
     // @ts-expect-error Types of property 'dataRef' are incompatible.
     provide(ComboboxContext, api)


### PR DESCRIPTION
In the Vue version of the combobox the input is synced when the combobox state changes. This is done because closing the combobox needs to reflect the current selected value. For example, pressing the `Escape` key after searching should revert to what the value was before the user started searching.

However, doing this on *open* is problematic:
1. Typing in the input field will open the combobox if it's not open already.
2. Opening the combobox causes the internal state to change.
3. This state change causes the input to be synced.

All three of these steps happen in the same render cycle. This causes the value that would've been written by the `input` event to be lost because the value is synced with the old value that is currently in state. This manifested as the first character causing the combobox to open but not adding (or replacing if there was a selection) characters in the input.