### PR TITLE
Fix incorrect closing while interacting with third party libraries in `Dialog` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stop propagation on the Popover Button ([#1263](https://github.com/tailwindlabs/headlessui/pull/1263))
 - Fix incorrect `active` option in the Listbox/Combobox component ([#1264](https://github.com/tailwindlabs/headlessui/pull/1264))
 - Properly merge incoming props ([#1265](https://github.com/tailwindlabs/headlessui/pull/1265))
+- Fix incorrect closing while interacting with third party libraries in `Dialog` component ([#1268](https://github.com/tailwindlabs/headlessui/pull/1268))
 
 ### Added
 
@@ -64,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve Combobox Input value ([#1248](https://github.com/tailwindlabs/headlessui/pull/1248))
 - Fix Tree-shaking support ([#1247](https://github.com/tailwindlabs/headlessui/pull/1247))
 - Stop propagation on the Popover Button ([#1263](https://github.com/tailwindlabs/headlessui/pull/1263))
+- Fix incorrect closing while interacting with third party libraries in `Dialog` component ([#1268](https://github.com/tailwindlabs/headlessui/pull/1268))
 
 ### Added
 

--- a/packages/@headlessui-react/src/hooks/use-focus-trap.ts
+++ b/packages/@headlessui-react/src/hooks/use-focus-trap.ts
@@ -152,6 +152,8 @@ export function useFocusTrap(
     },
     true
   )
+
+  return restoreElement
 }
 
 function contains(containers: Set<MutableRefObject<HTMLElement | null>>, element: HTMLElement) {

--- a/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
@@ -1035,6 +1035,59 @@ describe('Mouse interactions', () => {
       assertDialog({ state: DialogState.Visible })
     })
   )
+
+  it(
+    'should be possible to click on elements created by third party libraries',
+    suppressConsoleLogs(async () => {
+      let fn = jest.fn()
+
+      let ThirdPartyLibrary = defineComponent({
+        template: html`
+          <teleport to="body">
+            <button data-lib @click="fn">3rd party button</button>
+          </teleport>
+        `,
+        setup: () => ({ fn }),
+      })
+
+      renderTemplate({
+        components: { ThirdPartyLibrary },
+        template: `
+          <div>
+            <span>Main app</span>
+            <Dialog :open="isOpen" @close="setIsOpen">
+              <div>
+                Contents
+                <TabSentinel />
+              </div>
+            </Dialog>
+            <ThirdPartyLibrary />
+          </div>
+        `,
+        setup() {
+          let isOpen = ref(true)
+          return {
+            isOpen,
+            setIsOpen(value: boolean) {
+              isOpen.value = value
+            },
+          }
+        },
+      })
+
+      // Verify it is open
+      assertDialog({ state: DialogState.Visible })
+
+      // Click the button inside the 3rd party library
+      await click(document.querySelector('[data-lib]'))
+
+      // Verify we clicked on the 3rd party button
+      expect(fn).toHaveBeenCalledTimes(1)
+
+      // Verify the dialog is still open
+      assertDialog({ state: DialogState.Visible })
+    })
+  )
 })
 
 describe('Nesting', () => {

--- a/packages/@headlessui-vue/src/hooks/use-focus-trap.ts
+++ b/packages/@headlessui-vue/src/hooks/use-focus-trap.ts
@@ -175,6 +175,8 @@ export function useFocusTrap(
     },
     true
   )
+
+  return restoreElement
 }
 
 function contains(containers: Set<Ref<HTMLElement | null>>, element: HTMLElement) {

--- a/packages/@headlessui-vue/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-vue/src/hooks/use-outside-click.ts
@@ -17,12 +17,12 @@ function microTask(cb: () => void) {
   }
 }
 
+type Container = Ref<HTMLElement | null> | HTMLElement | null
+type ContainerCollection = Container[] | Set<Container>
+type ContainerInput = Container | ContainerCollection
+
 export function useOutsideClick(
-  containers:
-    | HTMLElement
-    | Ref<HTMLElement | null>
-    | (Ref<HTMLElement | null> | HTMLElement | null)[]
-    | Set<HTMLElement>,
+  containers: ContainerInput | (() => ContainerInput),
   cb: (event: MouseEvent | PointerEvent, target: HTMLElement) => void
 ) {
   let called = false
@@ -38,7 +38,11 @@ export function useOutsideClick(
     // Ignore if the target doesn't exist in the DOM anymore
     if (!target.ownerDocument.documentElement.contains(target)) return
 
-    let _containers = (() => {
+    let _containers = (function resolve(containers): ContainerCollection {
+      if (typeof containers === 'function') {
+        return resolve(containers())
+      }
+
       if (Array.isArray(containers)) {
         return containers
       }
@@ -48,7 +52,7 @@ export function useOutsideClick(
       }
 
       return [containers]
-    })()
+    })(containers)
 
     // Ignore if the target exists in one of the containers
     for (let container of _containers) {

--- a/packages/playground-react/package.json
+++ b/packages/playground-react/package.json
@@ -17,6 +17,7 @@
     "framer-motion": "^6.0.0",
     "next": "^12.0.8",
     "react": "16.14.0",
-    "react-dom": "16.14.0"
+    "react-dom": "16.14.0",
+    "react-flatpickr": "^3.10.9"
   }
 }

--- a/packages/playground-react/pages/dialog/dialog.tsx
+++ b/packages/playground-react/pages/dialog/dialog.tsx
@@ -1,7 +1,10 @@
 import React, { useState, Fragment } from 'react'
+import Flatpickr from 'react-flatpickr'
 import { Dialog, Menu, Portal, Transition } from '@headlessui/react'
 import { usePopper } from '../../utils/hooks/use-popper'
 import { classNames } from '../../utils/class-names'
+
+import 'flatpickr/dist/themes/light.css'
 
 function resolveClass({ active, disabled }) {
   return classNames(
@@ -52,6 +55,8 @@ export default function Home() {
     strategy: 'fixed',
     modifiers: [{ name: 'offset', options: { offset: [0, 10] } }],
   })
+
+  let [date, setDate] = useState(new Date())
 
   return (
     <>
@@ -207,6 +212,7 @@ export default function Home() {
                               </Transition>
                             </Menu>
                           </div>
+                          <Flatpickr value={date} onChange={([date]) => setDate(date)} />
                         </div>
                       </div>
                     </div>

--- a/packages/playground-vue/package.json
+++ b/packages/playground-vue/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@headlessui/vue": "*",
     "vue": "^3.2.27",
+    "vue-flatpickr-component": "^9.0.5",
     "vue-router": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/playground-vue/src/components/dialog/dialog.vue
+++ b/packages/playground-vue/src/components/dialog/dialog.vue
@@ -151,6 +151,7 @@
                           </TransitionRoot>
                         </Menu>
                       </div>
+                      <Flatpickr v-model="date" />
                     </div>
                   </div>
                 </div>
@@ -193,7 +194,10 @@ import {
   TransitionRoot,
   TransitionChild,
 } from '@headlessui/vue'
+import Flatpickr from 'vue-flatpickr-component'
 import { usePopper } from '../../playground-utils/hooks/use-popper'
+
+import 'flatpickr/dist/themes/light.css'
 
 function classNames(...classes) {
   return classes.filter(Boolean).join(' ')
@@ -269,6 +273,7 @@ export default {
     MenuItems,
     MenuItem,
     Portal,
+    Flatpickr,
     TransitionRoot,
     TransitionChild,
   },
@@ -280,9 +285,11 @@ export default {
       modifiers: [{ name: 'offset', options: { offset: [0, 10] } }],
     })
     let nested = ref(false)
+    let date = ref(new Date())
 
     return {
       nested,
+      date,
       isOpen,
       trigger,
       container,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2229,6 +2229,11 @@ find-versions@^4.0.0:
   dependencies:
     semver-regex "^3.1.2"
 
+flatpickr@^4.6.2, flatpickr@^4.6.9:
+  version "4.6.11"
+  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.6.11.tgz#c92f5108269c551c6b5069ecd754be610574574c"
+  integrity sha512-/rnbE/hu5I5zndLEyYfYvqE4vPDvI5At0lFcQA5eOPfjquZLcQ0HMKTL7rv5/+DvbPM3/vJcXpXjB/DjBh+1jw==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -4107,7 +4112,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2:
+prop-types@^15.5.10, prop-types@^15.6.2:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -4158,6 +4163,14 @@ react-dom@16.14.0, react-dom@^16.14.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.19.1"
+
+react-flatpickr@^3.10.9:
+  version "3.10.9"
+  resolved "https://registry.yarnpkg.com/react-flatpickr/-/react-flatpickr-3.10.9.tgz#88cf987b58e9502593a9e478d5e77eaa94d4ec53"
+  integrity sha512-n151Q1eXeQ8vycz7rTDaZy4VApbcNz5BUtj9exlkSft1JSSGlzzcPXrjdF3CUhnftRvE0LYV51drkonkjVogBQ==
+  dependencies:
+    flatpickr "^4.6.2"
+    prop-types "^15.5.10"
 
 react-is@^16.13.1:
   version "16.13.1"
@@ -5039,6 +5052,13 @@ vite@^2.7.13:
     rollup "^2.59.0"
   optionalDependencies:
     fsevents "~2.3.2"
+
+vue-flatpickr-component@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/vue-flatpickr-component/-/vue-flatpickr-component-9.0.5.tgz#350ec73b7f3d7f80b050c170c088234f9c3bd14c"
+  integrity sha512-fKuz/D4ePQKi+jPo4xjYRgBCLTWrTsCoKbx8nam63x4kTDtSqvFOjNwLvy0QgwC0lC+aFpUWa1dNYTH0hgUcCA==
+  dependencies:
+    flatpickr "^4.6.9"
 
 vue-router@^4.0.0:
   version "4.0.14"


### PR DESCRIPTION
This PR fixes an issue where the outside click behaviour was triggered if you clicked on 3rd party provided components that were portalled to the body.
From a DOM perspective this bug made sense because the 3rd party components are rendered **outside** of the current Dialog and therefore it closes.

This PR should fix that behaviour and it should be possible to interact with 3rd party libraries now.

You can play with it here:
- React: https://headlessui-react-git-fix-third-party-interactions-tailwindlabs.vercel.app/dialog/dialog
- Vue: https://headlessui-vue-git-fix-third-party-interactions-tailwindlabs.vercel.app/dialog/dialog 

Fixes: #432

