### PR TITLE
internal: ensure standalone imports and exports are rewritten as well

### DIFF
--- a/scripts/rewrite-imports.js
+++ b/scripts/rewrite-imports.js
@@ -8,7 +8,7 @@ console.time('Rewrote imports in')
 fastGlob.sync([process.argv.slice(2).join('')]).forEach((file) => {
   file = path.resolve(process.cwd(), file)
   let content = fs.readFileSync(file, 'utf8')
-  let result = content.replace(/from([^"']*?)(["'])\.(.*?)\2/g, 'from$1".$3.js"')
+  let result = content.replace(/(import|export)([^"']*?)(["'])\.(.*?)\3;/g, '$1$2".$4.js";')
   if (result !== content) {
     fs.writeFileSync(file, result, 'utf8')
   }


### PR DESCRIPTION
This PR provides a fix where we only rewrote `import x from './abc'` to `import x from './abc.js'`.
But we also have to do that for standalone `import './abc'` to `import './abc.js'`.

