### PR TITLE
Fix transition `enter` bug

### DIFF
--- a/packages/@headlessui-react/src/hooks/use-transition.ts
+++ b/packages/@headlessui-react/src/hooks/use-transition.ts
@@ -72,17 +72,6 @@ export function useTransition({
     if (latestDirection.current === 'idle') return // We don't need to transition
     if (!mounted.current) return
 
-    dd.add(() => {
-      if (!node) return
-
-      let rect = node.getBoundingClientRect()
-
-      if (rect.x === 0 && rect.y === 0 && rect.width === 0 && rect.height === 0) {
-        // The node is completely hidden
-        onStop.current(latestDirection.current)
-      }
-    })
-
     dd.dispose()
 
     beforeEvent()


### PR DESCRIPTION
We had an issue where an open Dialog got hidden by css didn't properly unmount because the Transition never "finished". We fixed this by checking if the node was hidden by using `getBoundingClientRect`.

Today I learned that just *reading* those values (aka call `node.getBoundingClientRect()`) it for whatever reason completely stops the transition. This causes the enter transitions to completely stop working.

Instead, we move this code so that we only check the existence of the Node when we try to transition out because this means that the Node is definitely there, just have to check its bounding rect.

Fixes: #1503
