### PR TITLE
Ensure that there is always an active option in the `Combobox`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Properly merge incoming props ([#1265](https://github.com/tailwindlabs/headlessui/pull/1265))
 - Fix incorrect closing while interacting with third party libraries in `Dialog` component ([#1268](https://github.com/tailwindlabs/headlessui/pull/1268))
 - Mimic browser select on focus when navigating via `Tab` ([#1272](https://github.com/tailwindlabs/headlessui/pull/1272))
+- Ensure that there is always an active option in the `Combobox` ([#1279](https://github.com/tailwindlabs/headlessui/pull/1279))
 
 ### Added
 
@@ -68,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix incorrect closing while interacting with third party libraries in `Dialog` component ([#1268](https://github.com/tailwindlabs/headlessui/pull/1268))
 - Mimic browser select on focus when navigating via `Tab` ([#1272](https://github.com/tailwindlabs/headlessui/pull/1272))
 - Resolve `initialFocusRef` correctly ([#1276](https://github.com/tailwindlabs/headlessui/pull/1276))
+- Ensure that there is always an active option in the `Combobox` ([#1279](https://github.com/tailwindlabs/headlessui/pull/1279))
 
 ### Added
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -38,6 +38,7 @@ import {
   getComboboxes,
   assertCombobox,
   ComboboxMode,
+  assertNotActiveComboboxOption,
 } from '../../test-utils/accessibility-assertions'
 import { Transition } from '../transitions/transition'
 
@@ -579,7 +580,7 @@ describe('Rendering', () => {
         })
         assertComboboxList({
           state: ComboboxState.Visible,
-          textContent: JSON.stringify({ active: false, selected: false, disabled: false }),
+          textContent: JSON.stringify({ active: true, selected: false, disabled: false }),
         })
       })
     )
@@ -667,15 +668,12 @@ describe('Rendering composition', () => {
 
       // Verify correct classNames
       expect('' + options[0].classList).toEqual(
-        JSON.stringify({ active: false, selected: false, disabled: false })
+        JSON.stringify({ active: true, selected: false, disabled: false })
       )
       expect('' + options[1].classList).toEqual(
         JSON.stringify({ active: false, selected: false, disabled: true })
       )
       expect('' + options[2].classList).toEqual('no-special-treatment')
-
-      // Double check that nothing is active
-      assertNoActiveComboboxOption(getComboboxInput())
 
       // Make the first option active
       await press(Keys.ArrowDown)
@@ -841,7 +839,7 @@ describe('Composition', () => {
       })
       assertComboboxList({
         state: ComboboxState.Visible,
-        textContent: JSON.stringify({ active: false, selected: false, disabled: false }),
+        textContent: JSON.stringify({ active: true, selected: false, disabled: false }),
       })
 
       await click(getComboboxButton())
@@ -905,7 +903,7 @@ describe('Keyboard interactions', () => {
           expect(options).toHaveLength(3)
           options.forEach((option) => assertComboboxOption(option, { selected: false }))
 
-          assertNoActiveComboboxOption()
+          assertActiveComboboxOption(options[0])
           assertNoSelectedComboboxOption()
         })
       )
@@ -1191,7 +1189,7 @@ describe('Keyboard interactions', () => {
           let options = getComboboxOptions()
           expect(options).toHaveLength(3)
           options.forEach((option) => assertComboboxOption(option))
-          assertNoActiveComboboxOption()
+          assertActiveComboboxOption(options[0])
         })
       )
 
@@ -1434,7 +1432,7 @@ describe('Keyboard interactions', () => {
           options.forEach((option) => assertComboboxOption(option))
 
           // Verify that the first combobox option is active
-          assertNoActiveComboboxOption()
+          assertActiveComboboxOption(options[0])
         })
       )
 
@@ -2133,7 +2131,7 @@ describe('Keyboard interactions', () => {
           options.forEach((option) => assertComboboxOption(option))
 
           // Verify that the first combobox option is active
-          assertNoActiveComboboxOption()
+          assertActiveComboboxOption(options[0])
         })
       )
 
@@ -2272,7 +2270,7 @@ describe('Keyboard interactions', () => {
           let options = getComboboxOptions()
           expect(options).toHaveLength(3)
           options.forEach((option) => assertComboboxOption(option))
-          assertNoActiveComboboxOption()
+          assertActiveComboboxOption(options[0])
 
           // We should be able to go down once
           await press(Keys.ArrowDown)
@@ -2322,7 +2320,7 @@ describe('Keyboard interactions', () => {
           let options = getComboboxOptions()
           expect(options).toHaveLength(3)
           options.forEach((option) => assertComboboxOption(option))
-          assertNoActiveComboboxOption()
+          assertActiveComboboxOption(options[1])
 
           // We should be able to go down once
           await press(Keys.ArrowDown)
@@ -2362,7 +2360,7 @@ describe('Keyboard interactions', () => {
           let options = getComboboxOptions()
           expect(options).toHaveLength(3)
           options.forEach((option) => assertComboboxOption(option))
-          assertNoActiveComboboxOption()
+          assertActiveComboboxOption(options[2])
 
           // Open combobox
           await press(Keys.ArrowDown)
@@ -2596,7 +2594,7 @@ describe('Keyboard interactions', () => {
           let options = getComboboxOptions()
           expect(options).toHaveLength(3)
           options.forEach((option) => assertComboboxOption(option))
-          assertNoActiveComboboxOption()
+          assertActiveComboboxOption(options[2])
 
           // Going up or down should select the single available option
           await press(Keys.ArrowUp)
@@ -2689,8 +2687,8 @@ describe('Keyboard interactions', () => {
 
           let options = getComboboxOptions()
 
-          // We should have no option selected
-          assertNoActiveComboboxOption()
+          // We should be on the first non-disabled option
+          assertActiveComboboxOption(options[0])
 
           // We should be able to go to the last option
           await press(Keys.End)
@@ -2723,8 +2721,8 @@ describe('Keyboard interactions', () => {
 
           let options = getComboboxOptions()
 
-          // We should have no option selected
-          assertNoActiveComboboxOption()
+          // We should be on the first non-disabled option
+          assertActiveComboboxOption(options[0])
 
           // We should be able to go to the last non-disabled option
           await press(Keys.End)
@@ -2757,13 +2755,14 @@ describe('Keyboard interactions', () => {
           // Open combobox
           await click(getComboboxButton())
 
-          // We opened via click, we don't have an active option
-          assertNoActiveComboboxOption()
+          let options = getComboboxOptions()
 
-          // We should not be able to go to the end
+          // We should be on the first non-disabled option
+          assertActiveComboboxOption(options[0])
+
+          // We should not be able to go to the end (no-op)
           await press(Keys.End)
 
-          let options = getComboboxOptions()
           assertActiveComboboxOption(options[0])
         })
       )
@@ -2828,7 +2827,7 @@ describe('Keyboard interactions', () => {
           let options = getComboboxOptions()
 
           // We should be on the first option
-          assertNoActiveComboboxOption()
+          assertActiveComboboxOption(options[0])
 
           // We should be able to go to the last option
           await press(Keys.PageDown)
@@ -2864,8 +2863,8 @@ describe('Keyboard interactions', () => {
 
           let options = getComboboxOptions()
 
-          // We should have nothing active
-          assertNoActiveComboboxOption()
+          // We should be on the first non-disabled option
+          assertActiveComboboxOption(options[0])
 
           // We should be able to go to the last non-disabled option
           await press(Keys.PageDown)
@@ -2898,13 +2897,14 @@ describe('Keyboard interactions', () => {
           // Open combobox
           await click(getComboboxButton())
 
-          // We opened via click, we don't have an active option
-          assertNoActiveComboboxOption()
+          let options = getComboboxOptions()
+
+          // We should be on the first non-disabled option
+          assertActiveComboboxOption(options[0])
 
           // We should not be able to go to the end
           await press(Keys.PageDown)
 
-          let options = getComboboxOptions()
           assertActiveComboboxOption(options[0])
         })
       )
@@ -3003,13 +3003,13 @@ describe('Keyboard interactions', () => {
           // Open combobox
           await click(getComboboxButton())
 
-          // We opened via click, we don't have an active option
-          assertNoActiveComboboxOption()
+          let options = getComboboxOptions()
+
+          // We should be on the first non-disabled option
+          assertActiveComboboxOption(options[2])
 
           // We should not be able to go to the end
           await press(Keys.Home)
-
-          let options = getComboboxOptions()
 
           // We should be on the first non-disabled option
           assertActiveComboboxOption(options[2])
@@ -3041,13 +3041,14 @@ describe('Keyboard interactions', () => {
           // Open combobox
           await click(getComboboxButton())
 
-          // We opened via click, we don't have an active option
-          assertNoActiveComboboxOption()
+          let options = getComboboxOptions()
+
+          // We should be on the last option
+          assertActiveComboboxOption(options[3])
 
           // We should not be able to go to the end
           await press(Keys.Home)
 
-          let options = getComboboxOptions()
           assertActiveComboboxOption(options[3])
         })
       )
@@ -3146,15 +3147,14 @@ describe('Keyboard interactions', () => {
           // Open combobox
           await click(getComboboxButton())
 
-          // We opened via click, we don't have an active option
-          assertNoActiveComboboxOption()
-
-          // We should not be able to go to the end
-          await press(Keys.PageUp)
-
           let options = getComboboxOptions()
 
-          // We should be on the first non-disabled option
+          // We opened via click, we default to the first non-disabled option
+          assertActiveComboboxOption(options[2])
+
+          // We should not be able to go to the end (no-op — already there)
+          await press(Keys.PageUp)
+
           assertActiveComboboxOption(options[2])
         })
       )
@@ -3184,13 +3184,14 @@ describe('Keyboard interactions', () => {
           // Open combobox
           await click(getComboboxButton())
 
-          // We opened via click, we don't have an active option
-          assertNoActiveComboboxOption()
+          let options = getComboboxOptions()
 
-          // We should not be able to go to the end
+          // We opened via click, we default to the first non-disabled option
+          assertActiveComboboxOption(options[3])
+
+          // We should not be able to go to the end (no-op — already there)
           await press(Keys.PageUp)
 
-          let options = getComboboxOptions()
           assertActiveComboboxOption(options[3])
         })
       )
@@ -4019,7 +4020,7 @@ describe('Mouse interactions', () => {
       let options = getComboboxOptions()
 
       await mouseMove(options[1])
-      assertNoActiveComboboxOption()
+      assertNotActiveComboboxOption(options[1])
     })
   )
 
@@ -4048,8 +4049,8 @@ describe('Mouse interactions', () => {
       // Try to hover over option 1, which is disabled
       await mouseMove(options[1])
 
-      // We should not have an active option now
-      assertNoActiveComboboxOption()
+      // We should not have option 1 as the active option now
+      assertNotActiveComboboxOption(options[1])
     })
   )
 
@@ -4120,10 +4121,10 @@ describe('Mouse interactions', () => {
 
       // Try to hover over option 1, which is disabled
       await mouseMove(options[1])
-      assertNoActiveComboboxOption()
+      assertNotActiveComboboxOption(options[1])
 
       await mouseLeave(options[1])
-      assertNoActiveComboboxOption()
+      assertNotActiveComboboxOption(options[1])
     })
   )
 
@@ -4216,9 +4217,10 @@ describe('Mouse interactions', () => {
 
       let options = getComboboxOptions()
 
-      // We should be able to click the first option
+      // We should not be able to click the disabled option
       await click(options[1])
       assertComboboxList({ state: ComboboxState.Visible })
+      assertNotActiveComboboxOption(options[1])
       assertActiveElement(getComboboxInput())
       expect(handleChange).toHaveBeenCalledTimes(0)
 
@@ -4228,8 +4230,10 @@ describe('Mouse interactions', () => {
       // Open combobox again
       await click(getComboboxButton())
 
-      // Verify the active option is non existing
-      assertNoActiveComboboxOption()
+      options = getComboboxOptions()
+
+      // Verify the active option is not the disabled one
+      assertNotActiveComboboxOption(options[1])
     })
   )
 
@@ -4261,10 +4265,10 @@ describe('Mouse interactions', () => {
 
       let options = getComboboxOptions()
 
-      // Verify that nothing is active yet
-      assertNoActiveComboboxOption()
+      // Verify that the first item is active
+      assertActiveComboboxOption(options[0])
 
-      // We should be able to focus the first option
+      // We should be able to focus the second option
       await focus(options[1])
       assertActiveComboboxOption(options[1])
     })
@@ -4296,7 +4300,7 @@ describe('Mouse interactions', () => {
 
       // We should not be able to focus the first option
       await focus(options[1])
-      assertNoActiveComboboxOption()
+      assertNotActiveComboboxOption(options[1])
     })
   )
 

--- a/packages/@headlessui-react/src/test-utils/accessibility-assertions.ts
+++ b/packages/@headlessui-react/src/test-utils/accessibility-assertions.ts
@@ -537,6 +537,22 @@ export function assertActiveComboboxOption(
   }
 }
 
+export function assertNotActiveComboboxOption(
+  item: HTMLElement | null,
+  combobox = getComboboxInput()
+) {
+  try {
+    if (combobox === null) return expect(combobox).not.toBe(null)
+    if (item === null) return expect(item).not.toBe(null)
+
+    // Ensure link between combobox & combobox item does not exist
+    expect(combobox).not.toHaveAttribute('aria-activedescendant', item.getAttribute('id'))
+  } catch (err) {
+    if (err instanceof Error) Error.captureStackTrace(err, assertNotActiveComboboxOption)
+    throw err
+  }
+}
+
 export function assertNoActiveComboboxOption(combobox = getComboboxInput()) {
   try {
     if (combobox === null) return expect(combobox).not.toBe(null)

--- a/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
@@ -54,6 +54,7 @@ import {
   getComboboxes,
   assertCombobox,
   ComboboxMode,
+  assertNotActiveComboboxOption,
 } from '../../test-utils/accessibility-assertions'
 import { html } from '../../test-utils/html'
 import { useOpenClosedProvider, State, useOpenClosed } from '../../internal/open-closed'
@@ -687,7 +688,7 @@ describe('Rendering', () => {
         })
         assertComboboxList({
           state: ComboboxState.Visible,
-          textContent: JSON.stringify({ active: false, selected: false, disabled: false }),
+          textContent: JSON.stringify({ active: true, selected: false, disabled: false }),
         })
       })
     )
@@ -1001,7 +1002,7 @@ describe('Keyboard interactions', () => {
           expect(options).toHaveLength(3)
           options.forEach((option) => assertComboboxOption(option, { selected: false }))
 
-          assertNoActiveComboboxOption()
+          assertActiveComboboxOption(options[0])
           assertNoSelectedComboboxOption()
         })
       )
@@ -1308,7 +1309,7 @@ describe('Keyboard interactions', () => {
           let options = getComboboxOptions()
           expect(options).toHaveLength(3)
           options.forEach((option) => assertComboboxOption(option))
-          assertNoActiveComboboxOption()
+          assertActiveComboboxOption(options[0])
         })
       )
 
@@ -1563,7 +1564,7 @@ describe('Keyboard interactions', () => {
           options.forEach((option) => assertComboboxOption(option))
 
           // Verify that the first combobox option is active
-          assertNoActiveComboboxOption()
+          assertActiveComboboxOption(options[0])
         })
       )
 
@@ -2281,7 +2282,7 @@ describe('Keyboard interactions', () => {
           options.forEach((option) => assertComboboxOption(option))
 
           // Verify that the first combobox option is active
-          assertNoActiveComboboxOption()
+          assertActiveComboboxOption(options[0])
         })
       )
 
@@ -2432,7 +2433,7 @@ describe('Keyboard interactions', () => {
           let options = getComboboxOptions()
           expect(options).toHaveLength(3)
           options.forEach((option) => assertComboboxOption(option))
-          assertNoActiveComboboxOption()
+          assertActiveComboboxOption(options[0])
 
           // We should be able to go down once
           await press(Keys.ArrowDown)
@@ -2483,7 +2484,7 @@ describe('Keyboard interactions', () => {
           let options = getComboboxOptions()
           expect(options).toHaveLength(3)
           options.forEach((option) => assertComboboxOption(option))
-          assertNoActiveComboboxOption()
+          assertActiveComboboxOption(options[1])
 
           // We should be able to go down once
           await press(Keys.ArrowDown)
@@ -2522,7 +2523,7 @@ describe('Keyboard interactions', () => {
           let options = getComboboxOptions()
           expect(options).toHaveLength(3)
           options.forEach((option) => assertComboboxOption(option))
-          assertNoActiveComboboxOption()
+          assertActiveComboboxOption(options[2])
 
           // Open combobox
           await press(Keys.ArrowDown)
@@ -2766,7 +2767,7 @@ describe('Keyboard interactions', () => {
           let options = getComboboxOptions()
           expect(options).toHaveLength(3)
           options.forEach((option) => assertComboboxOption(option))
-          assertNoActiveComboboxOption()
+          assertActiveComboboxOption(options[2])
 
           // Going up or down should select the single available option
           await press(Keys.ArrowUp)
@@ -2865,8 +2866,8 @@ describe('Keyboard interactions', () => {
 
           let options = getComboboxOptions()
 
-          // We should have no option selected
-          assertNoActiveComboboxOption()
+          // We should be on the first non-disabled option
+          assertActiveComboboxOption(options[0])
 
           // We should be able to go to the last option
           await press(Keys.End)
@@ -2898,8 +2899,8 @@ describe('Keyboard interactions', () => {
 
           let options = getComboboxOptions()
 
-          // We should have no option selected
-          assertNoActiveComboboxOption()
+          // We should be on the first non-disabled option
+          assertActiveComboboxOption(options[0])
 
           // We should be able to go to the last non-disabled option
           await press(Keys.End)
@@ -2929,13 +2930,14 @@ describe('Keyboard interactions', () => {
           // Open combobox
           await click(getComboboxButton())
 
-          // We opened via click, we don't have an active option
-          assertNoActiveComboboxOption()
+          let options = getComboboxOptions()
 
-          // We should not be able to go to the end
+          // We should be on the first non-disabled option
+          assertActiveComboboxOption(options[0])
+
+          // We should not be able to go to the end (no-op)
           await press(Keys.End)
 
-          let options = getComboboxOptions()
           assertActiveComboboxOption(options[0])
         })
       )
@@ -2998,7 +3000,7 @@ describe('Keyboard interactions', () => {
           let options = getComboboxOptions()
 
           // We should be on the first option
-          assertNoActiveComboboxOption()
+          assertActiveComboboxOption(options[0])
 
           // We should be able to go to the last option
           await press(Keys.PageDown)
@@ -3033,8 +3035,8 @@ describe('Keyboard interactions', () => {
 
           let options = getComboboxOptions()
 
-          // We should have nothing active
-          assertNoActiveComboboxOption()
+          // We should be on the first non-disabled option
+          assertActiveComboboxOption(options[0])
 
           // We should be able to go to the last non-disabled option
           await press(Keys.PageDown)
@@ -3064,13 +3066,14 @@ describe('Keyboard interactions', () => {
           // Open combobox
           await click(getComboboxButton())
 
-          // We opened via click, we don't have an active option
-          assertNoActiveComboboxOption()
+          let options = getComboboxOptions()
+
+          // We should be on the first non-disabled option
+          assertActiveComboboxOption(options[0])
 
           // We should not be able to go to the end
           await press(Keys.PageDown)
 
-          let options = getComboboxOptions()
           assertActiveComboboxOption(options[0])
         })
       )
@@ -3166,13 +3169,13 @@ describe('Keyboard interactions', () => {
           // Open combobox
           await click(getComboboxButton())
 
-          // We opened via click, we don't have an active option
-          assertNoActiveComboboxOption()
+          let options = getComboboxOptions()
+
+          // We should be on the first non-disabled option
+          assertActiveComboboxOption(options[2])
 
           // We should not be able to go to the end
           await press(Keys.Home)
-
-          let options = getComboboxOptions()
 
           // We should be on the first non-disabled option
           assertActiveComboboxOption(options[2])
@@ -3201,13 +3204,14 @@ describe('Keyboard interactions', () => {
           // Open combobox
           await click(getComboboxButton())
 
-          // We opened via click, we don't have an active option
-          assertNoActiveComboboxOption()
+          let options = getComboboxOptions()
+
+          // We should be on the last option
+          assertActiveComboboxOption(options[3])
 
           // We should not be able to go to the end
           await press(Keys.Home)
 
-          let options = getComboboxOptions()
           assertActiveComboboxOption(options[3])
         })
       )
@@ -3303,15 +3307,14 @@ describe('Keyboard interactions', () => {
           // Open combobox
           await click(getComboboxButton())
 
-          // We opened via click, we don't have an active option
-          assertNoActiveComboboxOption()
-
-          // We should not be able to go to the end
-          await press(Keys.PageUp)
-
           let options = getComboboxOptions()
 
-          // We should be on the first non-disabled option
+          // We opened via click, we default to the first non-disabled option
+          assertActiveComboboxOption(options[2])
+
+          // We should not be able to go to the end (no-op — already there)
+          await press(Keys.PageUp)
+
           assertActiveComboboxOption(options[2])
         })
       )
@@ -3338,13 +3341,14 @@ describe('Keyboard interactions', () => {
           // Open combobox
           await click(getComboboxButton())
 
-          // We opened via click, we don't have an active option
-          assertNoActiveComboboxOption()
+          let options = getComboboxOptions()
 
-          // We should not be able to go to the end
+          // We opened via click, we default to the first non-disabled option
+          assertActiveComboboxOption(options[3])
+
+          // We should not be able to go to the end (no-op — already there)
           await press(Keys.PageUp)
 
-          let options = getComboboxOptions()
           assertActiveComboboxOption(options[3])
         })
       )
@@ -4252,7 +4256,7 @@ describe('Mouse interactions', () => {
       let options = getComboboxOptions()
 
       await mouseMove(options[1])
-      assertNoActiveComboboxOption()
+      assertNotActiveComboboxOption(options[1])
     })
   )
 
@@ -4282,8 +4286,8 @@ describe('Mouse interactions', () => {
       // Try to hover over option 1, which is disabled
       await mouseMove(options[1])
 
-      // We should not have an active option now
-      assertNoActiveComboboxOption()
+      // We should not have option 1 as the active option now
+      assertNotActiveComboboxOption(options[1])
     })
   )
 
@@ -4358,10 +4362,10 @@ describe('Mouse interactions', () => {
 
       // Try to hover over option 1, which is disabled
       await mouseMove(options[1])
-      assertNoActiveComboboxOption()
+      assertNotActiveComboboxOption(options[1])
 
       await mouseLeave(options[1])
-      assertNoActiveComboboxOption()
+      assertNotActiveComboboxOption(options[1])
     })
   )
 
@@ -4442,9 +4446,10 @@ describe('Mouse interactions', () => {
 
       let options = getComboboxOptions()
 
-      // We should be able to click the first option
+      // We should not be able to click the disabled option
       await click(options[1])
       assertComboboxList({ state: ComboboxState.Visible })
+      assertNotActiveComboboxOption(options[1])
       assertActiveElement(getComboboxInput())
       expect(handleChange).toHaveBeenCalledTimes(0)
 
@@ -4454,8 +4459,10 @@ describe('Mouse interactions', () => {
       // Open combobox again
       await click(getComboboxButton())
 
-      // Verify the active option is non existing
-      assertNoActiveComboboxOption()
+      options = getComboboxOptions()
+
+      // Verify the active option is not the disabled one
+      assertNotActiveComboboxOption(options[1])
     })
   )
 
@@ -4484,10 +4491,10 @@ describe('Mouse interactions', () => {
 
       let options = getComboboxOptions()
 
-      // Verify that nothing is active yet
-      assertNoActiveComboboxOption()
+      // Verify that the first item is active
+      assertActiveComboboxOption(options[0])
 
-      // We should be able to focus the first option
+      // We should be able to focus the second option
       await focus(options[1])
       assertActiveComboboxOption(options[1])
     })

--- a/packages/@headlessui-vue/src/test-utils/accessibility-assertions.ts
+++ b/packages/@headlessui-vue/src/test-utils/accessibility-assertions.ts
@@ -537,6 +537,22 @@ export function assertActiveComboboxOption(
   }
 }
 
+export function assertNotActiveComboboxOption(
+  item: HTMLElement | null,
+  combobox = getComboboxInput()
+) {
+  try {
+    if (combobox === null) return expect(combobox).not.toBe(null)
+    if (item === null) return expect(item).not.toBe(null)
+
+    // Ensure link between combobox & combobox item does not exist
+    expect(combobox).not.toHaveAttribute('aria-activedescendant', item.getAttribute('id'))
+  } catch (err) {
+    if (err instanceof Error) Error.captureStackTrace(err, assertNotActiveComboboxOption)
+    throw err
+  }
+}
+
 export function assertNoActiveComboboxOption(combobox = getComboboxInput()) {
   try {
     if (combobox === null) return expect(combobox).not.toBe(null)

--- a/packages/playground-vue/src/components/combobox/multi-select.vue
+++ b/packages/playground-vue/src/components/combobox/multi-select.vue
@@ -66,7 +66,9 @@
                   class="shadow-xs max-h-60 overflow-auto rounded-md py-1 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5"
                 >
                   <ComboboxOption
-                    v-for="person in people"
+                    v-for="person in people.filter((person) =>
+                      person.name.toLowerCase().includes(query.toLowerCase())
+                    )"
                     :key="person.id"
                     :value="person"
                     as="template"


### PR DESCRIPTION
This PR ensures that the first non-disabled `Combobox.Option` will be the active one if no other active option exists.

This should improve the general UX of the `Combobox` component, because now you can search and immediately press <kbd>Enter</kbd> to choose that option instead of searching, pressing <kbd>ArrowUp</kbd> and then pressing <kbd>Enter</kbd>.

Some rules that apply:
- If you have an active option already, that one should stay the active option as long as it can.
- If no active option exists, but a `Combobox.Option` registers itself and _is_ selected, then the first selected option will become the active one.
- If you mosue out, then no active option should exist.
   - This will prevent weird jumps/scrolls if you leave the last option with your mouse and it jumps up to make the first option active.

