### PR TITLE
Implement `nullable` mode on `Combobox` in single value mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `<form>` compatibility ([#1214](https://github.com/tailwindlabs/headlessui/pull/1214))
 - Add `multi` value support for Listbox & Combobox ([#1243](https://github.com/tailwindlabs/headlessui/pull/1243))
+- Implement `nullable` mode on `Combobox` in single value mode ([#1295](https://github.com/tailwindlabs/headlessui/pull/1295))
 
 ## [Unreleased - @headlessui/vue]
 
@@ -77,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `<form>` compatibility ([#1214](https://github.com/tailwindlabs/headlessui/pull/1214))
 - Add `multi` value support for Listbox & Combobox ([#1243](https://github.com/tailwindlabs/headlessui/pull/1243))
+- Implement `nullable` mode on `Combobox` in single value mode ([#1295](https://github.com/tailwindlabs/headlessui/pull/1295))
 
 ## [@headlessui/react@v1.5.0] - 2022-02-17
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -1724,6 +1724,74 @@ describe('Keyboard interactions', () => {
     })
   })
 
+  describe('`Backspace` key', () => {
+    it(
+      'should reset the value when the last character is removed, when in `nullable` mode',
+      suppressConsoleLogs(async () => {
+        let handleChange = jest.fn()
+        function Example() {
+          let [value, setValue] = useState<string>('bob')
+          let [query, setQuery] = useState<string>('')
+
+          return (
+            <Combobox
+              value={value}
+              onChange={(value) => {
+                setValue(value)
+                handleChange(value)
+              }}
+              nullable
+            >
+              <Combobox.Input onChange={(event) => setQuery(event.target.value)} />
+              <Combobox.Button>Trigger</Combobox.Button>
+              <Combobox.Options>
+                <Combobox.Option value="alice">Alice</Combobox.Option>
+                <Combobox.Option value="bob">Bob</Combobox.Option>
+                <Combobox.Option value="charlie">Charlie</Combobox.Option>
+              </Combobox.Options>
+            </Combobox>
+          )
+        }
+
+        render(<Example />)
+
+        // Open combobox
+        await click(getComboboxButton())
+
+        let options: ReturnType<typeof getComboboxOptions>
+
+        // Bob should be active
+        options = getComboboxOptions()
+        expect(getComboboxInput()).toHaveValue('bob')
+        assertActiveComboboxOption(options[1])
+
+        assertActiveElement(getComboboxInput())
+
+        // Delete a character
+        await press(Keys.Backspace)
+        expect(getComboboxInput()?.value).toBe('bo')
+        assertActiveComboboxOption(options[1])
+
+        // Delete a character
+        await press(Keys.Backspace)
+        expect(getComboboxInput()?.value).toBe('b')
+        assertActiveComboboxOption(options[1])
+
+        // Delete a character
+        await press(Keys.Backspace)
+        expect(getComboboxInput()?.value).toBe('')
+
+        // Verify that we don't have an active option anymore since we are in `nullable` mode
+        assertNotActiveComboboxOption(options[1])
+        assertNoActiveComboboxOption()
+
+        // Verify that we saw the `null` change coming in
+        expect(handleChange).toHaveBeenCalledTimes(1)
+        expect(handleChange).toHaveBeenCalledWith(null)
+      })
+    )
+  })
+
   describe('Input', () => {
     describe('`Enter` key', () => {
       it(

--- a/packages/@headlessui-react/src/components/keyboard.ts
+++ b/packages/@headlessui-react/src/components/keyboard.ts
@@ -5,6 +5,7 @@ export enum Keys {
   Enter = 'Enter',
   Escape = 'Escape',
   Backspace = 'Backspace',
+  Delete = 'Delete',
 
   ArrowLeft = 'ArrowLeft',
   ArrowUp = 'ArrowUp',

--- a/packages/@headlessui-react/src/test-utils/interactions.ts
+++ b/packages/@headlessui-react/src/test-utils/interactions.ts
@@ -151,6 +151,23 @@ let order: Record<
       return fireEvent.keyUp(element, event)
     },
   ],
+  [Keys.Backspace.key!]: [
+    function keydown(element, event) {
+      if (element instanceof HTMLInputElement) {
+        let ev = Object.assign({}, event, {
+          target: Object.assign({}, event.target, {
+            value: element.value.slice(0, -1),
+          }),
+        })
+        return fireEvent.keyDown(element, ev)
+      }
+
+      return fireEvent.keyDown(element, event)
+    },
+    function keyup(element, event) {
+      return fireEvent.keyUp(element, event)
+    },
+  ],
 }
 
 export async function type(events: Partial<KeyboardEvent>[], element = document.activeElement) {

--- a/packages/@headlessui-vue/src/keyboard.ts
+++ b/packages/@headlessui-vue/src/keyboard.ts
@@ -5,6 +5,7 @@ export enum Keys {
   Enter = 'Enter',
   Escape = 'Escape',
   Backspace = 'Backspace',
+  Delete = 'Delete',
 
   ArrowLeft = 'ArrowLeft',
   ArrowUp = 'ArrowUp',

--- a/packages/@headlessui-vue/src/test-utils/interactions.ts
+++ b/packages/@headlessui-vue/src/test-utils/interactions.ts
@@ -151,6 +151,23 @@ let order: Record<
       return fireEvent.keyUp(element, event)
     },
   ],
+  [Keys.Backspace.key!]: [
+    function keydown(element, event) {
+      if (element instanceof HTMLInputElement) {
+        let ev = Object.assign({}, event, {
+          target: Object.assign({}, event.target, {
+            value: element.value.slice(0, -1),
+          }),
+        })
+        return fireEvent.keyDown(element, ev)
+      }
+
+      return fireEvent.keyDown(element, event)
+    },
+    function keyup(element, event) {
+      return fireEvent.keyUp(element, event)
+    },
+  ],
 }
 
 export async function type(events: Partial<KeyboardEvent>[], element = document.activeElement) {


### PR DESCRIPTION
This PR adds a `nullable` prop to the `Combobox` component which is defaulted to `false`.

If this prop is provided, and you clear the text in the input value, then the `Combobox` option will
be cleared as well. We will do that by calling your `onChange` with `null` in React, or setting the
`v-model` to `null` in Vue.

This feature allows you to "clear" a Combobox value once it is set, whereas otherwise this isn't
possible unless you provide a custom "Unset" `Combobox.Option` or a button to reset the value.


