### PR TITLE
Fix incorrect `active` option in the Listbox/Combobox component

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -4057,7 +4057,7 @@ describe('Mouse interactions', () => {
     'should be possible to mouse leave an option and make it inactive',
     suppressConsoleLogs(async () => {
       render(
-        <Combobox value="test" onChange={console.log}>
+        <Combobox value="bob" onChange={console.log}>
           <Combobox.Input onChange={NOOP} />
           <Combobox.Button>Trigger</Combobox.Button>
           <Combobox.Options>

--- a/packages/@headlessui-react/src/components/listbox/listbox.test.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.test.tsx
@@ -3723,7 +3723,7 @@ describe('Mouse interactions', () => {
     'should be possible to mouse leave an option and make it inactive',
     suppressConsoleLogs(async () => {
       render(
-        <Listbox value={undefined} onChange={console.log}>
+        <Listbox value="bob" onChange={console.log}>
           <Listbox.Button>Trigger</Listbox.Button>
           <Listbox.Options>
             <Listbox.Option value="alice">alice</Listbox.Option>

--- a/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
@@ -4302,7 +4302,7 @@ describe('Mouse interactions', () => {
             </ComboboxOptions>
           </Combobox>
         `,
-        setup: () => ({ value: ref(null) }),
+        setup: () => ({ value: ref('bob') }),
       })
 
       // Open combobox

--- a/packages/@headlessui-vue/src/components/listbox/listbox.test.tsx
+++ b/packages/@headlessui-vue/src/components/listbox/listbox.test.tsx
@@ -3862,7 +3862,7 @@ describe('Mouse interactions', () => {
             </ListboxOptions>
           </Listbox>
         `,
-        setup: () => ({ value: ref(null) }),
+        setup: () => ({ value: ref('bob') }),
       })
 
       // Open listbox


### PR DESCRIPTION
This pr fixes an incorrect `active` option

The React code had a bug in the Listbox and Combobox components where it incorrectly made the first selected value the active value.

The first selected option should be the active option when you open the listbox. However when you already had the component in an `open` state, hovered over a non-selected item and them left the option by moving it to the body then the first selected option became the active one again.

This made sense because we used a `useEffect` in each option to make it the active one if it was also selected. Since every component re-renders, code got called and the bug arises.

Now, instead we moved the logic to make it the active option to the reducer logic. We will check it when we register an option and doesn't have an active option index yet or when we open the Listbox/Combobox.

This should also solve the strange scrolling behaviour where the options scroll up if you have more options than you display.
