### PR TITLE
Fix event handlers with arity > 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure `Escape` propagates correctly in `Combobox` component ([#1511](https://github.com/tailwindlabs/headlessui/pull/1511))
 - Remove leftover code in Combobox component ([#1514](https://github.com/tailwindlabs/headlessui/pull/1514))
+- Fix event handlers with arity > 1 ([#1515](https://github.com/tailwindlabs/headlessui/pull/1515))
 
 ## [Unreleased - @headlessui/vue]
 

--- a/packages/@headlessui-react/src/utils/render.ts
+++ b/packages/@headlessui-react/src/utils/render.ts
@@ -201,7 +201,7 @@ function mergeProps(...listOfProps: Props<any, any>[]) {
 
   let eventHandlers: Record<
     string,
-    ((event: { defaultPrevented: boolean }) => void | undefined)[]
+    ((event: { defaultPrevented: boolean }, ...args: any[]) => void | undefined)[]
   > = {}
 
   for (let props of listOfProps) {
@@ -232,13 +232,13 @@ function mergeProps(...listOfProps: Props<any, any>[]) {
   // Merge event handlers
   for (let eventName in eventHandlers) {
     Object.assign(target, {
-      [eventName](event: { defaultPrevented: boolean }) {
+      [eventName](event: { defaultPrevented: boolean }, ...args: any[]) {
         let handlers = eventHandlers[eventName]
 
         for (let handler of handlers) {
           if (event.defaultPrevented) return
 
-          handler(event)
+          handler(event, ...args)
         }
       },
     })


### PR DESCRIPTION
This PR fixes an issue where event handlers with an arity > 1 receives `undefined` as the second
argument instead of the required argument.

One of those examples is the `onDragEnd` handler, it receives an event and `PanInfo` but before this
fix this was always undefined.

Fixes: #1513

