### PR TITLE
Don’t throw when SSR rendering internal portals in Vue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Simplify `Popover` Tab logic by using sentinel nodes instead of keydown event interception ([#1440](https://github.com/tailwindlabs/headlessui/pull/1440))
 - Ensure the `PopoverPanel` is clickable without closing the `Popover` ([#1443](https://github.com/tailwindlabs/headlessui/pull/1443))
 - Improve "Scroll lock" scrollbar width for `Dialog` component ([#1457](https://github.com/tailwindlabs/headlessui/pull/1457))
+- Don’t throw when SSR rendering internal portals in Vue ([#1459](https://github.com/tailwindlabs/headlessui/pull/1459))
 
 ## [Unreleased - @headlessui/react]
 

--- a/packages/@headlessui-vue/src/components/portal/portal.ts
+++ b/packages/@headlessui-vue/src/components/portal/portal.ts
@@ -23,6 +23,10 @@ import { getOwnerDocument } from '../../utils/owner'
 function getPortalRoot(contextElement?: Element | null) {
   let ownerDocument = getOwnerDocument(contextElement)
   if (!ownerDocument) {
+    if (contextElement === null) {
+      return null
+    }
+
     throw new Error(
       `[Headless UI]: Cannot find ownerDocument for contextElement: ${contextElement}`
     )


### PR DESCRIPTION
They will at least not error now. Ideally we would SSR render the content inside the portal but that will be for another day.

Fixes #1429