### PR TITLE
Only render the `FocusSentinel` if required in the `Tabs` component

### DIFF
--- a/packages/@headlessui-react/src/components/tabs/tabs.tsx
+++ b/packages/@headlessui-react/src/components/tabs/tabs.tsx
@@ -144,6 +144,7 @@ function useData(component: string) {
   }
   return context
 }
+type _Data = ReturnType<typeof useData>
 
 let TabsActionsContext = createContext<{
   registerTab(tab: MutableRefObject<HTMLElement | null>): () => void
@@ -162,6 +163,7 @@ function useActions(component: string) {
   }
   return context
 }
+type _Actions = ReturnType<typeof useActions>
 
 function stateReducer(state: StateDefinition, action: Actions) {
   return match(action.type, reducers, state, action)
@@ -205,13 +207,13 @@ let Tabs = forwardRefWithAs(function Tabs<TTag extends ElementType = typeof DEFA
   let onChangeRef = useLatestValue(onChange || (() => {}))
   let stableTabsRef = useLatestValue(state.tabs)
 
-  let tabsData = useMemo<ContextType<typeof TabsDataContext>>(
+  let tabsData = useMemo<_Data>(
     () => ({ orientation, activation, ...state }),
     [orientation, activation, state]
   )
 
   let lastChangedIndex = useLatestValue(state.selectedIndex)
-  let tabsActions: ContextType<typeof TabsActionsContext> = useMemo(
+  let tabsActions: _Actions = useMemo(
     () => ({
       registerTab(tab) {
         dispatch({ type: ActionTypes.RegisterTab, tab })
@@ -245,18 +247,20 @@ let Tabs = forwardRefWithAs(function Tabs<TTag extends ElementType = typeof DEFA
     <TabsSSRContext.Provider value={SSRCounter}>
       <TabsActionsContext.Provider value={tabsActions}>
         <TabsDataContext.Provider value={tabsData}>
-          <FocusSentinel
-            onFocus={() => {
-              for (let tab of stableTabsRef.current) {
-                if (tab.current?.tabIndex === 0) {
-                  tab.current?.focus()
-                  return true
+          {tabsData.tabs.length <= 0 && (
+            <FocusSentinel
+              onFocus={() => {
+                for (let tab of stableTabsRef.current) {
+                  if (tab.current?.tabIndex === 0) {
+                    tab.current?.focus()
+                    return true
+                  }
                 }
-              }
 
-              return false
-            }}
-          />
+                return false
+              }}
+            />
+          )}
           {render({
             ourProps,
             theirProps,

--- a/packages/@headlessui-vue/src/components/tabs/tabs.ts
+++ b/packages/@headlessui-vue/src/components/tabs/tabs.ts
@@ -139,19 +139,20 @@ export let TabGroup = defineComponent({
       let slot = { selectedIndex: selectedIndex.value }
 
       return h(Fragment, [
-        h(FocusSentinel, {
-          onFocus: () => {
-            for (let tab of tabs.value) {
-              let el = dom(tab)
-              if (el?.tabIndex === 0) {
-                el.focus()
-                return true
+        tabs.value.length <= 0 &&
+          h(FocusSentinel, {
+            onFocus: () => {
+              for (let tab of tabs.value) {
+                let el = dom(tab)
+                if (el?.tabIndex === 0) {
+                  el.focus()
+                  return true
+                }
               }
-            }
 
-            return false
-          },
-        }),
+              return false
+            },
+          }),
         render({
           props: {
             ...attrs,


### PR DESCRIPTION
The `Tabs` component renders a hidden `FocusSentinel` in case it needs to capture focus but the
`Tabs` aren't ready yet. The moment the `FocusSentinel` receives focus and successfully forwards it
to one of the `Tabs`, then it removes itself.

However, the the `FocusSentinel` can also be removed the moment the `Tabs` themselves are ready.

This PR will make sure that it removes itself the moment the `Tabs` are ready.

Fixes: #1491
