### PR TITLE
Fix closing of `Popover.Panel` in React 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased - @headlessui/react]
 
-- Nothing yet!
+### Fixed
+
+- Fix closing of `Popover.Panel` in React 18 ([#1409](https://github.com/tailwindlabs/headlessui/pull/1409))
 
 ## [@headlessui/react@1.6.1] - 2022-05-03
 

--- a/packages/@headlessui-react/src/components/popover/popover.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.tsx
@@ -640,9 +640,6 @@ let Panel = forwardRefWithAs(function Panel<TTag extends ElementType = typeof DE
     [state, internalPanelRef, dispatch]
   )
 
-  // Unlink on "unmount" myself
-  useEffect(() => () => dispatch({ type: ActionTypes.SetPanel, panel: null }), [dispatch])
-
   // Unlink on "unmount" children
   useEffect(() => {
     if (props.static) return

--- a/packages/@headlessui-vue/src/components/popover/popover.ts
+++ b/packages/@headlessui-vue/src/components/popover/popover.ts
@@ -1,7 +1,7 @@
 import {
+  computed,
   defineComponent,
   inject,
-  onUnmounted,
   provide,
   ref,
   watchEffect,
@@ -9,7 +9,6 @@ import {
   // Types
   InjectionKey,
   Ref,
-  computed,
 } from 'vue'
 
 import { match } from '../../utils/match'
@@ -476,10 +475,6 @@ export let PopoverPanel = defineComponent({
     expose({ el: api.panel, $el: api.panel })
 
     provide(PopoverPanelContext, api.panelId)
-
-    onUnmounted(() => {
-      api.panel.value = null
-    })
 
     // Move focus within panel
     watchEffect(() => {


### PR DESCRIPTION
This PR removes some unnecessary code that has been handled a different way and by doing that fixes a React 18 compatibility issue where the `Popover` would immediately close if you click anywhere inside of the `Popover.Panel`.

The reason for this is that we used the cleanup function of a `useEffect` to set the `panel` to `null`. In React 18, this will be executed twice therefore the `Panel` gets set to `null` while it didn't have to do that yet.

Fixes: #1407
