### PR TITLE
Fix getting Vue dom elements

### DIFF
--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `by` prop for `Listbox`, `Combobox` and `RadioGroup` ([#1482](https://github.com/tailwindlabs/headlessui/pull/1482))
 - Add `@headlessui/tailwindcss` plugin ([#1487](https://github.com/tailwindlabs/headlessui/pull/1487))
 
+### Fixed
+
+- Fix getting Vue dom elements ([#1610](https://github.com/tailwindlabs/headlessui/pull/1610))
+
 ## [1.6.5] - 2022-06-20
 
 ### Fixed

--- a/packages/@headlessui-vue/src/utils/dom.ts
+++ b/packages/@headlessui-vue/src/utils/dom.ts
@@ -4,5 +4,5 @@ export function dom<T extends Element | ComponentPublicInstance>(ref?: Ref<T | n
   if (ref == null) return null
   if (ref.value == null) return null
 
-  return '$el' in ref.value ? (ref.value.$el as T | null) : ref.value
+  return (ref.value as { $el?: T }).$el ?? ref.value
 }


### PR DESCRIPTION
It seems like there is a bug trying to get the dom element from a Vue component. I got this problem trying to use a custom button to open a Menu.

Here's a reproduction of the issue: https://stackblitz.com/edit/vitejs-vite-rgp3jk?file=src/App.vue

I reproduced the error in the `playground-vue` as well to test my fix.

What I saw debugging the problem in my app is that `ref.value` is actually a Proxy. That's why doing `'$el' in ref.value` returns false, but doing `ref.value.$el` actually works. I guess it has to do with the way that Vue references component instances, but I think this should be a safe refactor.

Possibly related to https://github.com/vuejs/core/issues/6137