### PR TITLE
Vue: Add toggle event for Popover

### DIFF
--- a/packages/@headlessui-vue/src/components/popover/popover.ts
+++ b/packages/@headlessui-vue/src/components/popover/popover.ts
@@ -97,10 +97,11 @@ interface PopoverRegisterBag {
 
 export let Popover = defineComponent({
   name: 'Popover',
+  emits: { 'toggle': (_value: boolean) => true },
   props: {
     as: { type: [Object, String], default: 'div' },
   },
-  setup(props, { slots, attrs, expose }) {
+  setup(props, { slots, attrs, emit, expose }) {
     let buttonId = `headlessui-popover-button-${useId()}`
     let panelId = `headlessui-popover-panel-${useId()}`
 
@@ -141,6 +142,7 @@ export let Popover = defineComponent({
           [PopoverStates.Open]: PopoverStates.Closed,
           [PopoverStates.Closed]: PopoverStates.Open,
         })
+        emit('toggle', !!popoverState.value)
       },
       closePopover() {
         if (popoverState.value === PopoverStates.Closed) return


### PR DESCRIPTION
Hey 👋

I'm working with the Popover component in Vue, and I found it weird that I don't have an emit event when the component opens and closes.

It seems to me that this is not a case to handle in React?

If I missed something, sorry 😅