### PR TITLE
Simplify `Popover` Tab logic by using sentinel nodes instead of keydown event interception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure `DialogPanel` exposes its ref ([#1404](https://github.com/tailwindlabs/headlessui/pull/1404))
 - Ignore `Escape` when event got prevented in `Dialog` component ([#1424](https://github.com/tailwindlabs/headlessui/pull/1424))
 - Improve `FocusTrap` behaviour ([#1432](https://github.com/tailwindlabs/headlessui/pull/1432))
+- Simplify `Popover` Tab logic by using sentinel nodes instead of keydown event interception ([#1440](https://github.com/tailwindlabs/headlessui/pull/1440))
 
 ## [Unreleased - @headlessui/react]
 
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix closing of `Popover.Panel` in React 18 ([#1409](https://github.com/tailwindlabs/headlessui/pull/1409))
 - Ignore `Escape` when event got prevented in `Dialog` component ([#1424](https://github.com/tailwindlabs/headlessui/pull/1424))
 - Improve `FocusTrap` behaviour ([#1432](https://github.com/tailwindlabs/headlessui/pull/1432))
+- Simplify `Popover` Tab logic by using sentinel nodes instead of keydown event interception ([#1440](https://github.com/tailwindlabs/headlessui/pull/1440))
 
 ## [@headlessui/react@1.6.1] - 2022-05-03
 

--- a/packages/@headlessui-react/src/utils/focus-management.ts
+++ b/packages/@headlessui-react/src/utils/focus-management.ts
@@ -129,7 +129,7 @@ export function sortByDomNode<T>(
   })
 }
 
-export function focusIn(container: HTMLElement | HTMLElement[], focus: Focus) {
+export function focusIn(container: HTMLElement | HTMLElement[], focus: Focus, sorted = true) {
   let ownerDocument = Array.isArray(container)
     ? container.length > 0
       ? container[0].ownerDocument
@@ -137,7 +137,9 @@ export function focusIn(container: HTMLElement | HTMLElement[], focus: Focus) {
     : container.ownerDocument
 
   let elements = Array.isArray(container)
-    ? sortByDomNode(container)
+    ? sorted
+      ? sortByDomNode(container)
+      : container
     : getFocusableElements(container)
   let active = ownerDocument.activeElement as HTMLElement
 

--- a/packages/@headlessui-vue/src/components/popover/popover.ts
+++ b/packages/@headlessui-vue/src/components/popover/popover.ts
@@ -1,6 +1,8 @@
 import {
+  Fragment,
   computed,
   defineComponent,
+  h,
   inject,
   provide,
   ref,
@@ -19,7 +21,6 @@ import {
   getFocusableElements,
   Focus,
   focusIn,
-  FocusResult,
   isFocusableElement,
   FocusableMode,
 } from '../../utils/focus-management'
@@ -29,6 +30,9 @@ import { useResolveButtonType } from '../../hooks/use-resolve-button-type'
 import { useOutsideClick } from '../../hooks/use-outside-click'
 import { getOwnerDocument } from '../../utils/owner'
 import { useEventListener } from '../../hooks/use-event-listener'
+import { Hidden, Features as HiddenFeatures } from '../../internal/hidden'
+import { useTabDirection, Direction as TabDirection } from '../../hooks/use-tab-direction'
+import { microTask } from '../../utils/micro-task'
 
 enum PopoverStates {
   Open,
@@ -42,6 +46,11 @@ interface StateDefinition {
   buttonId: string
   panel: Ref<HTMLElement | null>
   panelId: string
+
+  isPortalled: Ref<boolean>
+
+  beforePanelSentinel: Ref<HTMLElement | null>
+  afterPanelSentinel: Ref<HTMLElement | null>
 
   // State mutators
   togglePopover(): void
@@ -101,8 +110,22 @@ export let Popover = defineComponent({
 
     let popoverState = ref<StateDefinition['popoverState']['value']>(PopoverStates.Closed)
     let button = ref<StateDefinition['button']['value']>(null)
+    let beforePanelSentinel = ref<StateDefinition['beforePanelSentinel']['value']>(null)
+    let afterPanelSentinel = ref<StateDefinition['afterPanelSentinel']['value']>(null)
     let panel = ref<StateDefinition['panel']['value']>(null)
     let ownerDocument = computed(() => getOwnerDocument(internalPopoverRef))
+    let isPortalled = computed(() => {
+      if (!dom(button)) return false
+      if (!dom(panel)) return false
+
+      for (let root of document.querySelectorAll('body > *')) {
+        if (Number(root?.contains(dom(button))) ^ Number(root?.contains(dom(panel)))) {
+          return true
+        }
+      }
+
+      return false
+    })
 
     let api = {
       popoverState,
@@ -110,6 +133,9 @@ export let Popover = defineComponent({
       panelId,
       panel,
       button,
+      isPortalled,
+      beforePanelSentinel,
+      afterPanelSentinel,
       togglePopover() {
         popoverState.value = match(popoverState.value, {
           [PopoverStates.Open]: PopoverStates.Closed,
@@ -171,11 +197,13 @@ export let Popover = defineComponent({
     useEventListener(
       ownerDocument.value?.defaultView,
       'focus',
-      () => {
+      (event) => {
         if (popoverState.value !== PopoverStates.Open) return
         if (isFocusWithinPopoverGroup()) return
         if (!button) return
         if (!panel) return
+        if (dom(api.beforePanelSentinel)?.contains(event.target as HTMLElement)) return
+        if (dom(api.afterPanelSentinel)?.contains(event.target as HTMLElement)) return
 
         api.closePopover()
       },
@@ -218,6 +246,7 @@ export let PopoverButton = defineComponent({
     as: { type: [Object, String], default: 'button' },
     disabled: { type: [Boolean], default: false },
   },
+  inheritAttrs: false,
   setup(props, { attrs, slots, expose }) {
     let api = usePopoverContext('PopoverButton')
     let ownerDocument = computed(() => getOwnerDocument(api.button))
@@ -230,21 +259,8 @@ export let PopoverButton = defineComponent({
     let panelContext = usePopoverPanelContext()
     let isWithinPanel = panelContext === null ? false : panelContext === api.panelId
 
-    // TODO: Revisit when handling Tab/Shift+Tab when using Portal's
-    let activeElementRef = ref<Element | null>(null)
-    let previousActiveElementRef = ref<Element | null>()
-
-    useEventListener(
-      ownerDocument.value?.defaultView,
-      'focus',
-      () => {
-        previousActiveElementRef.value = activeElementRef.value
-        activeElementRef.value = ownerDocument.value?.activeElement as HTMLElement
-      },
-      true
-    )
-
     let elementRef = ref(null)
+    let sentinelId = `headlessui-focus-sentinel-${useId()}`
 
     if (!isWithinPanel) {
       watchEffect(() => {
@@ -292,39 +308,6 @@ export let PopoverButton = defineComponent({
             event.stopPropagation()
             api.closePopover()
             break
-
-          case Keys.Tab:
-            if (api.popoverState.value !== PopoverStates.Open) return
-            if (!api.panel) return
-            if (!api.button) return
-
-            // TODO: Revisit when handling Tab/Shift+Tab when using Portal's
-            if (event.shiftKey) {
-              // Check if the last focused element exists, and check that it is not inside button or panel itself
-              if (!previousActiveElementRef.value) return
-              if (dom(api.button)?.contains(previousActiveElementRef.value)) return
-              if (dom(api.panel)?.contains(previousActiveElementRef.value)) return
-
-              // Check if the last focused element is *after* the button in the DOM
-              let focusableElements = getFocusableElements(ownerDocument.value?.body)
-              let previousIdx = focusableElements.indexOf(
-                previousActiveElementRef.value as HTMLElement
-              )
-              let buttonIdx = focusableElements.indexOf(dom(api.button)!)
-              if (buttonIdx > previousIdx) return
-
-              event.preventDefault()
-              event.stopPropagation()
-
-              focusIn(dom(api.panel)!, Focus.Last)
-            } else {
-              event.preventDefault()
-              event.stopPropagation()
-
-              focusIn(dom(api.panel)!, Focus.First)
-            }
-
-            break
         }
       }
     }
@@ -336,29 +319,6 @@ export let PopoverButton = defineComponent({
         // the Space key doesn't cancel the handleKeyUp, which in turn
         // triggers a *click*.
         event.preventDefault()
-      }
-      if (api.popoverState.value !== PopoverStates.Open) return
-      if (!api.panel) return
-      if (!api.button) return
-
-      // TODO: Revisit when handling Tab/Shift+Tab when using Portal's
-      switch (event.key) {
-        case Keys.Tab:
-          // Check if the last focused element exists, and check that it is not inside button or panel itself
-          if (!previousActiveElementRef.value) return
-          if (dom(api.button)?.contains(previousActiveElementRef.value)) return
-          if (dom(api.panel)?.contains(previousActiveElementRef.value)) return
-
-          // Check if the last focused element is *after* the button in the DOM
-          let focusableElements = getFocusableElements(ownerDocument.value?.body)
-          let previousIdx = focusableElements.indexOf(previousActiveElementRef.value as HTMLElement)
-          let buttonIdx = focusableElements.indexOf(dom(api.button)!)
-          if (buttonIdx > previousIdx) return
-
-          event.preventDefault()
-          event.stopPropagation()
-          focusIn(dom(api.panel)!, Focus.Last)
-          break
       }
     }
 
@@ -377,7 +337,8 @@ export let PopoverButton = defineComponent({
     }
 
     return () => {
-      let slot = { open: api.popoverState.value === PopoverStates.Open }
+      let visible = api.popoverState.value === PopoverStates.Open
+      let slot = { open: visible }
       let ourProps = isWithinPanel
         ? {
             ref: elementRef,
@@ -399,13 +360,45 @@ export let PopoverButton = defineComponent({
             onClick: handleClick,
           }
 
-      return render({
-        props: { ...props, ...ourProps },
-        slot,
-        attrs: attrs,
-        slots: slots,
-        name: 'PopoverButton',
-      })
+      let direction = useTabDirection()
+      function handleFocus() {
+        let el = dom(api.panel) as HTMLElement
+        if (!el) return
+
+        function run() {
+          match(direction.value, {
+            [TabDirection.Forwards]: () => focusIn(el, Focus.First),
+            [TabDirection.Backwards]: () => focusIn(el, Focus.Last),
+          })
+        }
+
+        // TODO: Cleanup once we are using real browser tests
+        if (process.env.NODE_ENV === 'test') {
+          microTask(run)
+        } else {
+          run()
+        }
+      }
+
+      return h(Fragment, [
+        render({
+          props: { ...attrs, ...props, ...ourProps },
+          slot,
+          attrs: attrs,
+          slots: slots,
+          name: 'PopoverButton',
+        }),
+        visible &&
+          !isWithinPanel &&
+          api.isPortalled.value &&
+          h(Hidden, {
+            id: sentinelId,
+            features: HiddenFeatures.Focusable,
+            as: 'button',
+            type: 'button',
+            onFocus: handleFocus,
+          }),
+      ])
     }
   },
 })
@@ -467,10 +460,14 @@ export let PopoverPanel = defineComponent({
     unmount: { type: Boolean, default: true },
     focus: { type: Boolean, default: false },
   },
+  inheritAttrs: false,
   setup(props, { attrs, slots, expose }) {
     let { focus } = props
     let api = usePopoverContext('PopoverPanel')
     let ownerDocument = computed(() => getOwnerDocument(api.panel))
+
+    let beforePanelSentinelId = `headlessui-focus-sentinel-before-${useId()}`
+    let afterPanelSentinelId = `headlessui-focus-sentinel-after-${useId()}`
 
     expose({ el: api.panel, $el: api.panel })
 
@@ -488,46 +485,6 @@ export let PopoverPanel = defineComponent({
       focusIn(dom(api.panel)!, Focus.First)
     })
 
-    // Handle Tab / Shift+Tab focus positioning
-    useEventListener(ownerDocument.value?.defaultView, 'keydown', (event: KeyboardEvent) => {
-      if (api.popoverState.value !== PopoverStates.Open) return
-      if (!dom(api.panel)) return
-
-      if (event.key !== Keys.Tab) return
-      if (!ownerDocument.value?.activeElement) return
-      if (!dom(api.panel)?.contains(ownerDocument.value.activeElement)) return
-
-      // We will take-over the default tab behaviour so that we have a bit
-      // control over what is focused next. It will behave exactly the same,
-      // but it will also "fix" some issues based on whether you are using a
-      // Portal or not.
-      event.preventDefault()
-
-      let result = focusIn(dom(api.panel)!, event.shiftKey ? Focus.Previous : Focus.Next)
-
-      if (result === FocusResult.Underflow) {
-        return dom(api.button)?.focus()
-      } else if (result === FocusResult.Overflow) {
-        if (!dom(api.button)) return
-
-        let elements = getFocusableElements(ownerDocument.value.body)
-        let buttonIdx = elements.indexOf(dom(api.button)!)
-
-        let nextElements = elements
-          .splice(buttonIdx + 1) // Elements after button
-          .filter((element) => !dom(api.panel)?.contains(element)) // Ignore items in panel
-
-        // Try to focus the next element, however it could fail if we are in a
-        // Portal that happens to be the very last one in the DOM. In that
-        // case we would Error (because nothing after the button is
-        // focusable). Therefore we will try and focus the very first item in
-        // the document.body.
-        if (focusIn(nextElements, Focus.First) === FocusResult.Error) {
-          focusIn(ownerDocument.value.body, Focus.First)
-        }
-      }
-    })
-
     // Handle focus out when we are in special "focus" mode
     useEventListener(
       ownerDocument.value?.defaultView,
@@ -536,11 +493,18 @@ export let PopoverPanel = defineComponent({
         if (!focus) return
         if (api.popoverState.value !== PopoverStates.Open) return
         if (!dom(api.panel)) return
+
+        let activeElement = ownerDocument?.value?.activeElement as HTMLElement
+
         if (
-          ownerDocument.value?.activeElement &&
-          dom(api.panel)?.contains(ownerDocument.value.activeElement as HTMLElement)
-        )
+          activeElement &&
+          (dom(api.panel)?.contains(activeElement) ||
+            dom(api.beforePanelSentinel)?.contains?.(activeElement) ||
+            dom(api.afterPanelSentinel)?.contains?.(activeElement))
+        ) {
           return
+        }
+
         api.closePopover()
       },
       true
@@ -570,6 +534,76 @@ export let PopoverPanel = defineComponent({
       }
     }
 
+    let direction = useTabDirection()
+    function handleBeforeFocus() {
+      let el = dom(api.panel) as HTMLElement
+      if (!el) return
+
+      function run() {
+        match(direction.value, {
+          [TabDirection.Forwards]: () => {
+            focusIn(el, Focus.First)
+          },
+          [TabDirection.Backwards]: () => {
+            // Coming from the Popover.Panel (which is portalled to somewhere else). Let's redirect
+            // the focus to the Popover.Button again.
+            dom(api.button)?.focus({ preventScroll: true })
+          },
+        })
+      }
+
+      // TODO: Cleanup once we are using real browser tests
+      if (process.env.NODE_ENV === 'test') {
+        microTask(run)
+      } else {
+        run()
+      }
+    }
+
+    function handleAfterFocus() {
+      let el = dom(api.panel) as HTMLElement
+      if (!el) return
+
+      function run() {
+        match(direction.value, {
+          [TabDirection.Forwards]: () => {
+            let button = dom(api.button)
+            let panel = dom(api.panel)
+            if (!button) return
+
+            let elements = getFocusableElements()
+
+            let idx = elements.indexOf(button)
+            let before = elements.slice(0, idx + 1)
+            let after = elements.slice(idx + 1)
+
+            let combined = [...after, ...before]
+
+            // Ignore sentinel buttons and items inside the panel
+            for (let element of combined.slice()) {
+              if (
+                element?.id?.startsWith?.('headlessui-focus-sentinel-') ||
+                panel?.contains(element)
+              ) {
+                let idx = combined.indexOf(element)
+                if (idx !== -1) combined.splice(idx, 1)
+              }
+            }
+
+            focusIn(combined, Focus.First, false)
+          },
+          [TabDirection.Backwards]: () => focusIn(el, Focus.Last),
+        })
+      }
+
+      // TODO: Cleanup once we are using real browser tests
+      if (process.env.NODE_ENV === 'test') {
+        microTask(run)
+      } else {
+        run()
+      }
+    }
+
     return () => {
       let slot = {
         open: api.popoverState.value === PopoverStates.Open,
@@ -582,15 +616,37 @@ export let PopoverPanel = defineComponent({
         onKeydown: handleKeyDown,
       }
 
-      return render({
-        props: { ...props, ...ourProps },
-        slot,
-        attrs,
-        slots,
-        features: Features.RenderStrategy | Features.Static,
-        visible: visible.value,
-        name: 'PopoverPanel',
-      })
+      return h(Fragment, [
+        visible.value &&
+          api.isPortalled.value &&
+          h(Hidden, {
+            id: beforePanelSentinelId,
+            ref: api.beforePanelSentinel,
+            features: HiddenFeatures.Focusable,
+            as: 'button',
+            type: 'button',
+            onFocus: handleBeforeFocus,
+          }),
+        render({
+          props: { ...attrs, ...props, ...ourProps },
+          slot,
+          attrs,
+          slots,
+          features: Features.RenderStrategy | Features.Static,
+          visible: visible.value,
+          name: 'PopoverPanel',
+        }),
+        visible.value &&
+          api.isPortalled.value &&
+          h(Hidden, {
+            id: afterPanelSentinelId,
+            ref: api.afterPanelSentinel,
+            features: HiddenFeatures.Focusable,
+            as: 'button',
+            type: 'button',
+            onFocus: handleAfterFocus,
+          }),
+      ])
     }
   },
 })

--- a/packages/@headlessui-vue/src/utils/focus-management.ts
+++ b/packages/@headlessui-vue/src/utils/focus-management.ts
@@ -122,7 +122,7 @@ export function sortByDomNode<T>(
   })
 }
 
-export function focusIn(container: HTMLElement | HTMLElement[], focus: Focus) {
+export function focusIn(container: HTMLElement | HTMLElement[], focus: Focus, sorted = true) {
   let ownerDocument =
     (Array.isArray(container)
       ? container.length > 0
@@ -131,7 +131,9 @@ export function focusIn(container: HTMLElement | HTMLElement[], focus: Focus) {
       : container?.ownerDocument) ?? document
 
   let elements = Array.isArray(container)
-    ? sortByDomNode(container)
+    ? sorted
+      ? sortByDomNode(container)
+      : container
     : getFocusableElements(container)
   let active = ownerDocument.activeElement as HTMLElement
 

--- a/packages/playground-react/pages/popover/popover.tsx
+++ b/packages/playground-react/pages/popover/popover.tsx
@@ -7,24 +7,12 @@ let Button = forwardRef(
     return (
       <Popover.Button
         ref={ref}
-        className="border-2 border-transparent bg-gray-300 px-3 py-2 focus:border-blue-900 focus:outline-none"
+        className="border-2 border-transparent bg-gray-300 px-3 py-2 text-left focus:border-blue-900 focus:outline-none"
         {...props}
       />
     )
   }
 )
-
-function Link(props: React.ComponentProps<'a'>) {
-  return (
-    <a
-      href="/"
-      className="border-2 border-transparent px-3 py-2 hover:bg-gray-200 focus:border-blue-900 focus:bg-gray-200 focus:outline-none"
-      {...props}
-    >
-      {props.children}
-    </a>
-  )
-}
 
 export default function Home() {
   let options = {
@@ -36,7 +24,7 @@ export default function Home() {
   let [reference1, popper1] = usePopper(options)
   let [reference2, popper2] = usePopper(options)
 
-  let links = ['First', 'Second', 'Third', 'Fourth']
+  let items = ['First', 'Second', 'Third', 'Fourth']
 
   return (
     <div className="flex items-center justify-center space-x-12 p-12">
@@ -60,10 +48,10 @@ export default function Home() {
             Normal
           </Popover.Button>
           <Popover.Panel className="absolute z-30 flex w-64 flex-col border-2 border-blue-900 bg-gray-100">
-            {links.map((link, i) => (
-              <Link key={link} hidden={i === 2}>
-                Normal - {link}
-              </Link>
+            {items.map((item, i) => (
+              <Button key={item} hidden={i === 2}>
+                Normal - {item}
+              </Button>
             ))}
           </Popover.Panel>
         </Popover>
@@ -74,8 +62,8 @@ export default function Home() {
             focus
             className="absolute flex w-64 flex-col border-2 border-blue-900 bg-gray-100"
           >
-            {links.map((link, i) => (
-              <Link key={link}>Focus - {link}</Link>
+            {items.map((item) => (
+              <Button key={item}>Focus - {item}</Button>
             ))}
           </Popover.Panel>
         </Popover>
@@ -87,8 +75,8 @@ export default function Home() {
               ref={popper1}
               className="flex w-64 flex-col border-2 border-blue-900 bg-gray-100"
             >
-              {links.map((link) => (
-                <Link key={link}>Portal - {link}</Link>
+              {items.map((item) => (
+                <Button key={item}>Portal - {item}</Button>
               ))}
             </Popover.Panel>
           </Portal>
@@ -102,8 +90,8 @@ export default function Home() {
               focus
               className="flex w-64 flex-col border-2 border-blue-900 bg-gray-100"
             >
-              {links.map((link) => (
-                <Link key={link}>Focus in Portal - {link}</Link>
+              {items.map((item) => (
+                <Button key={item}>Focus in Portal - {item}</Button>
               ))}
             </Popover.Panel>
           </Portal>

--- a/packages/playground-vue/src/components/popover/popover.vue
+++ b/packages/playground-vue/src/components/popover/popover.vue
@@ -20,14 +20,14 @@
           >Normal</PopoverButton
         >
         <PopoverPanel class="absolute z-30 flex w-64 flex-col border-2 border-blue-900 bg-gray-100">
-          <a
+          <button
             v-for="(link, i) of links"
+            :key="i"
             :hidden="i === 2"
-            href="/"
-            class="border-2 border-transparent px-3 py-2 hover:bg-gray-200 focus:border-blue-900 focus:bg-gray-200 focus:outline-none"
+            class="border-2 border-transparent px-3 py-2 text-left hover:bg-gray-200 focus:border-blue-900 focus:bg-gray-200 focus:outline-none"
           >
             Normal - {{ link }}
-          </a>
+          </button>
         </PopoverPanel>
       </Popover>
 
@@ -40,13 +40,13 @@
           focus
           class="absolute flex w-64 flex-col border-2 border-blue-900 bg-gray-100"
         >
-          <a
+          <button
             v-for="(link, i) of links"
-            href="/"
-            class="border-2 border-transparent px-3 py-2 hover:bg-gray-200 focus:border-blue-900 focus:bg-gray-200 focus:outline-none"
+            :key="i"
+            class="border-2 border-transparent px-3 py-2 text-left hover:bg-gray-200 focus:border-blue-900 focus:bg-gray-200 focus:outline-none"
           >
             Focus - {{ link }}
-          </a>
+          </button>
         </PopoverPanel>
       </Popover>
 
@@ -61,13 +61,13 @@
             ref="container1"
             class="flex w-64 flex-col border-2 border-blue-900 bg-gray-100"
           >
-            <a
+            <button
               v-for="(link, i) of links"
-              href="/"
-              class="border-2 border-transparent px-3 py-2 hover:bg-gray-200 focus:border-blue-900 focus:bg-gray-200 focus:outline-none"
+              :key="i"
+              class="border-2 border-transparent px-3 py-2 text-left hover:bg-gray-200 focus:border-blue-900 focus:bg-gray-200 focus:outline-none"
             >
               Portal - {{ link }}
-            </a>
+            </button>
           </PopoverPanel>
         </Portal>
       </Popover>
@@ -84,13 +84,13 @@
             focus
             class="flex w-64 flex-col border-2 border-blue-900 bg-gray-100"
           >
-            <a
+            <button
               v-for="(link, i) of links"
-              href="/"
-              class="border-2 border-transparent px-3 py-2 hover:bg-gray-200 focus:border-blue-900 focus:bg-gray-200 focus:outline-none"
+              :key="i"
+              class="border-2 border-transparent px-3 py-2 text-left hover:bg-gray-200 focus:border-blue-900 focus:bg-gray-200 focus:outline-none"
             >
               Focus in Portal - {{ link }}
-            </a>
+            </button>
           </PopoverPanel>
         </Portal>
       </Popover>


### PR DESCRIPTION
This PR will simplify the `Popover` component by using the same strategy we applied in the
`FocusTrap` component.

This uses sentinel DOM nodes instead of `keydown` event interception and manually trying to focus
the next element. This improves a bunch of subtle bugs because now the browser will handle all of
the Tab related logic. This means that it fixes the following bugs for free:

Fixes: #1215
Fixes: #1140
Fixes: #467
