### PR TITLE
fix keyboard navigation on disabled elements

### DIFF
--- a/packages/@headlessui-vue/src/components/tabs/tabs.ts
+++ b/packages/@headlessui-vue/src/components/tabs/tabs.ts
@@ -227,6 +227,8 @@ export let Tab = defineComponent({
         event.preventDefault()
         event.stopPropagation()
 
+        if (props.disabled) return
+
         api.setSelectedIndex(myIndex.value)
         return
       }


### PR DESCRIPTION

fixes #1593 

the disabled tabs can no longer be activated to using the keyboard (however, the disabled tabs can still be focused)