### PR TITLE
Fix enter transitions in Vue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Manually passthrough `attrs` for `Combobox`, `Listbox` and `TabsGroup` component ([#1372](https://github.com/tailwindlabs/headlessui/pull/1372))
+- Fix enter transitions in Vue ([#1395](https://github.com/tailwindlabs/headlessui/pull/1395))
 
 ## [@headlessui/react@v1.6.0] - 2022-04-25
 

--- a/packages/@headlessui-vue/src/components/transitions/transition.ts
+++ b/packages/@headlessui-vue/src/components/transitions/transition.ts
@@ -291,7 +291,7 @@ export let TransitionChild = defineComponent({
 
     onMounted(() => {
       watch(
-        [show, appear],
+        [show],
         (_oldValues, _newValues, onInvalidate) => {
           executeTransition(onInvalidate)
           initial.value = false
@@ -394,7 +394,7 @@ export let TransitionRoot = defineComponent({
       state.value = TreeStates.Hidden
     })
 
-    let initial = { value: true }
+    let initial = ref(true)
     let transitionBag = {
       show,
       appear: computed(() => props.appear || !initial.value),

--- a/packages/playground-vue/package.json
+++ b/packages/playground-vue/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@headlessui/vue": "*",
+    "@heroicons/vue": "^1.0.6",
     "vue": "^3.2.27",
     "vue-flatpickr-component": "^9.0.5",
     "vue-router": "^4.0.0"

--- a/packages/playground-vue/src/components/dialog/slide-over.vue
+++ b/packages/playground-vue/src/components/dialog/slide-over.vue
@@ -1,0 +1,112 @@
+<template>
+  <TransitionRoot as="template" :show="open">
+    <Dialog as="div" class="relative z-10" @close="open = false">
+      <TransitionChild
+        as="template"
+        enter="ease-in-out duration-500"
+        enter-from="opacity-0"
+        enter-to="opacity-100"
+        leave="ease-in-out duration-500"
+        leave-from="opacity-100"
+        leave-to="opacity-0"
+      >
+        <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+      </TransitionChild>
+
+      <div class="fixed inset-0 overflow-hidden">
+        <div class="absolute inset-0 overflow-hidden">
+          <div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10">
+            <TransitionChild
+              as="template"
+              enter="transform transition ease-in-out duration-500 sm:duration-700"
+              enter-from="translate-x-full"
+              enter-to="translate-x-0"
+              leave="transform transition ease-in-out duration-500 sm:duration-700"
+              leave-from="translate-x-0"
+              leave-to="translate-x-full"
+            >
+              <DialogPanel class="pointer-events-auto w-screen max-w-md">
+                <div class="flex h-full flex-col overflow-y-scroll bg-white shadow-xl">
+                  <div class="flex-1 overflow-y-auto py-6 px-4 sm:px-6">
+                    <div class="flex items-start justify-between">
+                      <DialogTitle class="text-lg font-medium text-gray-900">Title...</DialogTitle>
+                      <div class="ml-3 flex h-7 items-center">
+                        <button
+                          type="button"
+                          class="-m-2 p-2 text-gray-400 hover:text-gray-500"
+                          @click="open = false"
+                        >
+                          <span class="sr-only">Close panel</span>
+                          <XIcon class="h-6 w-6" aria-hidden="true" />
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </DialogPanel>
+            </TransitionChild>
+          </div>
+        </div>
+      </div>
+    </Dialog>
+  </TransitionRoot>
+</template>
+
+<script>
+import { ref, watchEffect } from 'vue'
+import { Dialog, DialogPanel, DialogTitle, TransitionChild, TransitionRoot } from '@headlessui/vue'
+import { XIcon } from '@heroicons/vue/outline'
+
+const products = [
+  {
+    id: 1,
+    name: 'Throwback Hip Bag',
+    href: '#',
+    color: 'Salmon',
+    price: '$90.00',
+    quantity: 1,
+    imageSrc: 'https://tailwindui.com/img/ecommerce-images/shopping-cart-page-04-product-01.jpg',
+    imageAlt:
+      'Salmon orange fabric pouch with match zipper, gray zipper pull, and adjustable hip belt.',
+  },
+  {
+    id: 2,
+    name: 'Medium Stuff Satchel',
+    href: '#',
+    color: 'Blue',
+    price: '$32.00',
+    quantity: 1,
+    imageSrc: 'https://tailwindui.com/img/ecommerce-images/shopping-cart-page-04-product-02.jpg',
+    imageAlt:
+      'Front of satchel with blue canvas body, black straps and handle, drawstring top, and front zipper pouch.',
+  },
+  // More products...
+]
+
+export default {
+  components: {
+    Dialog,
+    DialogPanel,
+    DialogTitle,
+    TransitionChild,
+    TransitionRoot,
+    XIcon,
+  },
+  setup() {
+    const open = ref(true)
+
+    watchEffect(() => {
+      if (open.value === false) {
+        setTimeout(() => {
+          open.value = true
+        }, 1000)
+      }
+    })
+
+    return {
+      products,
+      open,
+    }
+  },
+}
+</script>

--- a/packages/playground-vue/src/routes.json
+++ b/packages/playground-vue/src/routes.json
@@ -166,6 +166,11 @@
         "name": "Dialog",
         "path": "/dialog/dialog",
         "component": "./components/dialog/dialog.vue"
+      },
+      {
+        "name": "Dialog Slide Over",
+        "path": "/dialog/slide-over",
+        "component": "./components/dialog/slide-over.vue"
       }
     ]
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -326,6 +326,11 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
 
+"@heroicons/vue@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@heroicons/vue/-/vue-1.0.6.tgz#d8b90734b436eb5a87f40cc300b64a0fb0031f7f"
+  integrity sha512-ng2YcCQrdoQWEFpw+ipFl2rZo8mZ56v0T5+MyfQQvNqfKChwgP6DMloZLW+rl17GEcHkE3H82UTAMKBKZr4+WA==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"


### PR DESCRIPTION
This PR fixes an issue with enter transitions in the Vue `Transition` component. Now the enter
transition will only work after the `show` value has changed OR if the `appear` prop has been
passed.

