### PR TITLE
Menu should not trap focus for tab key

### DIFF
--- a/packages/@headlessui-react/src/components/menu/menu.test.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.test.tsx
@@ -1359,7 +1359,7 @@ describe('Keyboard interactions', () => {
 
   describe('`Tab` key', () => {
     it(
-      'should focus trap when we use Tab',
+      'should close when we use Tab',
       suppressConsoleLogs(async () => {
         render(
           <Menu>
@@ -1401,9 +1401,9 @@ describe('Keyboard interactions', () => {
         // Try to tab
         await press(Keys.Tab)
 
-        // Verify it is still open
-        assertMenuButton({ state: MenuState.Visible })
-        assertMenu({ state: MenuState.Visible })
+        // Verify it is closed
+        assertMenuButton({ state: MenuState.InvisibleUnmounted })
+        assertMenu({ state: MenuState.InvisibleUnmounted })
       })
     )
 
@@ -1450,9 +1450,9 @@ describe('Keyboard interactions', () => {
         // Try to Shift+Tab
         await press(shift(Keys.Tab))
 
-        // Verify it is still open
-        assertMenuButton({ state: MenuState.Visible })
-        assertMenu({ state: MenuState.Visible })
+        // Verify it is closed
+        assertMenuButton({ state: MenuState.InvisibleUnmounted })
+        assertMenu({ state: MenuState.InvisibleUnmounted })
       })
     )
   })

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -490,8 +490,7 @@ let Items = forwardRefWithAs(function Items<TTag extends ElementType = typeof DE
         break
 
       case Keys.Tab:
-        event.preventDefault()
-        event.stopPropagation()
+        dispatch({ type: ActionTypes.CloseMenu })
         break
 
       default:

--- a/packages/@headlessui-vue/src/components/menu/menu.test.tsx
+++ b/packages/@headlessui-vue/src/components/menu/menu.test.tsx
@@ -1656,7 +1656,7 @@ describe('Keyboard interactions', () => {
   })
 
   describe('`Tab` key', () => {
-    it('should focus trap when we use Tab', async () => {
+    it('should not focus trap when we use Tab', async () => {
       renderTemplate(jsx`
         <Menu>
           <MenuButton>Trigger</MenuButton>
@@ -1697,12 +1697,12 @@ describe('Keyboard interactions', () => {
       // Try to tab
       await press(Keys.Tab)
 
-      // Verify it is still open
-      assertMenuButton({ state: MenuState.Visible })
-      assertMenu({ state: MenuState.Visible })
+      // Verify it is closed
+      assertMenuButton({ state: MenuState.InvisibleUnmounted })
+      assertMenu({ state: MenuState.InvisibleUnmounted })
     })
 
-    it('should focus trap when we use Shift+Tab', async () => {
+    it('should not focus trap when we use Shift+Tab', async () => {
       renderTemplate(jsx`
         <Menu>
           <MenuButton>Trigger</MenuButton>
@@ -1743,9 +1743,9 @@ describe('Keyboard interactions', () => {
       // Try to Shift+Tab
       await press(shift(Keys.Tab))
 
-      // Verify it is still open
-      assertMenuButton({ state: MenuState.Visible })
-      assertMenu({ state: MenuState.Visible })
+      // Verify it is closed
+      assertMenuButton({ state: MenuState.InvisibleUnmounted })
+      assertMenu({ state: MenuState.InvisibleUnmounted })
     })
   })
 

--- a/packages/@headlessui-vue/src/components/menu/menu.ts
+++ b/packages/@headlessui-vue/src/components/menu/menu.ts
@@ -409,8 +409,7 @@ export let MenuItems = defineComponent({
           break
 
         case Keys.Tab:
-          event.preventDefault()
-          event.stopPropagation()
+          api.closeMenu()
           break
 
         default:


### PR DESCRIPTION
Fix for #1634

Current behavior is that user cannot tab away from menu. According to the WAI ARIA Menu pattern, Tab key behavior should be as follows:

> Tab and Shift + Tab:
> Move focus into a menubar:
> If focus is moving into the menubar for the first time, focus is set on the first menuitem.
> If the menubar has previously contained focus, focus is optionally set on the menuitem that last had focus. Otherwise, it is set on the first menuitem that is not disabled.
> When focus is on a menuitem in a menu or menubar, move focus out of the menu or menubar, and close all menus and submenus.
> Note that Tab and Shift + Tab do not move focus into a menu. Unlike a menubar, a menu is not visually persistent, and authors are responsible for ensuring focus moves to an item inside of a menu when the menu opens.