### PR TITLE
Ensure focus trap, Tabs and Dialog play well together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove `focus()` from Listbox Option ([#1218](https://github.com/tailwindlabs/headlessui/pull/1218))
 - Improve some internal code ([#1221](https://github.com/tailwindlabs/headlessui/pull/1221))
 - Use `ownerDocument` instead of `document` ([#1158](https://github.com/tailwindlabs/headlessui/pull/1158))
+- Ensure focus trap, Tabs and Dialog play well together ([#1231](https://github.com/tailwindlabs/headlessui/pull/1231))
 
 ### Added
 
@@ -52,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don’t drop initial character when searching in Combobox ([#1223](https://github.com/tailwindlabs/headlessui/pull/1223))
 - Use `ownerDocument` instead of `document` ([#1158](https://github.com/tailwindlabs/headlessui/pull/1158))
 - Re-expose `el` ([#1230](https://github.com/tailwindlabs/headlessui/pull/1230))
+- Ensure focus trap, Tabs and Dialog play well together ([#1231](https://github.com/tailwindlabs/headlessui/pull/1231))
 
 ### Added
 

--- a/packages/@headlessui-react/src/components/tabs/tabs.test.tsx
+++ b/packages/@headlessui-react/src/components/tabs/tabs.test.tsx
@@ -33,492 +33,342 @@ describe('safeguards', () => {
     })
   )
 
-  it('should be possible to render Tab.Group without crashing', async () => {
-    render(
-      <Tab.Group>
-        <Tab.List>
-          <Tab>Tab 1</Tab>
-          <Tab>Tab 2</Tab>
-          <Tab>Tab 3</Tab>
-        </Tab.List>
+  it(
+    'should be possible to render Tab.Group without crashing',
+    suppressConsoleLogs(async () => {
+      render(
+        <Tab.Group>
+          <Tab.List>
+            <Tab>Tab 1</Tab>
+            <Tab>Tab 2</Tab>
+            <Tab>Tab 3</Tab>
+          </Tab.List>
 
-        <Tab.Panels>
-          <Tab.Panel>Content 1</Tab.Panel>
-          <Tab.Panel>Content 2</Tab.Panel>
-          <Tab.Panel>Content 3</Tab.Panel>
-        </Tab.Panels>
-      </Tab.Group>
-    )
+          <Tab.Panels>
+            <Tab.Panel>Content 1</Tab.Panel>
+            <Tab.Panel>Content 2</Tab.Panel>
+            <Tab.Panel>Content 3</Tab.Panel>
+          </Tab.Panels>
+        </Tab.Group>
+      )
 
-    assertTabs({ active: 0 })
-  })
+      assertTabs({ active: 0 })
+    })
+  )
 })
 
 describe('Rendering', () => {
-  it('should be possible to render the Tab.Panels first, then the Tab.List', async () => {
-    render(
-      <Tab.Group>
-        <Tab.Panels>
-          <Tab.Panel>Content 1</Tab.Panel>
-          <Tab.Panel>Content 2</Tab.Panel>
-          <Tab.Panel>Content 3</Tab.Panel>
-        </Tab.Panels>
-
-        <Tab.List>
-          <Tab>Tab 1</Tab>
-          <Tab>Tab 2</Tab>
-          <Tab>Tab 3</Tab>
-        </Tab.List>
-      </Tab.Group>
-    )
-
-    assertTabs({ active: 0 })
-  })
-
-  it('should guarantee the order of DOM nodes when performing actions', async () => {
-    function Example() {
-      let [hide, setHide] = useState(false)
-
-      return (
-        <>
-          <button onClick={() => setHide((v) => !v)}>toggle</button>
-          <Tab.Group>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              {!hide && <Tab>Tab 2</Tab>}
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              {!hide && <Tab.Panel>Content 2</Tab.Panel>}
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-        </>
-      )
-    }
-
-    render(<Example />)
-
-    await click(getByText('toggle')) // Remove Tab 2
-    await click(getByText('toggle')) // Re-add Tab 2
-
-    await press(Keys.Tab)
-    assertTabs({ active: 0 })
-
-    await press(Keys.ArrowRight)
-    assertTabs({ active: 1 })
-
-    await press(Keys.ArrowRight)
-    assertTabs({ active: 2 })
-  })
-
-  describe('`renderProps`', () => {
-    it('should expose the `selectedIndex` on the `Tab.Group` component', async () => {
+  it(
+    'should be possible to render the Tab.Panels first, then the Tab.List',
+    suppressConsoleLogs(async () => {
       render(
         <Tab.Group>
-          {(data) => (
-            <>
-              <pre id="exposed">{JSON.stringify(data)}</pre>
-
-              <Tab.List>
-                <Tab>Tab 1</Tab>
-                <Tab>Tab 2</Tab>
-                <Tab>Tab 3</Tab>
-              </Tab.List>
-
-              <Tab.Panels>
-                <Tab.Panel>Content 1</Tab.Panel>
-                <Tab.Panel>Content 2</Tab.Panel>
-                <Tab.Panel>Content 3</Tab.Panel>
-              </Tab.Panels>
-            </>
-          )}
-        </Tab.Group>
-      )
-
-      expect(document.getElementById('exposed')).toHaveTextContent(
-        JSON.stringify({ selectedIndex: 0 })
-      )
-
-      await click(getByText('Tab 2'))
-
-      expect(document.getElementById('exposed')).toHaveTextContent(
-        JSON.stringify({ selectedIndex: 1 })
-      )
-    })
-
-    it('should expose the `selectedIndex` on the `Tab.List` component', async () => {
-      render(
-        <Tab.Group>
-          <Tab.List>
-            {(data) => (
-              <>
-                <pre id="exposed">{JSON.stringify(data)}</pre>
-                <Tab>Tab 1</Tab>
-                <Tab>Tab 2</Tab>
-                <Tab>Tab 3</Tab>
-              </>
-            )}
-          </Tab.List>
-
           <Tab.Panels>
             <Tab.Panel>Content 1</Tab.Panel>
             <Tab.Panel>Content 2</Tab.Panel>
             <Tab.Panel>Content 3</Tab.Panel>
           </Tab.Panels>
-        </Tab.Group>
-      )
 
-      expect(document.getElementById('exposed')).toHaveTextContent(
-        JSON.stringify({ selectedIndex: 0 })
-      )
-
-      await click(getByText('Tab 2'))
-
-      expect(document.getElementById('exposed')).toHaveTextContent(
-        JSON.stringify({ selectedIndex: 1 })
-      )
-    })
-
-    it('should expose the `selectedIndex` on the `Tab.Panels` component', async () => {
-      render(
-        <Tab.Group>
           <Tab.List>
             <Tab>Tab 1</Tab>
             <Tab>Tab 2</Tab>
             <Tab>Tab 3</Tab>
           </Tab.List>
-
-          <Tab.Panels>
-            {(data) => (
-              <>
-                <pre id="exposed">{JSON.stringify(data)}</pre>
-                <Tab.Panel>Content 1</Tab.Panel>
-                <Tab.Panel>Content 2</Tab.Panel>
-                <Tab.Panel>Content 3</Tab.Panel>
-              </>
-            )}
-          </Tab.Panels>
         </Tab.Group>
       )
-
-      expect(document.getElementById('exposed')).toHaveTextContent(
-        JSON.stringify({ selectedIndex: 0 })
-      )
-
-      await click(getByText('Tab 2'))
-
-      expect(document.getElementById('exposed')).toHaveTextContent(
-        JSON.stringify({ selectedIndex: 1 })
-      )
-    })
-
-    it('should expose the `selected` state on the `Tab` components', async () => {
-      render(
-        <Tab.Group>
-          <Tab.List>
-            <Tab>
-              {(data) => (
-                <>
-                  <pre data-tab={0}>{JSON.stringify(data)}</pre>
-                  <span>Tab 1</span>
-                </>
-              )}
-            </Tab>
-            <Tab>
-              {(data) => (
-                <>
-                  <pre data-tab={1}>{JSON.stringify(data)}</pre>
-                  <span>Tab 2</span>
-                </>
-              )}
-            </Tab>
-            <Tab>
-              {(data) => (
-                <>
-                  <pre data-tab={2}>{JSON.stringify(data)}</pre>
-                  <span>Tab 3</span>
-                </>
-              )}
-            </Tab>
-          </Tab.List>
-
-          <Tab.Panels>
-            <Tab.Panel>Content 1</Tab.Panel>
-            <Tab.Panel>Content 2</Tab.Panel>
-            <Tab.Panel>Content 3</Tab.Panel>
-          </Tab.Panels>
-        </Tab.Group>
-      )
-
-      expect(document.querySelector('[data-tab="0"]')).toHaveTextContent(
-        JSON.stringify({ selected: true })
-      )
-      expect(document.querySelector('[data-tab="1"]')).toHaveTextContent(
-        JSON.stringify({ selected: false })
-      )
-      expect(document.querySelector('[data-tab="2"]')).toHaveTextContent(
-        JSON.stringify({ selected: false })
-      )
-
-      await click(getTabs()[1])
-
-      expect(document.querySelector('[data-tab="0"]')).toHaveTextContent(
-        JSON.stringify({ selected: false })
-      )
-      expect(document.querySelector('[data-tab="1"]')).toHaveTextContent(
-        JSON.stringify({ selected: true })
-      )
-      expect(document.querySelector('[data-tab="2"]')).toHaveTextContent(
-        JSON.stringify({ selected: false })
-      )
-    })
-
-    it('should expose the `selected` state on the `Tab.Panel` components', async () => {
-      render(
-        <Tab.Group>
-          <Tab.List>
-            <Tab>Tab 1</Tab>
-            <Tab>Tab 2</Tab>
-            <Tab>Tab 3</Tab>
-          </Tab.List>
-
-          <Tab.Panels>
-            <Tab.Panel unmount={false}>
-              {(data) => (
-                <>
-                  <pre data-panel={0}>{JSON.stringify(data)}</pre>
-                  <span>Content 1</span>
-                </>
-              )}
-            </Tab.Panel>
-            <Tab.Panel unmount={false}>
-              {(data) => (
-                <>
-                  <pre data-panel={1}>{JSON.stringify(data)}</pre>
-                  <span>Content 2</span>
-                </>
-              )}
-            </Tab.Panel>
-            <Tab.Panel unmount={false}>
-              {(data) => (
-                <>
-                  <pre data-panel={2}>{JSON.stringify(data)}</pre>
-                  <span>Content 3</span>
-                </>
-              )}
-            </Tab.Panel>
-          </Tab.Panels>
-        </Tab.Group>
-      )
-
-      expect(document.querySelector('[data-panel="0"]')).toHaveTextContent(
-        JSON.stringify({ selected: true })
-      )
-      expect(document.querySelector('[data-panel="1"]')).toHaveTextContent(
-        JSON.stringify({ selected: false })
-      )
-      expect(document.querySelector('[data-panel="2"]')).toHaveTextContent(
-        JSON.stringify({ selected: false })
-      )
-
-      await click(getByText('Tab 2'))
-
-      expect(document.querySelector('[data-panel="0"]')).toHaveTextContent(
-        JSON.stringify({ selected: false })
-      )
-      expect(document.querySelector('[data-panel="1"]')).toHaveTextContent(
-        JSON.stringify({ selected: true })
-      )
-      expect(document.querySelector('[data-panel="2"]')).toHaveTextContent(
-        JSON.stringify({ selected: false })
-      )
-    })
-  })
-
-  describe('`defaultIndex`', () => {
-    it('should jump to the nearest tab when the defaultIndex is out of bounds (-2)', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={-2}>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
 
       assertTabs({ active: 0 })
-      assertActiveElement(getByText('Tab 1'))
     })
+  )
 
-    it('should jump to the nearest tab when the defaultIndex is out of bounds (+5)', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={5}>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-
-      assertTabs({ active: 2 })
-      assertActiveElement(getByText('Tab 3'))
-    })
-
-    it('should jump to the next available tab when the defaultIndex is a disabled tab', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={0}>
-            <Tab.List>
-              <Tab disabled>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-
-      assertTabs({ active: 1 })
-      assertActiveElement(getByText('Tab 2'))
-    })
-
-    it('should jump to the next available tab when the defaultIndex is a disabled tab and wrap around', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={2}>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab disabled>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-
-      assertTabs({ active: 0 })
-      assertActiveElement(getByText('Tab 1'))
-    })
-
-    it('should not change the Tab if the defaultIndex changes', async () => {
+  it(
+    'should guarantee the order of DOM nodes when performing actions',
+    suppressConsoleLogs(async () => {
       function Example() {
-        let [defaultIndex, setDefaultIndex] = useState(1)
+        let [hide, setHide] = useState(false)
 
         return (
           <>
-            <Tab.Group defaultIndex={defaultIndex}>
+            <button onClick={() => setHide((v) => !v)}>toggle</button>
+            <Tab.Group>
               <Tab.List>
                 <Tab>Tab 1</Tab>
-                <Tab>Tab 2</Tab>
+                {!hide && <Tab>Tab 2</Tab>}
                 <Tab>Tab 3</Tab>
               </Tab.List>
 
               <Tab.Panels>
                 <Tab.Panel>Content 1</Tab.Panel>
-                <Tab.Panel>Content 2</Tab.Panel>
+                {!hide && <Tab.Panel>Content 2</Tab.Panel>}
                 <Tab.Panel>Content 3</Tab.Panel>
               </Tab.Panels>
             </Tab.Group>
-
-            <button>after</button>
-            <button onClick={() => setDefaultIndex(0)}>change</button>
           </>
         )
       }
 
       render(<Example />)
 
-      assertActiveElement(document.body)
+      await click(getByText('toggle')) // Remove Tab 2
+      await click(getByText('toggle')) // Re-add Tab 2
 
       await press(Keys.Tab)
+      assertTabs({ active: 0 })
 
+      await press(Keys.ArrowRight)
       assertTabs({ active: 1 })
-      assertActiveElement(getByText('Tab 2'))
 
-      await click(getByText('Tab 3'))
-
-      assertTabs({ active: 2 })
-      assertActiveElement(getByText('Tab 3'))
-
-      // Change default index
-      await click(getByText('change'))
-
-      // Nothing should change...
+      await press(Keys.ArrowRight)
       assertTabs({ active: 2 })
     })
+  )
+
+  describe('`renderProps`', () => {
+    it(
+      'should expose the `selectedIndex` on the `Tab.Group` component',
+      suppressConsoleLogs(async () => {
+        render(
+          <Tab.Group>
+            {(data) => (
+              <>
+                <pre id="exposed">{JSON.stringify(data)}</pre>
+
+                <Tab.List>
+                  <Tab>Tab 1</Tab>
+                  <Tab>Tab 2</Tab>
+                  <Tab>Tab 3</Tab>
+                </Tab.List>
+
+                <Tab.Panels>
+                  <Tab.Panel>Content 1</Tab.Panel>
+                  <Tab.Panel>Content 2</Tab.Panel>
+                  <Tab.Panel>Content 3</Tab.Panel>
+                </Tab.Panels>
+              </>
+            )}
+          </Tab.Group>
+        )
+
+        expect(document.getElementById('exposed')).toHaveTextContent(
+          JSON.stringify({ selectedIndex: 0 })
+        )
+
+        await click(getByText('Tab 2'))
+
+        expect(document.getElementById('exposed')).toHaveTextContent(
+          JSON.stringify({ selectedIndex: 1 })
+        )
+      })
+    )
+
+    it(
+      'should expose the `selectedIndex` on the `Tab.List` component',
+      suppressConsoleLogs(async () => {
+        render(
+          <Tab.Group>
+            <Tab.List>
+              {(data) => (
+                <>
+                  <pre id="exposed">{JSON.stringify(data)}</pre>
+                  <Tab>Tab 1</Tab>
+                  <Tab>Tab 2</Tab>
+                  <Tab>Tab 3</Tab>
+                </>
+              )}
+            </Tab.List>
+
+            <Tab.Panels>
+              <Tab.Panel>Content 1</Tab.Panel>
+              <Tab.Panel>Content 2</Tab.Panel>
+              <Tab.Panel>Content 3</Tab.Panel>
+            </Tab.Panels>
+          </Tab.Group>
+        )
+
+        expect(document.getElementById('exposed')).toHaveTextContent(
+          JSON.stringify({ selectedIndex: 0 })
+        )
+
+        await click(getByText('Tab 2'))
+
+        expect(document.getElementById('exposed')).toHaveTextContent(
+          JSON.stringify({ selectedIndex: 1 })
+        )
+      })
+    )
+
+    it(
+      'should expose the `selectedIndex` on the `Tab.Panels` component',
+      suppressConsoleLogs(async () => {
+        render(
+          <Tab.Group>
+            <Tab.List>
+              <Tab>Tab 1</Tab>
+              <Tab>Tab 2</Tab>
+              <Tab>Tab 3</Tab>
+            </Tab.List>
+
+            <Tab.Panels>
+              {(data) => (
+                <>
+                  <pre id="exposed">{JSON.stringify(data)}</pre>
+                  <Tab.Panel>Content 1</Tab.Panel>
+                  <Tab.Panel>Content 2</Tab.Panel>
+                  <Tab.Panel>Content 3</Tab.Panel>
+                </>
+              )}
+            </Tab.Panels>
+          </Tab.Group>
+        )
+
+        expect(document.getElementById('exposed')).toHaveTextContent(
+          JSON.stringify({ selectedIndex: 0 })
+        )
+
+        await click(getByText('Tab 2'))
+
+        expect(document.getElementById('exposed')).toHaveTextContent(
+          JSON.stringify({ selectedIndex: 1 })
+        )
+      })
+    )
+
+    it(
+      'should expose the `selected` state on the `Tab` components',
+      suppressConsoleLogs(async () => {
+        render(
+          <Tab.Group>
+            <Tab.List>
+              <Tab>
+                {(data) => (
+                  <>
+                    <pre data-tab={0}>{JSON.stringify(data)}</pre>
+                    <span>Tab 1</span>
+                  </>
+                )}
+              </Tab>
+              <Tab>
+                {(data) => (
+                  <>
+                    <pre data-tab={1}>{JSON.stringify(data)}</pre>
+                    <span>Tab 2</span>
+                  </>
+                )}
+              </Tab>
+              <Tab>
+                {(data) => (
+                  <>
+                    <pre data-tab={2}>{JSON.stringify(data)}</pre>
+                    <span>Tab 3</span>
+                  </>
+                )}
+              </Tab>
+            </Tab.List>
+
+            <Tab.Panels>
+              <Tab.Panel>Content 1</Tab.Panel>
+              <Tab.Panel>Content 2</Tab.Panel>
+              <Tab.Panel>Content 3</Tab.Panel>
+            </Tab.Panels>
+          </Tab.Group>
+        )
+
+        expect(document.querySelector('[data-tab="0"]')).toHaveTextContent(
+          JSON.stringify({ selected: true })
+        )
+        expect(document.querySelector('[data-tab="1"]')).toHaveTextContent(
+          JSON.stringify({ selected: false })
+        )
+        expect(document.querySelector('[data-tab="2"]')).toHaveTextContent(
+          JSON.stringify({ selected: false })
+        )
+
+        await click(getTabs()[1])
+
+        expect(document.querySelector('[data-tab="0"]')).toHaveTextContent(
+          JSON.stringify({ selected: false })
+        )
+        expect(document.querySelector('[data-tab="1"]')).toHaveTextContent(
+          JSON.stringify({ selected: true })
+        )
+        expect(document.querySelector('[data-tab="2"]')).toHaveTextContent(
+          JSON.stringify({ selected: false })
+        )
+      })
+    )
+
+    it(
+      'should expose the `selected` state on the `Tab.Panel` components',
+      suppressConsoleLogs(async () => {
+        render(
+          <Tab.Group>
+            <Tab.List>
+              <Tab>Tab 1</Tab>
+              <Tab>Tab 2</Tab>
+              <Tab>Tab 3</Tab>
+            </Tab.List>
+
+            <Tab.Panels>
+              <Tab.Panel unmount={false}>
+                {(data) => (
+                  <>
+                    <pre data-panel={0}>{JSON.stringify(data)}</pre>
+                    <span>Content 1</span>
+                  </>
+                )}
+              </Tab.Panel>
+              <Tab.Panel unmount={false}>
+                {(data) => (
+                  <>
+                    <pre data-panel={1}>{JSON.stringify(data)}</pre>
+                    <span>Content 2</span>
+                  </>
+                )}
+              </Tab.Panel>
+              <Tab.Panel unmount={false}>
+                {(data) => (
+                  <>
+                    <pre data-panel={2}>{JSON.stringify(data)}</pre>
+                    <span>Content 3</span>
+                  </>
+                )}
+              </Tab.Panel>
+            </Tab.Panels>
+          </Tab.Group>
+        )
+
+        expect(document.querySelector('[data-panel="0"]')).toHaveTextContent(
+          JSON.stringify({ selected: true })
+        )
+        expect(document.querySelector('[data-panel="1"]')).toHaveTextContent(
+          JSON.stringify({ selected: false })
+        )
+        expect(document.querySelector('[data-panel="2"]')).toHaveTextContent(
+          JSON.stringify({ selected: false })
+        )
+
+        await click(getByText('Tab 2'))
+
+        expect(document.querySelector('[data-panel="0"]')).toHaveTextContent(
+          JSON.stringify({ selected: false })
+        )
+        expect(document.querySelector('[data-panel="1"]')).toHaveTextContent(
+          JSON.stringify({ selected: true })
+        )
+        expect(document.querySelector('[data-panel="2"]')).toHaveTextContent(
+          JSON.stringify({ selected: false })
+        )
+      })
+    )
   })
 
-  describe('`selectedIndex`', () => {
-    it('should be possible to change active tab controlled and uncontrolled', async () => {
-      let handleChange = jest.fn()
-
-      function ControlledTabs() {
-        let [selectedIndex, setSelectedIndex] = useState(0)
-
-        return (
+  describe('`defaultIndex`', () => {
+    it(
+      'should jump to the nearest tab when the defaultIndex is out of bounds (-2)',
+      suppressConsoleLogs(async () => {
+        render(
           <>
-            <Tab.Group
-              selectedIndex={selectedIndex}
-              onChange={(value) => {
-                setSelectedIndex(value)
-                handleChange(value)
-              }}
-            >
+            <Tab.Group defaultIndex={-2}>
               <Tab.List>
                 <Tab>Tab 1</Tab>
                 <Tab>Tab 2</Tab>
@@ -533,36 +383,1889 @@ describe('Rendering', () => {
             </Tab.Group>
 
             <button>after</button>
-            <button onClick={() => setSelectedIndex((prev) => prev + 1)}>setSelectedIndex</button>
           </>
         )
-      }
 
-      render(<ControlledTabs />)
+        assertActiveElement(document.body)
 
-      assertActiveElement(document.body)
+        await press(Keys.Tab)
 
-      // test uncontrolled behaviour
-      await click(getByText('Tab 2'))
-      expect(handleChange).toHaveBeenCalledTimes(1)
-      expect(handleChange).toHaveBeenNthCalledWith(1, 1)
-      assertTabs({ active: 1 })
+        assertTabs({ active: 0 })
+        assertActiveElement(getByText('Tab 1'))
+      })
+    )
 
-      // test controlled behaviour
-      await click(getByText('setSelectedIndex'))
-      assertTabs({ active: 2 })
+    it(
+      'should jump to the nearest tab when the defaultIndex is out of bounds (+5)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={5}>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
 
-      // test uncontrolled behaviour again
-      await click(getByText('Tab 2'))
-      expect(handleChange).toHaveBeenCalledTimes(2)
-      expect(handleChange).toHaveBeenNthCalledWith(2, 1)
-      assertTabs({ active: 1 })
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+
+        assertTabs({ active: 2 })
+        assertActiveElement(getByText('Tab 3'))
+      })
+    )
+
+    it(
+      'should jump to the next available tab when the defaultIndex is a disabled tab',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={0}>
+              <Tab.List>
+                <Tab disabled>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+
+        assertTabs({ active: 1 })
+        assertActiveElement(getByText('Tab 2'))
+      })
+    )
+
+    it(
+      'should jump to the next available tab when the defaultIndex is a disabled tab and wrap around',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={2}>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab disabled>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+
+        assertTabs({ active: 0 })
+        assertActiveElement(getByText('Tab 1'))
+      })
+    )
+
+    it(
+      'should not change the Tab if the defaultIndex changes',
+      suppressConsoleLogs(async () => {
+        function Example() {
+          let [defaultIndex, setDefaultIndex] = useState(1)
+
+          return (
+            <>
+              <Tab.Group defaultIndex={defaultIndex}>
+                <Tab.List>
+                  <Tab>Tab 1</Tab>
+                  <Tab>Tab 2</Tab>
+                  <Tab>Tab 3</Tab>
+                </Tab.List>
+
+                <Tab.Panels>
+                  <Tab.Panel>Content 1</Tab.Panel>
+                  <Tab.Panel>Content 2</Tab.Panel>
+                  <Tab.Panel>Content 3</Tab.Panel>
+                </Tab.Panels>
+              </Tab.Group>
+
+              <button>after</button>
+              <button onClick={() => setDefaultIndex(0)}>change</button>
+            </>
+          )
+        }
+
+        render(<Example />)
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+
+        assertTabs({ active: 1 })
+        assertActiveElement(getByText('Tab 2'))
+
+        await click(getByText('Tab 3'))
+
+        assertTabs({ active: 2 })
+        assertActiveElement(getByText('Tab 3'))
+
+        // Change default index
+        await click(getByText('change'))
+
+        // Nothing should change...
+        assertTabs({ active: 2 })
+      })
+    )
+  })
+
+  describe('`selectedIndex`', () => {
+    it(
+      'should be possible to change active tab controlled and uncontrolled',
+      suppressConsoleLogs(async () => {
+        let handleChange = jest.fn()
+
+        function ControlledTabs() {
+          let [selectedIndex, setSelectedIndex] = useState(0)
+
+          return (
+            <>
+              <Tab.Group
+                selectedIndex={selectedIndex}
+                onChange={(value) => {
+                  setSelectedIndex(value)
+                  handleChange(value)
+                }}
+              >
+                <Tab.List>
+                  <Tab>Tab 1</Tab>
+                  <Tab>Tab 2</Tab>
+                  <Tab>Tab 3</Tab>
+                </Tab.List>
+
+                <Tab.Panels>
+                  <Tab.Panel>Content 1</Tab.Panel>
+                  <Tab.Panel>Content 2</Tab.Panel>
+                  <Tab.Panel>Content 3</Tab.Panel>
+                </Tab.Panels>
+              </Tab.Group>
+
+              <button>after</button>
+              <button onClick={() => setSelectedIndex((prev) => prev + 1)}>setSelectedIndex</button>
+            </>
+          )
+        }
+
+        render(<ControlledTabs />)
+
+        assertActiveElement(document.body)
+
+        // test uncontrolled behaviour
+        await click(getByText('Tab 2'))
+        expect(handleChange).toHaveBeenCalledTimes(1)
+        expect(handleChange).toHaveBeenNthCalledWith(1, 1)
+        assertTabs({ active: 1 })
+
+        // test controlled behaviour
+        await click(getByText('setSelectedIndex'))
+        assertTabs({ active: 2 })
+
+        // test uncontrolled behaviour again
+        await click(getByText('Tab 2'))
+        expect(handleChange).toHaveBeenCalledTimes(2)
+        expect(handleChange).toHaveBeenNthCalledWith(2, 1)
+        assertTabs({ active: 1 })
+      })
+    )
+
+    it(
+      'should jump to the nearest tab when the selectedIndex is out of bounds (-2)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group selectedIndex={-2}>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+
+        assertTabs({ active: 0 })
+        assertActiveElement(getByText('Tab 1'))
+      })
+    )
+
+    it(
+      'should jump to the nearest tab when the selectedIndex is out of bounds (+5)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group selectedIndex={5}>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+
+        assertTabs({ active: 2 })
+        assertActiveElement(getByText('Tab 3'))
+      })
+    )
+
+    it(
+      'should jump to the next available tab when the selectedIndex is a disabled tab',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group selectedIndex={0}>
+              <Tab.List>
+                <Tab disabled>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+
+        assertTabs({ active: 1 })
+        assertActiveElement(getByText('Tab 2'))
+      })
+    )
+
+    it(
+      'should jump to the next available tab when the selectedIndex is a disabled tab and wrap around',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={2}>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab disabled>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+
+        assertTabs({ active: 0 })
+        assertActiveElement(getByText('Tab 1'))
+      })
+    )
+
+    it(
+      'should prefer selectedIndex over defaultIndex',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group selectedIndex={0} defaultIndex={2}>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+
+        assertTabs({ active: 0 })
+        assertActiveElement(getByText('Tab 1'))
+      })
+    )
+  })
+
+  describe(`'Tab'`, () => {
+    describe('`type` attribute', () => {
+      it(
+        'should set the `type` to "button" by default',
+        suppressConsoleLogs(async () => {
+          render(
+            <Tab.Group>
+              <Tab.List>
+                <Tab>Trigger</Tab>
+              </Tab.List>
+            </Tab.Group>
+          )
+
+          expect(getTabs()[0]).toHaveAttribute('type', 'button')
+        })
+      )
+
+      it(
+        'should not set the `type` to "button" if it already contains a `type`',
+        suppressConsoleLogs(async () => {
+          render(
+            <Tab.Group>
+              <Tab.List>
+                <Tab type="submit">Trigger</Tab>
+              </Tab.List>
+            </Tab.Group>
+          )
+
+          expect(getTabs()[0]).toHaveAttribute('type', 'submit')
+        })
+      )
+
+      it(
+        'should set the `type` to "button" when using the `as` prop which resolves to a "button"',
+        suppressConsoleLogs(async () => {
+          let CustomButton = React.forwardRef<HTMLButtonElement>((props, ref) => (
+            <button ref={ref} {...props} />
+          ))
+
+          render(
+            <Tab.Group>
+              <Tab.List>
+                <Tab as={CustomButton}>Trigger</Tab>
+              </Tab.List>
+            </Tab.Group>
+          )
+
+          expect(getTabs()[0]).toHaveAttribute('type', 'button')
+        })
+      )
+
+      it(
+        'should not set the type if the "as" prop is not a "button"',
+        suppressConsoleLogs(async () => {
+          render(
+            <Tab.Group>
+              <Tab.List>
+                <Tab as="div">Trigger</Tab>
+              </Tab.List>
+            </Tab.Group>
+          )
+
+          expect(getTabs()[0]).not.toHaveAttribute('type')
+        })
+      )
+
+      it(
+        'should not set the `type` to "button" when using the `as` prop which resolves to a "div"',
+        suppressConsoleLogs(async () => {
+          let CustomButton = React.forwardRef<HTMLDivElement>((props, ref) => (
+            <div ref={ref} {...props} />
+          ))
+
+          render(
+            <Tab.Group>
+              <Tab.List>
+                <Tab as={CustomButton}>Trigger</Tab>
+              </Tab.List>
+            </Tab.Group>
+          )
+
+          expect(getTabs()[0]).not.toHaveAttribute('type')
+        })
+      )
     })
+  })
+})
 
-    it('should jump to the nearest tab when the selectedIndex is out of bounds (-2)', async () => {
+describe('Keyboard interactions', () => {
+  describe('`Tab` key', () => {
+    it(
+      'should be possible to tab to the default initial first tab',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+
+        assertTabs({ active: 0 })
+        assertActiveElement(getByText('Tab 1'))
+
+        await press(Keys.Tab)
+        assertActiveElement(getByText('Content 1'))
+
+        await press(Keys.Tab)
+        assertActiveElement(getByText('after'))
+
+        await press(shift(Keys.Tab))
+        assertActiveElement(getByText('Content 1'))
+
+        await press(shift(Keys.Tab))
+        assertActiveElement(getByText('Tab 1'))
+      })
+    )
+
+    it(
+      'should be possible to tab to the default index tab',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={1}>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+
+        assertTabs({ active: 1 })
+        assertActiveElement(getByText('Tab 2'))
+
+        await press(Keys.Tab)
+        assertActiveElement(getByText('Content 2'))
+
+        await press(Keys.Tab)
+        assertActiveElement(getByText('after'))
+
+        await press(shift(Keys.Tab))
+        assertActiveElement(getByText('Content 2'))
+
+        await press(shift(Keys.Tab))
+        assertActiveElement(getByText('Tab 2'))
+      })
+    )
+  })
+
+  describe('`ArrowRight` key', () => {
+    it(
+      'should be possible to go to the next item (activation = `auto`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 0 })
+
+        await press(Keys.ArrowRight)
+        assertTabs({ active: 1 })
+
+        await press(Keys.ArrowRight)
+        assertTabs({ active: 2 })
+      })
+    )
+
+    it(
+      'should be possible to go to the next item (activation = `manual`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group manual>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 0 })
+
+        await press(Keys.ArrowRight)
+        assertTabs({ active: 0 })
+        await press(Keys.Enter)
+        assertTabs({ active: 1 })
+
+        await press(Keys.ArrowRight)
+        assertTabs({ active: 1 })
+        await press(Keys.Enter)
+        assertTabs({ active: 2 })
+      })
+    )
+
+    it(
+      'should wrap around at the end (activation = `auto`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 0 })
+
+        await press(Keys.ArrowRight)
+        assertTabs({ active: 1 })
+
+        await press(Keys.ArrowRight)
+        assertTabs({ active: 2 })
+
+        await press(Keys.ArrowRight)
+        assertTabs({ active: 0 })
+
+        await press(Keys.ArrowRight)
+        assertTabs({ active: 1 })
+      })
+    )
+
+    it(
+      'should wrap around at the end (activation = `manual`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group manual>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 0 })
+
+        await press(Keys.ArrowRight)
+        assertTabs({ active: 0 })
+        await press(Keys.Enter)
+        assertTabs({ active: 1 })
+
+        await press(Keys.ArrowRight)
+        assertTabs({ active: 1 })
+        await press(Keys.Enter)
+        assertTabs({ active: 2 })
+
+        await press(Keys.ArrowRight)
+        assertTabs({ active: 2 })
+        await press(Keys.Enter)
+        assertTabs({ active: 0 })
+
+        await press(Keys.ArrowRight)
+        assertTabs({ active: 0 })
+        await press(Keys.Enter)
+        assertTabs({ active: 1 })
+      })
+    )
+
+    it(
+      'should not be possible to go right when in vertical mode (activation = `auto`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group vertical>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 0, orientation: 'vertical' })
+
+        await press(Keys.ArrowRight)
+        // no-op
+        assertTabs({ active: 0, orientation: 'vertical' })
+      })
+    )
+
+    it(
+      'should not be possible to go right when in vertical mode (activation = `manual`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group vertical manual>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 0, orientation: 'vertical' })
+
+        await press(Keys.ArrowRight)
+        assertTabs({ active: 0, orientation: 'vertical' })
+        await press(Keys.Enter)
+        // no-op
+        assertTabs({ active: 0, orientation: 'vertical' })
+      })
+    )
+  })
+
+  describe('`ArrowLeft` key', () => {
+    it(
+      'should be possible to go to the previous item (activation = `auto`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={2}>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 2 })
+
+        await press(Keys.ArrowLeft)
+        assertTabs({ active: 1 })
+
+        await press(Keys.ArrowLeft)
+        assertTabs({ active: 0 })
+      })
+    )
+
+    it(
+      'should be possible to go to the previous item (activation = `manual`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={2} manual>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 2 })
+
+        await press(Keys.ArrowLeft)
+        assertTabs({ active: 2 })
+        await press(Keys.Enter)
+        assertTabs({ active: 1 })
+
+        await press(Keys.ArrowLeft)
+        assertTabs({ active: 1 })
+        await press(Keys.Enter)
+        assertTabs({ active: 0 })
+      })
+    )
+
+    it(
+      'should wrap around at the beginning (activation = `auto`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={2}>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 2 })
+
+        await press(Keys.ArrowLeft)
+        assertTabs({ active: 1 })
+
+        await press(Keys.ArrowLeft)
+        assertTabs({ active: 0 })
+
+        await press(Keys.ArrowLeft)
+        assertTabs({ active: 2 })
+
+        await press(Keys.ArrowLeft)
+        assertTabs({ active: 1 })
+      })
+    )
+
+    it(
+      'should wrap around at the beginning (activation = `manual`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={2} manual>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 2 })
+
+        await press(Keys.ArrowLeft)
+        assertTabs({ active: 2 })
+        await press(Keys.Enter)
+        assertTabs({ active: 1 })
+
+        await press(Keys.ArrowLeft)
+        assertTabs({ active: 1 })
+        await press(Keys.Enter)
+        assertTabs({ active: 0 })
+
+        await press(Keys.ArrowLeft)
+        assertTabs({ active: 0 })
+        await press(Keys.Enter)
+        assertTabs({ active: 2 })
+
+        await press(Keys.ArrowLeft)
+        assertTabs({ active: 2 })
+        await press(Keys.Enter)
+        assertTabs({ active: 1 })
+      })
+    )
+
+    it(
+      'should not be possible to go left when in vertical mode (activation = `auto`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group vertical>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 0, orientation: 'vertical' })
+
+        await press(Keys.ArrowLeft)
+        // no-op
+        assertTabs({ active: 0, orientation: 'vertical' })
+      })
+    )
+
+    it(
+      'should not be possible to go left when in vertical mode (activation = `manual`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group vertical manual>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 0, orientation: 'vertical' })
+
+        await press(Keys.ArrowLeft)
+        assertTabs({ active: 0, orientation: 'vertical' })
+        await press(Keys.Enter)
+
+        // no-op
+        assertTabs({ active: 0, orientation: 'vertical' })
+      })
+    )
+  })
+
+  describe('`ArrowDown` key', () => {
+    it(
+      'should be possible to go to the next item (activation = `auto`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group vertical>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 0, orientation: 'vertical' })
+
+        await press(Keys.ArrowDown)
+        assertTabs({ active: 1, orientation: 'vertical' })
+
+        await press(Keys.ArrowDown)
+        assertTabs({ active: 2, orientation: 'vertical' })
+      })
+    )
+
+    it(
+      'should be possible to go to the next item (activation = `manual`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group vertical manual>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 0, orientation: 'vertical' })
+
+        await press(Keys.ArrowDown)
+        assertTabs({ active: 0, orientation: 'vertical' })
+        await press(Keys.Enter)
+        assertTabs({ active: 1, orientation: 'vertical' })
+
+        await press(Keys.ArrowDown)
+        assertTabs({ active: 1, orientation: 'vertical' })
+        await press(Keys.Enter)
+        assertTabs({ active: 2, orientation: 'vertical' })
+      })
+    )
+
+    it(
+      'should wrap around at the end (activation = `auto`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group vertical>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 0, orientation: 'vertical' })
+
+        await press(Keys.ArrowDown)
+        assertTabs({ active: 1, orientation: 'vertical' })
+
+        await press(Keys.ArrowDown)
+        assertTabs({ active: 2, orientation: 'vertical' })
+
+        await press(Keys.ArrowDown)
+        assertTabs({ active: 0, orientation: 'vertical' })
+
+        await press(Keys.ArrowDown)
+        assertTabs({ active: 1, orientation: 'vertical' })
+      })
+    )
+
+    it(
+      'should wrap around at the end (activation = `manual`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group vertical manual>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 0, orientation: 'vertical' })
+
+        await press(Keys.ArrowDown)
+        assertTabs({ active: 0, orientation: 'vertical' })
+        await press(Keys.Enter)
+        assertTabs({ active: 1, orientation: 'vertical' })
+
+        await press(Keys.ArrowDown)
+        assertTabs({ active: 1, orientation: 'vertical' })
+        await press(Keys.Enter)
+        assertTabs({ active: 2, orientation: 'vertical' })
+
+        await press(Keys.ArrowDown)
+        assertTabs({ active: 2, orientation: 'vertical' })
+        await press(Keys.Enter)
+        assertTabs({ active: 0, orientation: 'vertical' })
+
+        await press(Keys.ArrowDown)
+        assertTabs({ active: 0, orientation: 'vertical' })
+        await press(Keys.Enter)
+        assertTabs({ active: 1, orientation: 'vertical' })
+      })
+    )
+
+    it(
+      'should not be possible to go down when in horizontal mode (activation = `auto`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 0 })
+
+        await press(Keys.ArrowDown)
+        // no-op
+        assertTabs({ active: 0 })
+      })
+    )
+
+    it(
+      'should not be possible to go down when in horizontal mode (activation = `manual`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group manual>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 0 })
+
+        await press(Keys.ArrowDown)
+        assertTabs({ active: 0 })
+        await press(Keys.Enter)
+
+        // no-op
+        assertTabs({ active: 0 })
+      })
+    )
+  })
+
+  describe('`ArrowUp` key', () => {
+    it(
+      'should be possible to go to the previous item (activation = `auto`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={2} vertical>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 2, orientation: 'vertical' })
+
+        await press(Keys.ArrowUp)
+        assertTabs({ active: 1, orientation: 'vertical' })
+
+        await press(Keys.ArrowUp)
+        assertTabs({ active: 0, orientation: 'vertical' })
+      })
+    )
+
+    it(
+      'should be possible to go to the previous item (activation = `manual`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={2} vertical manual>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 2, orientation: 'vertical' })
+
+        await press(Keys.ArrowUp)
+        assertTabs({ active: 2, orientation: 'vertical' })
+        await press(Keys.Enter)
+        assertTabs({ active: 1, orientation: 'vertical' })
+
+        await press(Keys.ArrowUp)
+        assertTabs({ active: 1, orientation: 'vertical' })
+        await press(Keys.Enter)
+        assertTabs({ active: 0, orientation: 'vertical' })
+      })
+    )
+
+    it(
+      'should wrap around at the beginning (activation = `auto`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={2} vertical>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 2, orientation: 'vertical' })
+
+        await press(Keys.ArrowUp)
+        assertTabs({ active: 1, orientation: 'vertical' })
+
+        await press(Keys.ArrowUp)
+        assertTabs({ active: 0, orientation: 'vertical' })
+
+        await press(Keys.ArrowUp)
+        assertTabs({ active: 2, orientation: 'vertical' })
+
+        await press(Keys.ArrowUp)
+        assertTabs({ active: 1, orientation: 'vertical' })
+      })
+    )
+
+    it(
+      'should wrap around at the beginning (activation = `manual`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={2} vertical manual>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 2, orientation: 'vertical' })
+
+        await press(Keys.ArrowUp)
+        assertTabs({ active: 2, orientation: 'vertical' })
+        await press(Keys.Enter)
+        assertTabs({ active: 1, orientation: 'vertical' })
+
+        await press(Keys.ArrowUp)
+        assertTabs({ active: 1, orientation: 'vertical' })
+        await press(Keys.Enter)
+        assertTabs({ active: 0, orientation: 'vertical' })
+
+        await press(Keys.ArrowUp)
+        assertTabs({ active: 0, orientation: 'vertical' })
+        await press(Keys.Enter)
+        assertTabs({ active: 2, orientation: 'vertical' })
+
+        await press(Keys.ArrowUp)
+        assertTabs({ active: 2, orientation: 'vertical' })
+        await press(Keys.Enter)
+        assertTabs({ active: 1, orientation: 'vertical' })
+      })
+    )
+
+    it(
+      'should not be possible to go left when in vertical mode (activation = `auto`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 0 })
+
+        await press(Keys.ArrowUp)
+        // no-op
+        assertTabs({ active: 0 })
+      })
+    )
+
+    it(
+      'should not be possible to go left when in vertical mode (activation = `manual`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group manual>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 0 })
+
+        await press(Keys.ArrowUp)
+        assertTabs({ active: 0 })
+        await press(Keys.Enter)
+
+        // no-op
+        assertTabs({ active: 0 })
+      })
+    )
+  })
+
+  describe('`Home` key', () => {
+    it(
+      'should be possible to go to the first focusable item (activation = `auto`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={1}>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 1 })
+
+        await press(Keys.Home)
+        assertTabs({ active: 0 })
+      })
+    )
+
+    it(
+      'should be possible to go to the first focusable item (activation = `manual`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={1} manual>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 1 })
+
+        await press(Keys.Home)
+        assertTabs({ active: 1 })
+        await press(Keys.Enter)
+        assertTabs({ active: 0 })
+      })
+    )
+  })
+
+  describe('`PageUp` key', () => {
+    it(
+      'should be possible to go to the first focusable item (activation = `auto`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={1}>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 1 })
+
+        await press(Keys.PageUp)
+        assertTabs({ active: 0 })
+      })
+    )
+
+    it(
+      'should be possible to go to the first focusable item (activation = `manual`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={1} manual>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 1 })
+
+        await press(Keys.PageUp)
+        assertTabs({ active: 1 })
+        await press(Keys.Enter)
+        assertTabs({ active: 0 })
+      })
+    )
+  })
+
+  describe('`End` key', () => {
+    it(
+      'should be possible to go to the first focusable item (activation = `auto`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={1}>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 1 })
+
+        await press(Keys.End)
+        assertTabs({ active: 2 })
+      })
+    )
+
+    it(
+      'should be possible to go to the first focusable item (activation = `manual`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={1} manual>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 1 })
+
+        await press(Keys.End)
+        assertTabs({ active: 1 })
+        await press(Keys.Enter)
+        assertTabs({ active: 2 })
+      })
+    )
+  })
+
+  describe('`PageDown` key', () => {
+    it(
+      'should be possible to go to the first focusable item (activation = `auto`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={1}>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 1 })
+
+        await press(Keys.PageDown)
+        assertTabs({ active: 2 })
+      })
+    )
+
+    it(
+      'should be possible to go to the first focusable item (activation = `manual`)',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group defaultIndex={1} manual>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        await press(Keys.Tab)
+        assertTabs({ active: 1 })
+
+        await press(Keys.PageDown)
+        assertTabs({ active: 1 })
+        await press(Keys.Enter)
+        assertTabs({ active: 2 })
+      })
+    )
+  })
+
+  describe('`Enter` key', () => {
+    it(
+      'should be possible to activate the focused tab',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group manual>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        getByText('Tab 3')?.focus()
+
+        assertActiveElement(getByText('Tab 3'))
+        assertTabs({ active: 0 })
+
+        await press(Keys.Enter)
+        assertTabs({ active: 2 })
+      })
+    )
+  })
+
+  describe('`Space` key', () => {
+    it(
+      'should be possible to activate the focused tab',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <Tab.Group manual>
+              <Tab.List>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Tab 3</Tab>
+              </Tab.List>
+
+              <Tab.Panels>
+                <Tab.Panel>Content 1</Tab.Panel>
+                <Tab.Panel>Content 2</Tab.Panel>
+                <Tab.Panel>Content 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+
+            <button>after</button>
+          </>
+        )
+
+        assertActiveElement(document.body)
+
+        getByText('Tab 3')?.focus()
+
+        assertActiveElement(getByText('Tab 3'))
+        assertTabs({ active: 0 })
+
+        await press(Keys.Space)
+        assertTabs({ active: 2 })
+      })
+    )
+  })
+})
+
+describe('Mouse interactions', () => {
+  it(
+    'should be possible to click on a tab to focus it',
+    suppressConsoleLogs(async () => {
       render(
         <>
-          <Tab.Group selectedIndex={-2}>
+          <Tab.Group defaultIndex={1}>
             <Tab.List>
               <Tab>Tab 1</Tab>
               <Tab>Tab 2</Tab>
@@ -581,46 +2284,26 @@ describe('Rendering', () => {
       )
 
       assertActiveElement(document.body)
-
       await press(Keys.Tab)
+      assertTabs({ active: 1 })
 
+      await click(getByText('Tab 1'))
       assertTabs({ active: 0 })
-      assertActiveElement(getByText('Tab 1'))
-    })
 
-    it('should jump to the nearest tab when the selectedIndex is out of bounds (+5)', async () => {
-      render(
-        <>
-          <Tab.Group selectedIndex={5}>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-
+      await click(getByText('Tab 3'))
       assertTabs({ active: 2 })
-      assertActiveElement(getByText('Tab 3'))
-    })
 
-    it('should jump to the next available tab when the selectedIndex is a disabled tab', async () => {
+      await click(getByText('Tab 2'))
+      assertTabs({ active: 1 })
+    })
+  )
+
+  it(
+    'should be a no-op when clicking on a disabled tab',
+    suppressConsoleLogs(async () => {
       render(
         <>
-          <Tab.Group selectedIndex={0}>
+          <Tab.Group defaultIndex={1}>
             <Tab.List>
               <Tab disabled>Tab 1</Tab>
               <Tab>Tab 2</Tab>
@@ -639,1451 +2322,24 @@ describe('Rendering', () => {
       )
 
       assertActiveElement(document.body)
-
       await press(Keys.Tab)
-
       assertTabs({ active: 1 })
-      assertActiveElement(getByText('Tab 2'))
+
+      await click(getByText('Tab 1'))
+      // No-op, Tab 2 is still active
+      assertTabs({ active: 1 })
     })
-
-    it('should jump to the next available tab when the selectedIndex is a disabled tab and wrap around', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={2}>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab disabled>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-
-      assertTabs({ active: 0 })
-      assertActiveElement(getByText('Tab 1'))
-    })
-
-    it('should prefer selectedIndex over defaultIndex', async () => {
-      render(
-        <>
-          <Tab.Group selectedIndex={0} defaultIndex={2}>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-
-      assertTabs({ active: 0 })
-      assertActiveElement(getByText('Tab 1'))
-    })
-  })
-
-  describe(`'Tab'`, () => {
-    describe('`type` attribute', () => {
-      it('should set the `type` to "button" by default', async () => {
-        render(
-          <Tab.Group>
-            <Tab.List>
-              <Tab>Trigger</Tab>
-            </Tab.List>
-          </Tab.Group>
-        )
-
-        expect(getTabs()[0]).toHaveAttribute('type', 'button')
-      })
-
-      it('should not set the `type` to "button" if it already contains a `type`', async () => {
-        render(
-          <Tab.Group>
-            <Tab.List>
-              <Tab type="submit">Trigger</Tab>
-            </Tab.List>
-          </Tab.Group>
-        )
-
-        expect(getTabs()[0]).toHaveAttribute('type', 'submit')
-      })
-
-      it('should set the `type` to "button" when using the `as` prop which resolves to a "button"', async () => {
-        let CustomButton = React.forwardRef<HTMLButtonElement>((props, ref) => (
-          <button ref={ref} {...props} />
-        ))
-
-        render(
-          <Tab.Group>
-            <Tab.List>
-              <Tab as={CustomButton}>Trigger</Tab>
-            </Tab.List>
-          </Tab.Group>
-        )
-
-        expect(getTabs()[0]).toHaveAttribute('type', 'button')
-      })
-
-      it('should not set the type if the "as" prop is not a "button"', async () => {
-        render(
-          <Tab.Group>
-            <Tab.List>
-              <Tab as="div">Trigger</Tab>
-            </Tab.List>
-          </Tab.Group>
-        )
-
-        expect(getTabs()[0]).not.toHaveAttribute('type')
-      })
-
-      it('should not set the `type` to "button" when using the `as` prop which resolves to a "div"', async () => {
-        let CustomButton = React.forwardRef<HTMLDivElement>((props, ref) => (
-          <div ref={ref} {...props} />
-        ))
-
-        render(
-          <Tab.Group>
-            <Tab.List>
-              <Tab as={CustomButton}>Trigger</Tab>
-            </Tab.List>
-          </Tab.Group>
-        )
-
-        expect(getTabs()[0]).not.toHaveAttribute('type')
-      })
-    })
-  })
+  )
 })
 
-describe('Keyboard interactions', () => {
-  describe('`Tab` key', () => {
-    it('should be possible to tab to the default initial first tab', async () => {
-      render(
-        <>
-          <Tab.Group>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
+it(
+  'should trigger the `onChange` when the tab changes',
+  suppressConsoleLogs(async () => {
+    let changes = jest.fn()
 
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-
-      assertTabs({ active: 0 })
-      assertActiveElement(getByText('Tab 1'))
-
-      await press(Keys.Tab)
-      assertActiveElement(getByText('Content 1'))
-
-      await press(Keys.Tab)
-      assertActiveElement(getByText('after'))
-
-      await press(shift(Keys.Tab))
-      assertActiveElement(getByText('Content 1'))
-
-      await press(shift(Keys.Tab))
-      assertActiveElement(getByText('Tab 1'))
-    })
-
-    it('should be possible to tab to the default index tab', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={1}>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-
-      assertTabs({ active: 1 })
-      assertActiveElement(getByText('Tab 2'))
-
-      await press(Keys.Tab)
-      assertActiveElement(getByText('Content 2'))
-
-      await press(Keys.Tab)
-      assertActiveElement(getByText('after'))
-
-      await press(shift(Keys.Tab))
-      assertActiveElement(getByText('Content 2'))
-
-      await press(shift(Keys.Tab))
-      assertActiveElement(getByText('Tab 2'))
-    })
-  })
-
-  describe('`ArrowRight` key', () => {
-    it('should be possible to go to the next item (activation = `auto`)', async () => {
-      render(
-        <>
-          <Tab.Group>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 0 })
-
-      await press(Keys.ArrowRight)
-      assertTabs({ active: 1 })
-
-      await press(Keys.ArrowRight)
-      assertTabs({ active: 2 })
-    })
-
-    it('should be possible to go to the next item (activation = `manual`)', async () => {
-      render(
-        <>
-          <Tab.Group manual>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 0 })
-
-      await press(Keys.ArrowRight)
-      assertTabs({ active: 0 })
-      await press(Keys.Enter)
-      assertTabs({ active: 1 })
-
-      await press(Keys.ArrowRight)
-      assertTabs({ active: 1 })
-      await press(Keys.Enter)
-      assertTabs({ active: 2 })
-    })
-
-    it('should wrap around at the end (activation = `auto`)', async () => {
-      render(
-        <>
-          <Tab.Group>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 0 })
-
-      await press(Keys.ArrowRight)
-      assertTabs({ active: 1 })
-
-      await press(Keys.ArrowRight)
-      assertTabs({ active: 2 })
-
-      await press(Keys.ArrowRight)
-      assertTabs({ active: 0 })
-
-      await press(Keys.ArrowRight)
-      assertTabs({ active: 1 })
-    })
-
-    it('should wrap around at the end (activation = `manual`)', async () => {
-      render(
-        <>
-          <Tab.Group manual>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 0 })
-
-      await press(Keys.ArrowRight)
-      assertTabs({ active: 0 })
-      await press(Keys.Enter)
-      assertTabs({ active: 1 })
-
-      await press(Keys.ArrowRight)
-      assertTabs({ active: 1 })
-      await press(Keys.Enter)
-      assertTabs({ active: 2 })
-
-      await press(Keys.ArrowRight)
-      assertTabs({ active: 2 })
-      await press(Keys.Enter)
-      assertTabs({ active: 0 })
-
-      await press(Keys.ArrowRight)
-      assertTabs({ active: 0 })
-      await press(Keys.Enter)
-      assertTabs({ active: 1 })
-    })
-
-    it('should not be possible to go right when in vertical mode (activation = `auto`)', async () => {
-      render(
-        <>
-          <Tab.Group vertical>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 0, orientation: 'vertical' })
-
-      await press(Keys.ArrowRight)
-      // no-op
-      assertTabs({ active: 0, orientation: 'vertical' })
-    })
-
-    it('should not be possible to go right when in vertical mode (activation = `manual`)', async () => {
-      render(
-        <>
-          <Tab.Group vertical manual>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 0, orientation: 'vertical' })
-
-      await press(Keys.ArrowRight)
-      assertTabs({ active: 0, orientation: 'vertical' })
-      await press(Keys.Enter)
-      // no-op
-      assertTabs({ active: 0, orientation: 'vertical' })
-    })
-  })
-
-  describe('`ArrowLeft` key', () => {
-    it('should be possible to go to the previous item (activation = `auto`)', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={2}>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 2 })
-
-      await press(Keys.ArrowLeft)
-      assertTabs({ active: 1 })
-
-      await press(Keys.ArrowLeft)
-      assertTabs({ active: 0 })
-    })
-
-    it('should be possible to go to the previous item (activation = `manual`)', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={2} manual>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 2 })
-
-      await press(Keys.ArrowLeft)
-      assertTabs({ active: 2 })
-      await press(Keys.Enter)
-      assertTabs({ active: 1 })
-
-      await press(Keys.ArrowLeft)
-      assertTabs({ active: 1 })
-      await press(Keys.Enter)
-      assertTabs({ active: 0 })
-    })
-
-    it('should wrap around at the beginning (activation = `auto`)', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={2}>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 2 })
-
-      await press(Keys.ArrowLeft)
-      assertTabs({ active: 1 })
-
-      await press(Keys.ArrowLeft)
-      assertTabs({ active: 0 })
-
-      await press(Keys.ArrowLeft)
-      assertTabs({ active: 2 })
-
-      await press(Keys.ArrowLeft)
-      assertTabs({ active: 1 })
-    })
-
-    it('should wrap around at the beginning (activation = `manual`)', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={2} manual>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 2 })
-
-      await press(Keys.ArrowLeft)
-      assertTabs({ active: 2 })
-      await press(Keys.Enter)
-      assertTabs({ active: 1 })
-
-      await press(Keys.ArrowLeft)
-      assertTabs({ active: 1 })
-      await press(Keys.Enter)
-      assertTabs({ active: 0 })
-
-      await press(Keys.ArrowLeft)
-      assertTabs({ active: 0 })
-      await press(Keys.Enter)
-      assertTabs({ active: 2 })
-
-      await press(Keys.ArrowLeft)
-      assertTabs({ active: 2 })
-      await press(Keys.Enter)
-      assertTabs({ active: 1 })
-    })
-
-    it('should not be possible to go left when in vertical mode (activation = `auto`)', async () => {
-      render(
-        <>
-          <Tab.Group vertical>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 0, orientation: 'vertical' })
-
-      await press(Keys.ArrowLeft)
-      // no-op
-      assertTabs({ active: 0, orientation: 'vertical' })
-    })
-
-    it('should not be possible to go left when in vertical mode (activation = `manual`)', async () => {
-      render(
-        <>
-          <Tab.Group vertical manual>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 0, orientation: 'vertical' })
-
-      await press(Keys.ArrowLeft)
-      assertTabs({ active: 0, orientation: 'vertical' })
-      await press(Keys.Enter)
-
-      // no-op
-      assertTabs({ active: 0, orientation: 'vertical' })
-    })
-  })
-
-  describe('`ArrowDown` key', () => {
-    it('should be possible to go to the next item (activation = `auto`)', async () => {
-      render(
-        <>
-          <Tab.Group vertical>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 0, orientation: 'vertical' })
-
-      await press(Keys.ArrowDown)
-      assertTabs({ active: 1, orientation: 'vertical' })
-
-      await press(Keys.ArrowDown)
-      assertTabs({ active: 2, orientation: 'vertical' })
-    })
-
-    it('should be possible to go to the next item (activation = `manual`)', async () => {
-      render(
-        <>
-          <Tab.Group vertical manual>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 0, orientation: 'vertical' })
-
-      await press(Keys.ArrowDown)
-      assertTabs({ active: 0, orientation: 'vertical' })
-      await press(Keys.Enter)
-      assertTabs({ active: 1, orientation: 'vertical' })
-
-      await press(Keys.ArrowDown)
-      assertTabs({ active: 1, orientation: 'vertical' })
-      await press(Keys.Enter)
-      assertTabs({ active: 2, orientation: 'vertical' })
-    })
-
-    it('should wrap around at the end (activation = `auto`)', async () => {
-      render(
-        <>
-          <Tab.Group vertical>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 0, orientation: 'vertical' })
-
-      await press(Keys.ArrowDown)
-      assertTabs({ active: 1, orientation: 'vertical' })
-
-      await press(Keys.ArrowDown)
-      assertTabs({ active: 2, orientation: 'vertical' })
-
-      await press(Keys.ArrowDown)
-      assertTabs({ active: 0, orientation: 'vertical' })
-
-      await press(Keys.ArrowDown)
-      assertTabs({ active: 1, orientation: 'vertical' })
-    })
-
-    it('should wrap around at the end (activation = `manual`)', async () => {
-      render(
-        <>
-          <Tab.Group vertical manual>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 0, orientation: 'vertical' })
-
-      await press(Keys.ArrowDown)
-      assertTabs({ active: 0, orientation: 'vertical' })
-      await press(Keys.Enter)
-      assertTabs({ active: 1, orientation: 'vertical' })
-
-      await press(Keys.ArrowDown)
-      assertTabs({ active: 1, orientation: 'vertical' })
-      await press(Keys.Enter)
-      assertTabs({ active: 2, orientation: 'vertical' })
-
-      await press(Keys.ArrowDown)
-      assertTabs({ active: 2, orientation: 'vertical' })
-      await press(Keys.Enter)
-      assertTabs({ active: 0, orientation: 'vertical' })
-
-      await press(Keys.ArrowDown)
-      assertTabs({ active: 0, orientation: 'vertical' })
-      await press(Keys.Enter)
-      assertTabs({ active: 1, orientation: 'vertical' })
-    })
-
-    it('should not be possible to go down when in horizontal mode (activation = `auto`)', async () => {
-      render(
-        <>
-          <Tab.Group>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 0 })
-
-      await press(Keys.ArrowDown)
-      // no-op
-      assertTabs({ active: 0 })
-    })
-
-    it('should not be possible to go down when in horizontal mode (activation = `manual`)', async () => {
-      render(
-        <>
-          <Tab.Group manual>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 0 })
-
-      await press(Keys.ArrowDown)
-      assertTabs({ active: 0 })
-      await press(Keys.Enter)
-
-      // no-op
-      assertTabs({ active: 0 })
-    })
-  })
-
-  describe('`ArrowUp` key', () => {
-    it('should be possible to go to the previous item (activation = `auto`)', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={2} vertical>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 2, orientation: 'vertical' })
-
-      await press(Keys.ArrowUp)
-      assertTabs({ active: 1, orientation: 'vertical' })
-
-      await press(Keys.ArrowUp)
-      assertTabs({ active: 0, orientation: 'vertical' })
-    })
-
-    it('should be possible to go to the previous item (activation = `manual`)', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={2} vertical manual>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 2, orientation: 'vertical' })
-
-      await press(Keys.ArrowUp)
-      assertTabs({ active: 2, orientation: 'vertical' })
-      await press(Keys.Enter)
-      assertTabs({ active: 1, orientation: 'vertical' })
-
-      await press(Keys.ArrowUp)
-      assertTabs({ active: 1, orientation: 'vertical' })
-      await press(Keys.Enter)
-      assertTabs({ active: 0, orientation: 'vertical' })
-    })
-
-    it('should wrap around at the beginning (activation = `auto`)', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={2} vertical>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 2, orientation: 'vertical' })
-
-      await press(Keys.ArrowUp)
-      assertTabs({ active: 1, orientation: 'vertical' })
-
-      await press(Keys.ArrowUp)
-      assertTabs({ active: 0, orientation: 'vertical' })
-
-      await press(Keys.ArrowUp)
-      assertTabs({ active: 2, orientation: 'vertical' })
-
-      await press(Keys.ArrowUp)
-      assertTabs({ active: 1, orientation: 'vertical' })
-    })
-
-    it('should wrap around at the beginning (activation = `manual`)', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={2} vertical manual>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 2, orientation: 'vertical' })
-
-      await press(Keys.ArrowUp)
-      assertTabs({ active: 2, orientation: 'vertical' })
-      await press(Keys.Enter)
-      assertTabs({ active: 1, orientation: 'vertical' })
-
-      await press(Keys.ArrowUp)
-      assertTabs({ active: 1, orientation: 'vertical' })
-      await press(Keys.Enter)
-      assertTabs({ active: 0, orientation: 'vertical' })
-
-      await press(Keys.ArrowUp)
-      assertTabs({ active: 0, orientation: 'vertical' })
-      await press(Keys.Enter)
-      assertTabs({ active: 2, orientation: 'vertical' })
-
-      await press(Keys.ArrowUp)
-      assertTabs({ active: 2, orientation: 'vertical' })
-      await press(Keys.Enter)
-      assertTabs({ active: 1, orientation: 'vertical' })
-    })
-
-    it('should not be possible to go left when in vertical mode (activation = `auto`)', async () => {
-      render(
-        <>
-          <Tab.Group>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 0 })
-
-      await press(Keys.ArrowUp)
-      // no-op
-      assertTabs({ active: 0 })
-    })
-
-    it('should not be possible to go left when in vertical mode (activation = `manual`)', async () => {
-      render(
-        <>
-          <Tab.Group manual>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 0 })
-
-      await press(Keys.ArrowUp)
-      assertTabs({ active: 0 })
-      await press(Keys.Enter)
-
-      // no-op
-      assertTabs({ active: 0 })
-    })
-  })
-
-  describe('`Home` key', () => {
-    it('should be possible to go to the first focusable item (activation = `auto`)', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={1}>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 1 })
-
-      await press(Keys.Home)
-      assertTabs({ active: 0 })
-    })
-
-    it('should be possible to go to the first focusable item (activation = `manual`)', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={1} manual>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 1 })
-
-      await press(Keys.Home)
-      assertTabs({ active: 1 })
-      await press(Keys.Enter)
-      assertTabs({ active: 0 })
-    })
-  })
-
-  describe('`PageUp` key', () => {
-    it('should be possible to go to the first focusable item (activation = `auto`)', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={1}>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 1 })
-
-      await press(Keys.PageUp)
-      assertTabs({ active: 0 })
-    })
-
-    it('should be possible to go to the first focusable item (activation = `manual`)', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={1} manual>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 1 })
-
-      await press(Keys.PageUp)
-      assertTabs({ active: 1 })
-      await press(Keys.Enter)
-      assertTabs({ active: 0 })
-    })
-  })
-
-  describe('`End` key', () => {
-    it('should be possible to go to the first focusable item (activation = `auto`)', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={1}>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 1 })
-
-      await press(Keys.End)
-      assertTabs({ active: 2 })
-    })
-
-    it('should be possible to go to the first focusable item (activation = `manual`)', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={1} manual>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 1 })
-
-      await press(Keys.End)
-      assertTabs({ active: 1 })
-      await press(Keys.Enter)
-      assertTabs({ active: 2 })
-    })
-  })
-
-  describe('`PageDown` key', () => {
-    it('should be possible to go to the first focusable item (activation = `auto`)', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={1}>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 1 })
-
-      await press(Keys.PageDown)
-      assertTabs({ active: 2 })
-    })
-
-    it('should be possible to go to the first focusable item (activation = `manual`)', async () => {
-      render(
-        <>
-          <Tab.Group defaultIndex={1} manual>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      await press(Keys.Tab)
-      assertTabs({ active: 1 })
-
-      await press(Keys.PageDown)
-      assertTabs({ active: 1 })
-      await press(Keys.Enter)
-      assertTabs({ active: 2 })
-    })
-  })
-
-  describe('`Enter` key', () => {
-    it('should be possible to activate the focused tab', async () => {
-      render(
-        <>
-          <Tab.Group manual>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      getByText('Tab 3')?.focus()
-
-      assertActiveElement(getByText('Tab 3'))
-      assertTabs({ active: 0 })
-
-      await press(Keys.Enter)
-      assertTabs({ active: 2 })
-    })
-  })
-
-  describe('`Space` key', () => {
-    it('should be possible to activate the focused tab', async () => {
-      render(
-        <>
-          <Tab.Group manual>
-            <Tab.List>
-              <Tab>Tab 1</Tab>
-              <Tab>Tab 2</Tab>
-              <Tab>Tab 3</Tab>
-            </Tab.List>
-
-            <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>Content 2</Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
-            </Tab.Panels>
-          </Tab.Group>
-
-          <button>after</button>
-        </>
-      )
-
-      assertActiveElement(document.body)
-
-      getByText('Tab 3')?.focus()
-
-      assertActiveElement(getByText('Tab 3'))
-      assertTabs({ active: 0 })
-
-      await press(Keys.Space)
-      assertTabs({ active: 2 })
-    })
-  })
-})
-
-describe('Mouse interactions', () => {
-  it('should be possible to click on a tab to focus it', async () => {
     render(
       <>
-        <Tab.Group defaultIndex={1}>
+        <Tab.Group onChange={changes}>
           <Tab.List>
             <Tab>Tab 1</Tab>
             <Tab>Tab 2</Tab>
@@ -2101,83 +2357,16 @@ describe('Mouse interactions', () => {
       </>
     )
 
-    assertActiveElement(document.body)
-    await press(Keys.Tab)
-    assertTabs({ active: 1 })
-
-    await click(getByText('Tab 1'))
-    assertTabs({ active: 0 })
-
-    await click(getByText('Tab 3'))
-    assertTabs({ active: 2 })
-
     await click(getByText('Tab 2'))
-    assertTabs({ active: 1 })
-  })
-
-  it('should be a no-op when clicking on a disabled tab', async () => {
-    render(
-      <>
-        <Tab.Group defaultIndex={1}>
-          <Tab.List>
-            <Tab disabled>Tab 1</Tab>
-            <Tab>Tab 2</Tab>
-            <Tab>Tab 3</Tab>
-          </Tab.List>
-
-          <Tab.Panels>
-            <Tab.Panel>Content 1</Tab.Panel>
-            <Tab.Panel>Content 2</Tab.Panel>
-            <Tab.Panel>Content 3</Tab.Panel>
-          </Tab.Panels>
-        </Tab.Group>
-
-        <button>after</button>
-      </>
-    )
-
-    assertActiveElement(document.body)
-    await press(Keys.Tab)
-    assertTabs({ active: 1 })
-
+    await click(getByText('Tab 3'))
+    await click(getByText('Tab 2'))
     await click(getByText('Tab 1'))
-    // No-op, Tab 2 is still active
-    assertTabs({ active: 1 })
+
+    expect(changes).toHaveBeenCalledTimes(4)
+
+    expect(changes).toHaveBeenNthCalledWith(1, 1)
+    expect(changes).toHaveBeenNthCalledWith(2, 2)
+    expect(changes).toHaveBeenNthCalledWith(3, 1)
+    expect(changes).toHaveBeenNthCalledWith(4, 0)
   })
-})
-
-it('should trigger the `onChange` when the tab changes', async () => {
-  let changes = jest.fn()
-
-  render(
-    <>
-      <Tab.Group onChange={changes}>
-        <Tab.List>
-          <Tab>Tab 1</Tab>
-          <Tab>Tab 2</Tab>
-          <Tab>Tab 3</Tab>
-        </Tab.List>
-
-        <Tab.Panels>
-          <Tab.Panel>Content 1</Tab.Panel>
-          <Tab.Panel>Content 2</Tab.Panel>
-          <Tab.Panel>Content 3</Tab.Panel>
-        </Tab.Panels>
-      </Tab.Group>
-
-      <button>after</button>
-    </>
-  )
-
-  await click(getByText('Tab 2'))
-  await click(getByText('Tab 3'))
-  await click(getByText('Tab 2'))
-  await click(getByText('Tab 1'))
-
-  expect(changes).toHaveBeenCalledTimes(4)
-
-  expect(changes).toHaveBeenNthCalledWith(1, 1)
-  expect(changes).toHaveBeenNthCalledWith(2, 2)
-  expect(changes).toHaveBeenNthCalledWith(3, 1)
-  expect(changes).toHaveBeenNthCalledWith(4, 0)
-})
+)

--- a/packages/@headlessui-react/src/components/tabs/tabs.tsx
+++ b/packages/@headlessui-react/src/components/tabs/tabs.tsx
@@ -28,6 +28,7 @@ import { useIsoMorphicEffect } from '../../hooks/use-iso-morphic-effect'
 import { useSyncRefs } from '../../hooks/use-sync-refs'
 import { useResolveButtonType } from '../../hooks/use-resolve-button-type'
 import { useLatestValue } from '../../hooks/use-latest-value'
+import { FocusSentinel } from '../../internal/focus-sentinel'
 
 interface StateDefinition {
   selectedIndex: number | null
@@ -160,6 +161,7 @@ let Tabs = forwardRefWithAs(function Tabs<TTag extends ElementType = typeof DEFA
   } as StateDefinition)
   let slot = useMemo(() => ({ selectedIndex: state.selectedIndex }), [state.selectedIndex])
   let onChangeRef = useLatestValue(onChange || (() => {}))
+  let stableTabsRef = useLatestValue(state.tabs)
 
   useEffect(() => {
     dispatch({ type: ActionTypes.SetOrientation, orientation })
@@ -229,6 +231,18 @@ let Tabs = forwardRefWithAs(function Tabs<TTag extends ElementType = typeof DEFA
   return (
     <TabsSSRContext.Provider value={typeof window === 'undefined' ? SSRCounter : null}>
       <TabsContext.Provider value={providerBag}>
+        <FocusSentinel
+          onFocus={() => {
+            for (let tab of stableTabsRef.current) {
+              if (tab.current?.tabIndex === 0) {
+                tab.current?.focus()
+                return true
+              }
+            }
+
+            return false
+          }}
+        />
         {render({
           props: { ref: tabsRef, ...passThroughProps },
           slot,

--- a/packages/@headlessui-react/src/components/tabs/tabs.tsx
+++ b/packages/@headlessui-react/src/components/tabs/tabs.tsx
@@ -169,7 +169,7 @@ let Tabs = forwardRefWithAs(function Tabs<TTag extends ElementType = typeof DEFA
     dispatch({ type: ActionTypes.SetActivation, activation })
   }, [activation])
 
-  useEffect(() => {
+  useIsoMorphicEffect(() => {
     if (state.tabs.length <= 0) return
     if (selectedIndex === null && state.selectedIndex !== null) return
 

--- a/packages/@headlessui-react/src/internal/focus-sentinel.tsx
+++ b/packages/@headlessui-react/src/internal/focus-sentinel.tsx
@@ -1,0 +1,46 @@
+import React, { useState, FocusEvent as ReactFocusEvent } from 'react'
+
+import { VisuallyHidden } from './visually-hidden'
+
+interface FocusSentinelProps {
+  onFocus(): boolean
+}
+
+export function FocusSentinel({ onFocus }: FocusSentinelProps) {
+  let [enabled, setEnabled] = useState(true)
+
+  if (!enabled) return null
+
+  return (
+    <VisuallyHidden
+      as="button"
+      type="button"
+      onFocus={(event: ReactFocusEvent) => {
+        event.preventDefault()
+        let frame: ReturnType<typeof requestAnimationFrame>
+
+        let tries = 50
+        function forwardFocus() {
+          // Prevent infinite loops
+          if (tries-- <= 0) {
+            if (frame) cancelAnimationFrame(frame)
+            return
+          }
+
+          // Try to move focus to the correct element. This depends on the implementation
+          // of `onFocus` of course since it would be different for each place we use it in.
+          if (onFocus()) {
+            setEnabled(false)
+            cancelAnimationFrame(frame)
+            return
+          }
+
+          // Retry
+          frame = requestAnimationFrame(forwardFocus)
+        }
+
+        frame = requestAnimationFrame(forwardFocus)
+      }}
+    />
+  )
+}

--- a/packages/@headlessui-vue/src/components/tabs/tabs.ts
+++ b/packages/@headlessui-vue/src/components/tabs/tabs.ts
@@ -1,14 +1,18 @@
 import {
+  Fragment,
+  computed,
   defineComponent,
-  ref,
-  provide,
+  h,
   inject,
   onMounted,
   onUnmounted,
-  computed,
+  provide,
+  ref,
+  watchEffect,
+
+  // Types
   InjectionKey,
   Ref,
-  watchEffect,
 } from 'vue'
 
 import { Features, render, omit } from '../../utils/render'
@@ -18,6 +22,7 @@ import { dom } from '../../utils/dom'
 import { match } from '../../utils/match'
 import { focusIn, Focus } from '../../utils/focus-management'
 import { useResolveButtonType } from '../../hooks/use-resolve-button-type'
+import { FocusSentinel } from '../../internal/focus-sentinel'
 
 type StateDefinition = {
   // State
@@ -132,13 +137,28 @@ export let TabGroup = defineComponent({
     return () => {
       let slot = { selectedIndex: selectedIndex.value }
 
-      return render({
-        props: omit(props, ['selectedIndex', 'defaultIndex', 'manual', 'vertical', 'onChange']),
-        slot,
-        slots,
-        attrs,
-        name: 'TabGroup',
-      })
+      return h(Fragment, [
+        h(FocusSentinel, {
+          onFocus: () => {
+            for (let tab of tabs.value) {
+              let el = dom(tab)
+              if (el?.tabIndex === 0) {
+                el.focus()
+                return true
+              }
+            }
+
+            return false
+          },
+        }),
+        render({
+          props: omit(props, ['selectedIndex', 'defaultIndex', 'manual', 'vertical', 'onChange']),
+          slot,
+          slots,
+          attrs,
+          name: 'TabGroup',
+        }),
+      ])
     }
   },
 })

--- a/packages/@headlessui-vue/src/internal/focus-sentinel.ts
+++ b/packages/@headlessui-vue/src/internal/focus-sentinel.ts
@@ -1,0 +1,50 @@
+import { h, ref, defineComponent } from 'vue'
+
+import { VisuallyHidden } from './visually-hidden'
+
+export let FocusSentinel = defineComponent({
+  props: {
+    onFocus: {
+      type: Function,
+      required: true,
+    },
+  },
+  setup(props) {
+    let enabled = ref(true)
+
+    return () => {
+      if (!enabled.value) return null
+
+      return h(VisuallyHidden, {
+        as: 'button',
+        type: 'button',
+        onFocus(event: FocusEvent) {
+          event.preventDefault()
+          let frame: ReturnType<typeof requestAnimationFrame>
+
+          let tries = 50
+          function forwardFocus() {
+            // Prevent infinite loops
+            if (tries-- <= 0) {
+              if (frame) cancelAnimationFrame(frame)
+              return
+            }
+
+            // Try to move focus to the correct element. This depends on the implementation
+            // of `onFocus` of course since it would be different for each place we use it in.
+            if (props.onFocus()) {
+              enabled.value = false
+              cancelAnimationFrame(frame)
+              return
+            }
+
+            // Retry
+            frame = requestAnimationFrame(forwardFocus)
+          }
+
+          frame = requestAnimationFrame(forwardFocus)
+        },
+      })
+    }
+  },
+})

--- a/packages/playground-react/pages/combinations/tabs-in-dialog.tsx
+++ b/packages/playground-react/pages/combinations/tabs-in-dialog.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react'
+import { Dialog, Tab } from '@headlessui/react'
+
+export default function App() {
+  let [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open dialog</button>
+      <Dialog open={open} onClose={setOpen} className="fixed inset-0 grid place-content-center">
+        <Dialog.Overlay className="fixed inset-0 bg-gray-500/70" />
+        <div className="inline-block transform overflow-hidden rounded-lg bg-white text-left align-bottom shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:align-middle">
+          <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+            <Tab.Group>
+              <Tab.List>
+                <Tab className="px-3 py-2">Tab 1</Tab>
+                <Tab className="px-3 py-2">Tab 2</Tab>
+                <Tab className="px-3 py-2">Tab 3</Tab>
+              </Tab.List>
+              <Tab.Panels>
+                <Tab.Panel className="px-3 py-2">Panel 1</Tab.Panel>
+                <Tab.Panel className="px-3 py-2">Panel 2</Tab.Panel>
+                <Tab.Panel className="px-3 py-2">Panel 3</Tab.Panel>
+              </Tab.Panels>
+            </Tab.Group>
+          </div>
+        </div>
+      </Dialog>
+    </>
+  )
+}

--- a/packages/playground-vue/src/components/combinations/tabs-in-dialog.vue
+++ b/packages/playground-vue/src/components/combinations/tabs-in-dialog.vue
@@ -1,0 +1,31 @@
+<template>
+  <button @click="open = true">Open dialog</button>
+  <Dialog :open="open" @close="open = false" class="fixed inset-0 grid place-content-center">
+    <DialogOverlay class="fixed inset-0 bg-gray-500/70" />
+    <div
+      class="inline-block transform overflow-hidden rounded-lg bg-white text-left align-bottom shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:align-middle"
+    >
+      <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+        <TabGroup>
+          <TabList>
+            <Tab class="px-3 py-2">Tab 1</Tab>
+            <Tab class="px-3 py-2">Tab 2</Tab>
+            <Tab class="px-3 py-2">Tab 3</Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel class="px-3 py-2">Panel 1</TabPanel>
+            <TabPanel class="px-3 py-2">Panel 2</TabPanel>
+            <TabPanel class="px-3 py-2">Panel 3</TabPanel>
+          </TabPanels>
+        </TabGroup>
+      </div>
+    </div>
+  </Dialog>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { Dialog, DialogOverlay, TabGroup, TabList, Tab, TabPanels, TabPanel } from '@headlessui/vue'
+
+let open = ref(false)
+</script>

--- a/packages/playground-vue/src/routes.json
+++ b/packages/playground-vue/src/routes.json
@@ -4,6 +4,17 @@
     "component": "./components/Home.vue"
   },
   {
+    "name": "Combinations",
+    "path": "/combinations",
+    "children": [
+      {
+        "name": "Tabs in Dialog",
+        "path": "/combinations/tabs-in-dialog",
+        "component": "./components/combinations/tabs-in-dialog.vue"
+      }
+    ]
+  },
+  {
     "name": "Combobox",
     "path": "/combobox",
     "children": [


### PR DESCRIPTION
When you render `Tabs` inside a `Dialog` then you will receive a warning like this: `There are no focusable elements inside the <FocusTrap />`
This is because the `Dialog` uses a `FocusTrap`, and the selected `Tab` registers itself in a next tick so it is not immediately in the DOM.


This PR fixes that so that they all play well together.

Fixes: #771

