### PR TITLE
Add `Dialog.Backdrop` and `Dialog.Panel` components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `<form>` compatibility ([#1214](https://github.com/tailwindlabs/headlessui/pull/1214))
 - Add `multi` value support for Listbox & Combobox ([#1243](https://github.com/tailwindlabs/headlessui/pull/1243))
 - Implement `nullable` mode on `Combobox` in single value mode ([#1295](https://github.com/tailwindlabs/headlessui/pull/1295))
+- Add `Dialog.Backdrop` and `Dialog.Panel` components ([#1333](https://github.com/tailwindlabs/headlessui/pull/1333))
 
 ## [Unreleased - @headlessui/vue]
 
@@ -80,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `<form>` compatibility ([#1214](https://github.com/tailwindlabs/headlessui/pull/1214))
 - Add `multi` value support for Listbox & Combobox ([#1243](https://github.com/tailwindlabs/headlessui/pull/1243))
 - Implement `nullable` mode on `Combobox` in single value mode ([#1295](https://github.com/tailwindlabs/headlessui/pull/1295))
+- Add `Dialog.Backdrop` and `Dialog.Panel` components ([#1333](https://github.com/tailwindlabs/headlessui/pull/1333))
 
 ## [@headlessui/react@v1.5.0] - 2022-02-17
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -1731,7 +1731,7 @@ describe('Keyboard interactions', () => {
         let handleChange = jest.fn()
         function Example() {
           let [value, setValue] = useState<string>('bob')
-          let [query, setQuery] = useState<string>('')
+          let [, setQuery] = useState<string>('')
 
           return (
             <Combobox

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -865,6 +865,9 @@ let Button = forwardRefWithAs(function Button<TTag extends ElementType = typeof 
           }
           actions.closeCombobox()
           return d.nextFrame(() => state.inputRef.current?.focus({ preventScroll: true }))
+
+        default:
+          return
       }
     },
     [d, state, actions, data]

--- a/packages/@headlessui-react/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-react/src/hooks/use-outside-click.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, useMemo, useRef } from 'react'
+import { MutableRefObject, useRef } from 'react'
 import { microTask } from '../utils/micro-task'
 import { useLatestValue } from './use-latest-value'
 import { useWindowEvent } from './use-window-event'
@@ -7,9 +7,15 @@ type Container = MutableRefObject<HTMLElement | null> | HTMLElement | null
 type ContainerCollection = Container[] | Set<Container>
 type ContainerInput = Container | ContainerCollection
 
+export enum Features {
+  None = 1 << 0,
+  IgnoreScrollbars = 1 << 1,
+}
+
 export function useOutsideClick(
   containers: ContainerInput | (() => ContainerInput),
-  cb: (event: MouseEvent | PointerEvent, target: HTMLElement) => void
+  cb: (event: MouseEvent | PointerEvent, target: HTMLElement) => void,
+  features: Features = Features.None
 ) {
   let called = useRef(false)
   let handler = useLatestValue((event: MouseEvent | PointerEvent) => {
@@ -39,6 +45,25 @@ export function useOutsideClick(
 
     // Ignore if the target doesn't exist in the DOM anymore
     if (!target.ownerDocument.documentElement.contains(target)) return
+
+    // Ignore scrollbars:
+    // This is a bit hacky, and is only necessary because we are checking for `pointerdown` and
+    // `mousedown` events. They _are_ being called if you click on a scrollbar. The `click` event
+    // is not called when clicking on a scrollbar, but we can't use that otherwise it won't work
+    // on mobile devices where only pointer events are being used.
+    if ((features & Features.IgnoreScrollbars) === Features.IgnoreScrollbars) {
+      // TODO: We can calculate this dynamically~is. On macOS if you have the "Automatically based
+      // on mouse or trackpad" setting enabled, then the scrollbar will float on top and therefore
+      // you can't calculate its with by checking the clientWidth and scrollWidth of the element.
+      // Therefore we are currently hardcoding this to be 20px.
+      let scrollbarWidth = 20
+
+      let viewport = target.ownerDocument.documentElement
+      if (event.clientX > viewport.clientWidth - scrollbarWidth) return
+      if (event.clientX < scrollbarWidth) return
+      if (event.clientY > viewport.clientHeight - scrollbarWidth) return
+      if (event.clientY < scrollbarWidth) return
+    }
 
     // Ignore if the target exists in one of the containers
     for (let container of _containers) {

--- a/packages/@headlessui-react/src/hooks/use-transition.ts
+++ b/packages/@headlessui-react/src/hooks/use-transition.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, useRef } from 'react'
+import { MutableRefObject } from 'react'
 
 import { Reason, transition } from '../components/transitions/utils/transition'
 import { disposables } from '../utils/disposables'

--- a/packages/@headlessui-react/src/test-utils/accessibility-assertions.ts
+++ b/packages/@headlessui-react/src/test-utils/accessibility-assertions.ts
@@ -1334,6 +1334,10 @@ export function getDialogOverlay(): HTMLElement | null {
   return document.querySelector('[id^="headlessui-dialog-overlay-"]')
 }
 
+export function getDialogBackdrop(): HTMLElement | null {
+  return document.querySelector('[id^="headlessui-dialog-backdrop-"]')
+}
+
 export function getDialogOverlays(): HTMLElement[] {
   return Array.from(document.querySelectorAll('[id^="headlessui-dialog-overlay-"]'))
 }

--- a/packages/@headlessui-vue/src/components/switch/switch.ts
+++ b/packages/@headlessui-vue/src/components/switch/switch.ts
@@ -98,7 +98,7 @@ export let Switch = defineComponent({
         event.preventDefault()
         toggle()
       } else if (event.key === Keys.Enter) {
-        attemptSubmit(event.currentTarget)
+        attemptSubmit(event.currentTarget as HTMLElement)
       }
     }
 

--- a/packages/@headlessui-vue/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-vue/src/hooks/use-outside-click.ts
@@ -21,9 +21,15 @@ type Container = Ref<HTMLElement | null> | HTMLElement | null
 type ContainerCollection = Container[] | Set<Container>
 type ContainerInput = Container | ContainerCollection
 
+export enum Features {
+  None = 1 << 0,
+  IgnoreScrollbars = 1 << 1,
+}
+
 export function useOutsideClick(
   containers: ContainerInput | (() => ContainerInput),
-  cb: (event: MouseEvent | PointerEvent, target: HTMLElement) => void
+  cb: (event: MouseEvent | PointerEvent, target: HTMLElement) => void,
+  features: Features = Features.None
 ) {
   let called = false
   function handle(event: MouseEvent | PointerEvent) {
@@ -53,6 +59,25 @@ export function useOutsideClick(
 
       return [containers]
     })(containers)
+
+    // Ignore scrollbars:
+    // This is a bit hacky, and is only necessary because we are checking for `pointerdown` and
+    // `mousedown` events. They _are_ being called if you click on a scrollbar. The `click` event
+    // is not called when clicking on a scrollbar, but we can't use that otherwise it won't work
+    // on mobile devices where only pointer events are being used.
+    if ((features & Features.IgnoreScrollbars) === Features.IgnoreScrollbars) {
+      // TODO: We can calculate this dynamically~is. On macOS if you have the "Automatically based
+      // on mouse or trackpad" setting enabled, then the scrollbar will float on top and therefore
+      // you can't calculate its with by checking the clientWidth and scrollWidth of the element.
+      // Therefore we are currently hardcoding this to be 20px.
+      let scrollbarWidth = 20
+
+      let viewport = target.ownerDocument.documentElement
+      if (event.clientX > viewport.clientWidth - scrollbarWidth) return
+      if (event.clientX < scrollbarWidth) return
+      if (event.clientY > viewport.clientHeight - scrollbarWidth) return
+      if (event.clientY < scrollbarWidth) return
+    }
 
     // Ignore if the target exists in one of the containers
     for (let container of _containers) {

--- a/packages/@headlessui-vue/src/index.test.ts
+++ b/packages/@headlessui-vue/src/index.test.ts
@@ -17,6 +17,8 @@ it('should expose the correct components', () => {
     // Dialog
     'Dialog',
     'DialogOverlay',
+    'DialogBackdrop',
+    'DialogPanel',
     'DialogTitle',
     'DialogDescription',
 

--- a/packages/@headlessui-vue/src/test-utils/accessibility-assertions.ts
+++ b/packages/@headlessui-vue/src/test-utils/accessibility-assertions.ts
@@ -1334,6 +1334,10 @@ export function getDialogOverlay(): HTMLElement | null {
   return document.querySelector('[id^="headlessui-dialog-overlay-"]')
 }
 
+export function getDialogBackdrop(): HTMLElement | null {
+  return document.querySelector('[id^="headlessui-dialog-backdrop-"]')
+}
+
 export function getDialogOverlays(): HTMLElement[] {
   return Array.from(document.querySelectorAll('[id^="headlessui-dialog-overlay-"]'))
 }


### PR DESCRIPTION
This PR adds 2 new components:

- `Dialog.Backdrop` (React), `DialogPanel` (Vue)
- `Dialog.Panel` (React), `DialogPanel` (Vue)

The `Dialog.Backdrop` will replace the `Dialog.Overlay` in a backwards compatible way, because the `Dialog.Overlay` will still be available.

## What does this solve?

If you have a `Dialog` with a lot of content, then you want to scroll the `Dialog`, however in a lot of usage implementations the `Dialog.Overlay` gets in the way, and you will only be able to scroll with your mouse while it's over the panel itself (the typical white area in the center of your screen). You usually can't scroll the overlay (the gray area) so that is not good.

In addition, the scrollbar is typically hidden by the `Dialog.Overlay`, so if your users use the scrollbar itself, they can either not reach it because the overlay sits on top of it, or they can't click it to drag up/down because the `Dialog` will then close.

To fix those problems, we introduced a `Dialog.Backdrop`, this is very similar to the `Dialog.Overlay`, but there is a technical difference, it will be rendered in a portal as a sibling of the `Dialog`, not as a child of the `Dialog`. This fixes the scrolling issues. We created a new component to guarantee backwards compatibility, otherwise this would be a breaking change because now the component will be rendered in a different spot in the DOM.

This introduces another issue, the "outside click" behaviour is now technically broken. Because in most cases you are not clicking outside the `Dialog` component because they are typically rendered in "full screen" (especially if you use the Tailwind UI dialogs). To fix this, the `Dialog.Overlay` had a click listener to close the `Dialog`, but this new `Dialog.Backdrop` replacement is now rendered in a different spot and you can't even click it in most cases. To solve this issue we introduced a `Dialog.Panel` where you can mark that typical white box in the middle of the screen and if you click outside of that box, the `Dialog` will close.

There is also a hard dependency between the `Dialog.Backdrop` and the `Dialog.Panel`. If you start using the new `Dialog.Backdrop` then you _have_ to use the `Dialog.Panel` as well to guarantee that all features keep working as they did before.

## Upgrade example:

### React

```diff
  import { useState } from 'react'
  import { Dialog } from '@headlessui/react'

  function MyDialog() {
    let [isOpen, setIsOpen] = useState(true)

    return (
      <Dialog open={isOpen} onClose={() => setIsOpen(false)}>
-       <Dialog.Overlay />
+       <Dialog.Backdrop />

+       <Dialog.Panel>
          <Dialog.Title>Deactivate account</Dialog.Title>
          <Dialog.Description>
            This will permanently deactivate your account
          </Dialog.Description>

          <p>
            Are you sure you want to deactivate your account? All of your data will
            be permanently removed. This action cannot be undone.
          </p>

          <button onClick={() => setIsOpen(false)}>Deactivate</button>
          <button onClick={() => setIsOpen(false)}>Cancel</button>
+       </Dialog.Panel>
      </Dialog>
    )
  }
```

### Vue

```diff
  <template>
    <Dialog :open="isOpen" @close="setIsOpen">
-     <DialogOverlay />
+     <DialogBackdrop />

+     <DialogPanel>
        <DialogTitle>Deactivate account</DialogTitle>
        <DialogDescription>
          This will permanently deactivate your account
        </DialogDescription>

        <p>
          Are you sure you want to deactivate your account? All of your data will be
          permanently removed. This action cannot be undone.
        </p>

        <button @click="setIsOpen(false)">Deactivate</button>
        <button @click="setIsOpen(false)">Cancel</button>
+     </DialogPanel>
    </Dialog>
  </template>

  <script setup>
    import { ref } from 'vue'
    import {
      Dialog,
-     DialogOverlay,
+     DialogBackdrop,
+     DialogPanel,
      DialogTitle,
      DialogDescription,
    } from '@headlessui/vue'

    const isOpen = ref(true)

    function setIsOpen(value) {
      isOpen.value = value
    }
  </script>
```

---

Fixes: #1056 
Fixes: #1132


