### PR TITLE
Ensure the Transition stops once DOM Nodes are hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow to override the `type` on the `Combobox.Input` ([#1476](https://github.com/tailwindlabs/headlessui/pull/1476))
 - Ensure the the `<Popover.Panel focus>` closes correctly ([#1477](https://github.com/tailwindlabs/headlessui/pull/1477))
 - Only render the `FocusSentinel` if required in the `Tabs` component ([#1493](https://github.com/tailwindlabs/headlessui/pull/1493))
+- Ensure the Transition stops once DOM Nodes are hidden ([#1500](https://github.com/tailwindlabs/headlessui/pull/1500))
 
 ### Added
 

--- a/packages/@headlessui-react/src/hooks/use-transition.ts
+++ b/packages/@headlessui-react/src/hooks/use-transition.ts
@@ -72,6 +72,17 @@ export function useTransition({
     if (latestDirection.current === 'idle') return // We don't need to transition
     if (!mounted.current) return
 
+    dd.add(() => {
+      if (!node) return
+
+      let rect = node.getBoundingClientRect()
+
+      if (rect.x === 0 && rect.y === 0 && rect.width === 0 && rect.height === 0) {
+        // The node is completely hidden
+        onStop.current(latestDirection.current)
+      }
+    })
+
     dd.dispose()
 
     beforeEvent()


### PR DESCRIPTION
This PR will fix an issue where the `onStop` callback internally is never called if the DOM node
becomes hidden.

This happens when you use the `Transition` component in combination with the `Dialog` component.
When the `Dialog` becomes "hidden", then we unmount everything, however transitions don't seem to
run, end or cancel on hidden DOM nodes. This causes an issue where "hidden" DOM nodes had a pending
transition.

This pending transition prevented `<Transition.Child>` and `<Transition>` components higher up the
tree from unmounting. This in turn resulted in the `Dialog` not completely unmounting properly.

Fixes: https://github.com/tailwindlabs/headlessui/issues/1417
Fixes: https://github.com/tailwindlabs/tailwindui-issues/issues/1215

