### PR TITLE
Allow overriding of props

### DIFF
--- a/packages/@headlessui-react/src/utils/render.ts
+++ b/packages/@headlessui-react/src/utils/render.ts
@@ -63,7 +63,7 @@ export function render<TFeature extends Features, TTag extends ElementType, TSlo
   visible?: boolean
   name: string
 }) {
-  let props = mergeProps(theirProps, ourProps)
+  let props = mergeProps(ourProps, theirProps)
 
   // Visible always render
   if (visible) return _render(props, slot, defaultTag, name)


### PR DESCRIPTION
### Background

I'm affected by [this bug](https://1password.community/discussion/comment/623484) which make 1Password believe that my Combox is something that it should care about:

<img width="500" alt="Screenshot 2022-05-19 at 10 47 08" src="https://user-images.githubusercontent.com/459267/169252721-f1327a8c-a78d-4d8a-b8e6-ecd4ef4526ce.png">

As a solution, I wanted to try [`type="search"`, as suggested herem](https://1password.community/discussion/comment/624860/#Comment_624860) on my `Combobox.Input` but headless UI doesn't allow me to do that as the props are getting overridden.

