### PR TITLE
Ensure the the `<Popover.Panel focus>` closes correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Allow to override the `type` on the `ComboboxInput` ([#1476](https://github.com/tailwindlabs/headlessui/pull/1476))
+- Ensure the the `<PopoverPanel focus>` closes correctly ([#1477](https://github.com/tailwindlabs/headlessui/pull/1477))
 
 ## [Unreleased - @headlessui/react]
 
 ### Fixed
 
 - Allow to override the `type` on the `Combobox.Input` ([#1476](https://github.com/tailwindlabs/headlessui/pull/1476))
+- Ensure the the `<Popover.Panel focus>` closes correctly ([#1477](https://github.com/tailwindlabs/headlessui/pull/1477))
 
 ## [@headlessui/vue@v1.6.2] - 2022-05-19
 

--- a/packages/@headlessui-react/src/components/popover/popover.test.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.test.tsx
@@ -1500,6 +1500,7 @@ describe('Keyboard interactions', () => {
 
         // Open the second popover
         await click(getByText('Trigger 2'))
+        getByText('Trigger 2')?.focus()
 
         // Ensure the second popover is open
         assertPopoverButton({ state: PopoverState.Visible }, getByText('Trigger 2'))
@@ -2146,6 +2147,7 @@ describe('Mouse interactions', () => {
 
       // Open popover
       await click(getPopoverButton())
+      getPopoverButton()?.focus()
 
       // Verify it is open
       assertPopoverButton({ state: PopoverState.Visible })
@@ -2267,6 +2269,64 @@ describe('Mouse interactions', () => {
 
       // Verify it is still open
       assertPopoverButton({ state: PopoverState.InvisibleHidden })
+    })
+  )
+
+  it(
+    'should be possible to close the Popover by clicking on the Popover.Button outside the Popover.Panel',
+    suppressConsoleLogs(async () => {
+      render(
+        <Popover>
+          <Popover.Button>Toggle</Popover.Button>
+          <Popover.Panel>
+            <button>Contents</button>
+          </Popover.Panel>
+        </Popover>
+      )
+
+      // Open the popover
+      await click(getPopoverButton())
+
+      // Verify it is open
+      assertPopoverPanel({ state: PopoverState.Visible })
+
+      // Close the popover
+      await click(getPopoverButton())
+
+      // Verify it is closed
+      assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
+
+      // Verify the button is focused
+      assertActiveElement(getPopoverButton())
+    })
+  )
+
+  it(
+    'should be possible to close the Popover by clicking on the Popover.Button outside the Popover.Panel (when using the `focus` prop)',
+    suppressConsoleLogs(async () => {
+      render(
+        <Popover>
+          <Popover.Button>Toggle</Popover.Button>
+          <Popover.Panel focus>
+            <button>Contents</button>
+          </Popover.Panel>
+        </Popover>
+      )
+
+      // Open the popover
+      await click(getPopoverButton())
+
+      // Verify it is open
+      assertPopoverPanel({ state: PopoverState.Visible })
+
+      // Close the popover
+      await click(getPopoverButton())
+
+      // Verify it is closed
+      assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
+
+      // Verify the button is focused
+      assertActiveElement(getPopoverButton())
     })
   )
 })

--- a/packages/@headlessui-react/src/test-utils/interactions.ts
+++ b/packages/@headlessui-react/src/test-utils/interactions.ts
@@ -241,17 +241,19 @@ export async function click(
       // Cancel in pointerDown cancels mouseDown, mouseUp
       let cancelled = !fireEvent.pointerDown(element, options)
       if (!cancelled) {
-        fireEvent.mouseDown(element, options)
+        cancelled = !fireEvent.mouseDown(element, options)
       }
 
       // Ensure to trigger a `focus` event if the element is focusable, or within a focusable element
-      let next: HTMLElement | null = element as HTMLElement | null
-      while (next !== null) {
-        if (next.matches(focusableSelector)) {
-          next.focus()
-          break
+      if (!cancelled) {
+        let next: HTMLElement | null = element as HTMLElement | null
+        while (next !== null) {
+          if (next.matches(focusableSelector)) {
+            next.focus()
+            break
+          }
+          next = next.parentElement
         }
-        next = next.parentElement
       }
 
       fireEvent.pointerUp(element, options)

--- a/packages/@headlessui-vue/src/components/popover/popover.test.ts
+++ b/packages/@headlessui-vue/src/components/popover/popover.test.ts
@@ -1610,6 +1610,7 @@ describe('Keyboard interactions', () => {
 
         // Open the second popover
         await click(getByText('Trigger 2'))
+        getByText('Trigger 2')?.focus()
 
         // Ensure the second popover is open
         assertPopoverButton({ state: PopoverState.Visible }, getByText('Trigger 2'))
@@ -2297,6 +2298,7 @@ describe('Mouse interactions', () => {
 
       // Open popover
       await click(getPopoverButton())
+      getPopoverButton()?.focus()
 
       // Verify it is open
       assertPopoverButton({ state: PopoverState.Visible })
@@ -2423,6 +2425,64 @@ describe('Mouse interactions', () => {
 
       // Verify it is still open
       assertPopoverButton({ state: PopoverState.InvisibleHidden })
+    })
+  )
+
+  it(
+    'should be possible to close the Popover by clicking on the Popover.Button outside the Popover.Panel',
+    suppressConsoleLogs(async () => {
+      renderTemplate(html`
+        <Popover>
+          <PopoverButton>Toggle</PopoverButton>
+          <PopoverPanel>
+            <button>Contents</button>
+          </PopoverPanel>
+        </Popover>
+      `)
+
+      // Open the popover
+      await click(getPopoverButton())
+
+      // Verify it is open
+      assertPopoverPanel({ state: PopoverState.Visible })
+
+      // Close the popover
+      await click(getPopoverButton())
+
+      // Verify it is closed
+      assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
+
+      // Verify the button is focused
+      assertActiveElement(getPopoverButton())
+    })
+  )
+
+  it(
+    'should be possible to close the Popover by clicking on the Popover.Button outside the Popover.Panel (when using the `focus` prop)',
+    suppressConsoleLogs(async () => {
+      renderTemplate(html`
+        <Popover>
+          <PopoverButton>Toggle</PopoverButton>
+          <PopoverPanel focus>
+            <button>Contents</button>
+          </PopoverPanel>
+        </Popover>
+      `)
+
+      // Open the popover
+      await click(getPopoverButton())
+
+      // Verify it is open
+      assertPopoverPanel({ state: PopoverState.Visible })
+
+      // Close the popover
+      await click(getPopoverButton())
+
+      // Verify it is closed
+      assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
+
+      // Verify the button is focused
+      assertActiveElement(getPopoverButton())
     })
   )
 })

--- a/packages/@headlessui-vue/src/test-utils/interactions.ts
+++ b/packages/@headlessui-vue/src/test-utils/interactions.ts
@@ -239,17 +239,19 @@ export async function click(
       // Cancel in pointerDown cancels mouseDown, mouseUp
       let cancelled = !fireEvent.pointerDown(element, options)
       if (!cancelled) {
-        fireEvent.mouseDown(element, options)
+        cancelled = !fireEvent.mouseDown(element, options)
       }
 
       // Ensure to trigger a `focus` event if the element is focusable, or within a focusable element
-      let next: HTMLElement | null = element as HTMLElement | null
-      while (next !== null) {
-        if (next.matches(focusableSelector)) {
-          next.focus()
-          break
+      if (!cancelled) {
+        let next: HTMLElement | null = element as HTMLElement | null
+        while (next !== null) {
+          if (next.matches(focusableSelector)) {
+            next.focus()
+            break
+          }
+          next = next.parentElement
         }
-        next = next.parentElement
       }
 
       fireEvent.pointerUp(element, options)


### PR DESCRIPTION
This PR fixes an issue where the `Popover.Panel` isn't closed correctly if you are using the `focus` prop. This is because the idea behind the `focus` flag is that when the `Popover.Panel` opens the focus is moved inside the `Popover.Panel`. If the focus is moved outside of the `Popover.Panel` then the `Popover.Panel` will close again.

The issue with this is that the moment you click the `Popover.Button` when the `Popover` is open the
the following happens:

1. Focus is moved to the `Popover.Button`.
2. `Popover` will close due to the above.
3. The click event happens on then `Popover.Button`.
4. Which opens the `Popover` again.

This means that you can't close is anymore via click. This PR fixes that issue.

Fixes: #1342

