### PR TITLE
Mimic browser select on focus when navigating via `Tab`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix incorrect `active` option in the Listbox/Combobox component ([#1264](https://github.com/tailwindlabs/headlessui/pull/1264))
 - Properly merge incoming props ([#1265](https://github.com/tailwindlabs/headlessui/pull/1265))
 - Fix incorrect closing while interacting with third party libraries in `Dialog` component ([#1268](https://github.com/tailwindlabs/headlessui/pull/1268))
+- Mimic browser select on focus when navigating via `Tab` ([#1272](https://github.com/tailwindlabs/headlessui/pull/1272))
 
 ### Added
 
@@ -65,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Tree-shaking support ([#1247](https://github.com/tailwindlabs/headlessui/pull/1247))
 - Stop propagation on the Popover Button ([#1263](https://github.com/tailwindlabs/headlessui/pull/1263))
 - Fix incorrect closing while interacting with third party libraries in `Dialog` component ([#1268](https://github.com/tailwindlabs/headlessui/pull/1268))
+- Mimic browser select on focus when navigating via `Tab` ([#1272](https://github.com/tailwindlabs/headlessui/pull/1272))
 
 ### Added
 

--- a/packages/@headlessui-react/src/utils/focus-management.ts
+++ b/packages/@headlessui-react/src/utils/focus-management.ts
@@ -103,6 +103,17 @@ export function focusElement(element: HTMLElement | null) {
   element?.focus({ preventScroll: true })
 }
 
+// https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/select
+export function isSelectableElement(
+  element: HTMLElement | null
+): element is HTMLInputElement | HTMLTextAreaElement {
+  return !!element && element.matches(['textarea', 'input'].join(','))
+}
+
+export function selectElementText(element: HTMLInputElement | HTMLTextAreaElement | null) {
+  element?.select()
+}
+
 export function sortByDomNode<T>(
   nodes: T[],
   resolveKey: (item: T) => HTMLElement | null = (i) => i as unknown as HTMLElement | null
@@ -171,6 +182,10 @@ export function focusIn(container: HTMLElement | HTMLElement[], focus: Focus) {
 
     // Try the focus the next element, might not work if it is "hidden" to the user.
     next?.focus(focusOptions)
+
+    if (isSelectableElement(next)) {
+      next.select()
+    }
 
     // Try the next one in line
     offset += direction

--- a/packages/@headlessui-vue/src/utils/focus-management.ts
+++ b/packages/@headlessui-vue/src/utils/focus-management.ts
@@ -96,6 +96,14 @@ export function focusElement(element: HTMLElement | null) {
   element?.focus({ preventScroll: true })
 }
 
+// https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/select
+let selectableSelector = ['textarea', 'input'].join(',')
+function isSelectableElement(
+  element: Element | null
+): element is HTMLInputElement | HTMLTextAreaElement {
+  return element?.matches?.(selectableSelector) ?? false
+}
+
 export function sortByDomNode<T>(
   nodes: T[],
   resolveKey: (item: T) => HTMLElement | null = (i) => i as unknown as HTMLElement | null
@@ -178,6 +186,18 @@ export function focusIn(container: HTMLElement | HTMLElement[], focus: Focus) {
   // However in that case the default focus styles are not applied *unless* you
   // also add this tabindex.
   if (!next.hasAttribute('tabindex')) next.setAttribute('tabindex', '0')
+
+  // By default if you <Tab> to a text input or a textarea, the browser will
+  // select all the text once the focus is inside these DOM Nodes. However,
+  // since we are manually moving focus this behaviour is not happening. This
+  // code will make sure that the text gets selected as-if you did it manually.
+  // Note: We only do this when going forward / backward. Not for the
+  // Focus.First or Focus.Last actions. This is similar to the `autoFocus`
+  // behaviour on an input where the input will get focus but won't be
+  // selected.
+  if (focus & (Focus.Next | Focus.Previous) && isSelectableElement(next)) {
+    next.select()
+  }
 
   return FocusResult.Success
 }


### PR DESCRIPTION
When using a `Dialog`, if a user tabs into an input or textarea element, the default browser behavior of selecting the text is not occurring. Instead the cursor is sent to the end of the input.

This PR resolves this by selecting the text if the element is able to select the text. 

resolves https://github.com/tailwindlabs/headlessui/issues/1271
