### PR TITLE
Fix false no focuable message

### DIFF
--- a/packages/@headlessui-react/src/utils/focus-management.ts
+++ b/packages/@headlessui-react/src/utils/focus-management.ts
@@ -149,7 +149,7 @@ export function focusIn(container: HTMLElement | HTMLElement[], focus: Focus) {
   let next = undefined
   do {
     // Guard against infinite loops
-    if (offset >= total || offset + total <= 0) return FocusResult.Error
+    if (offset > total || offset + total <= 0) return FocusResult.Error
 
     let nextIdx = startIndex + offset
 


### PR DESCRIPTION
Related to #1199 when opening nested dialogs in headless react, no focusable element warning was being logged to console even if there are focusable elements in the dialog. Checked on a Vue project and the same issue was not present in that package, so the fix only needs to be applied in react package.
This fix also works for any number of nested dialogs.