### PR TITLE
Adjust outside click handling

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed SSR support on Deno ([#1671](https://github.com/tailwindlabs/headlessui/pull/1671))
+- Don’t close dialog when opened during mouse up event ([#1667](https://github.com/tailwindlabs/headlessui/pull/1667))
+- Don’t close dialog when drag ends outside dialog ([#1667](https://github.com/tailwindlabs/headlessui/pull/1667))
+- Fix outside clicks to close dialog when nested, unopened dialogs are present ([#1667](https://github.com/tailwindlabs/headlessui/pull/1667))
 
 ## [1.6.6] - 2022-07-07
 

--- a/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
@@ -17,7 +17,7 @@ import {
   getDialogs,
   getDialogOverlays,
 } from '../../test-utils/accessibility-assertions'
-import { click, press, Keys } from '../../test-utils/interactions'
+import { click, mouseDrag, press, Keys } from '../../test-utils/interactions'
 import { PropsOf } from '../../types'
 import { Transition } from '../transitions/transition'
 import { createPortal } from 'react-dom'
@@ -1097,6 +1097,48 @@ describe('Mouse interactions', () => {
       await click(document.getElementById('inside'))
 
       assertDialog({ state: DialogState.Visible })
+    })
+  )
+
+  it(
+    'should not close the dialog if click starts inside the dialog but ends outside',
+    suppressConsoleLogs(async () => {
+      function Example() {
+        let [isOpen, setIsOpen] = useState(false)
+        return (
+          <>
+            <button id="trigger" onClick={() => setIsOpen((v) => !v)}>
+              Trigger
+            </button>
+            <div id="imoutside">this thing</div>
+            <Dialog open={isOpen} onClose={setIsOpen}>
+              <Dialog.Backdrop />
+              <Dialog.Panel>
+                <button id="inside">Inside</button>
+                <TabSentinel />
+              </Dialog.Panel>
+            </Dialog>
+          </>
+        )
+      }
+
+      render(<Example />)
+
+      // Open the dialog
+      await click(document.getElementById('trigger'))
+
+      assertDialog({ state: DialogState.Visible })
+
+      // Start a click inside the dialog and end it outside
+      await mouseDrag(document.getElementById('inside'), document.getElementById('imoutside'))
+
+      // It should not have hidden
+      assertDialog({ state: DialogState.Visible })
+
+      await click(document.getElementById('imoutside'))
+
+      // It's gone
+      assertDialog({ state: DialogState.InvisibleUnmounted })
     })
   )
 })

--- a/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
@@ -1066,6 +1066,39 @@ describe('Mouse interactions', () => {
       assertDialog({ state: DialogState.Visible })
     })
   )
+
+  it(
+    'should not close the dialog if opened during mouse up',
+    suppressConsoleLogs(async () => {
+      function Example() {
+        let [isOpen, setIsOpen] = useState(false)
+        return (
+          <>
+            <button id="trigger" onMouseUpCapture={() => setIsOpen((v) => !v)}>
+              Trigger
+            </button>
+            <Dialog open={isOpen} onClose={setIsOpen}>
+              <Dialog.Backdrop />
+              <Dialog.Panel>
+                <button id="inside">Inside</button>
+                <TabSentinel />
+              </Dialog.Panel>
+            </Dialog>
+          </>
+        )
+      }
+
+      render(<Example />)
+
+      await click(document.getElementById('trigger'))
+
+      assertDialog({ state: DialogState.Visible })
+
+      await click(document.getElementById('inside'))
+
+      assertDialog({ state: DialogState.Visible })
+    })
+  )
 })
 
 describe('Nesting', () => {

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -305,6 +305,7 @@ let DialogRoot = forwardRefWithAs(function Dialog<
   return (
     <StackProvider
       type="Dialog"
+      enabled={dialogState === DialogStates.Open}
       element={internalDialogRef}
       onUpdate={useEvent((message, type, element) => {
         if (type !== 'Dialog') return

--- a/packages/@headlessui-react/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-react/src/hooks/use-outside-click.ts
@@ -109,8 +109,8 @@ export function useOutsideClick(
         return
       }
 
-      handleOutsideClick(event, (event) => {
-        return event.target as HTMLElement
+      handleOutsideClick(event, () => {
+        return initialClickTarget.current as HTMLElement
       })
 
       initialClickTarget.current = null

--- a/packages/@headlessui-react/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-react/src/hooks/use-outside-click.ts
@@ -90,9 +90,31 @@ export function useOutsideClick(
     return cb(event, target)
   }
 
+  let initialClickTarget = useRef<EventTarget | null>(null)
+
+  useWindowEvent(
+    'mousedown',
+    (event) => {
+      if (enabledRef.current) {
+        initialClickTarget.current = event.target
+      }
+    },
+    true
+  )
+
   useWindowEvent(
     'click',
-    (event) => handleOutsideClick(event, (event) => event.target as HTMLElement),
+    (event) => {
+      if (!initialClickTarget.current) {
+        return
+      }
+
+      handleOutsideClick(event, (event) => {
+        return event.target as HTMLElement
+      })
+
+      initialClickTarget.current = null
+    },
 
     // We will use the `capture` phase so that layers in between with `event.stopPropagation()`
     // don't "cancel" this outside click check. E.g.: A `Menu` inside a `DialogPanel` if the `Menu`

--- a/packages/@headlessui-react/src/internal/stack-context.tsx
+++ b/packages/@headlessui-react/src/internal/stack-context.tsx
@@ -32,11 +32,13 @@ export function StackProvider({
   onUpdate,
   type,
   element,
+  enabled,
 }: {
   children: ReactNode
   onUpdate?: OnUpdate
   type: string
   element: MutableRefObject<HTMLElement | null>
+  enabled?: boolean
 }) {
   let parentUpdate = useStackContext()
 
@@ -49,9 +51,14 @@ export function StackProvider({
   })
 
   useIsoMorphicEffect(() => {
-    notify(StackMessage.Add, type, element)
-    return () => notify(StackMessage.Remove, type, element)
-  }, [notify, type, element])
+    let shouldNotify = enabled === undefined || enabled === true
+
+    shouldNotify && notify(StackMessage.Add, type, element)
+
+    return () => {
+      shouldNotify && notify(StackMessage.Remove, type, element)
+    }
+  }, [notify, type, element, enabled])
 
   return <StackContext.Provider value={notify}>{children}</StackContext.Provider>
 }

--- a/packages/@headlessui-react/src/test-utils/interactions.ts
+++ b/packages/@headlessui-react/src/test-utils/interactions.ts
@@ -344,6 +344,74 @@ export async function mouseLeave(element: Document | Element | Window | null) {
   }
 }
 
+export async function mouseDrag(
+  startingElement: Document | Element | Window | Node | null,
+  endingElement: Document | Element | Window | Node | null
+) {
+  let button = MouseButton.Left
+
+  try {
+    if (startingElement === null) return expect(startingElement).not.toBe(null)
+    if (endingElement === null) return expect(endingElement).not.toBe(null)
+    if (startingElement instanceof HTMLButtonElement && startingElement.disabled) return
+
+    let options = { button }
+
+    // Cancel in pointerDown cancels mouseDown, mouseUp
+    let cancelled = !fireEvent.pointerDown(startingElement, options)
+
+    if (!cancelled) {
+      cancelled = !fireEvent.mouseDown(startingElement, options)
+    }
+
+    // Ensure to trigger a `focus` event if the element is focusable, or within a focusable element
+    if (!cancelled) {
+      let next: HTMLElement | null = startingElement as HTMLElement | null
+      while (next !== null) {
+        if (next.matches(focusableSelector)) {
+          next.focus()
+          break
+        }
+        next = next.parentElement
+      }
+    }
+
+    fireEvent.pointerMove(startingElement, options)
+    if (!cancelled) {
+      fireEvent.mouseMove(startingElement, options)
+    }
+
+    fireEvent.pointerOut(startingElement, options)
+    if (!cancelled) {
+      fireEvent.mouseOut(startingElement, options)
+    }
+
+    // crosses over to the ending element
+
+    fireEvent.pointerOver(endingElement, options)
+    if (!cancelled) {
+      fireEvent.mouseOver(endingElement, options)
+    }
+
+    fireEvent.pointerMove(endingElement, options)
+    if (!cancelled) {
+      fireEvent.mouseMove(endingElement, options)
+    }
+
+    fireEvent.pointerUp(endingElement, options)
+    if (!cancelled) {
+      fireEvent.mouseUp(endingElement, options)
+    }
+
+    fireEvent.click(endingElement, options)
+
+    await new Promise(nextFrame)
+  } catch (err) {
+    if (err instanceof Error) Error.captureStackTrace(err, click)
+    throw err
+  }
+}
+
 // ---
 
 function focusNext(event: Partial<KeyboardEvent>) {

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed SSR support on Deno ([#1671](https://github.com/tailwindlabs/headlessui/pull/1671))
+- Don’t close dialog when opened during mouse up event ([#1667](https://github.com/tailwindlabs/headlessui/pull/1667))
+- Don’t close dialog when drag ends outside dialog ([#1667](https://github.com/tailwindlabs/headlessui/pull/1667))
+- Fix outside clicks to close dialog when nested, unopened dialogs are present ([#1667](https://github.com/tailwindlabs/headlessui/pull/1667))
 
 ## [1.6.7] - 2022-07-12
 

--- a/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
@@ -1444,6 +1444,48 @@ describe('Mouse interactions', () => {
       assertDialog({ state: DialogState.Visible })
     })
   )
+
+  it(
+    'should not close the dialog if opened during mouse up',
+    suppressConsoleLogs(async () => {
+      renderTemplate({
+        template: `
+          <div>
+            <button id="trigger" @mouseup.capture="toggleOpen">
+              Trigger
+            </button>
+            <Dialog :open="isOpen" @close="setIsOpen">
+              <DialogBackdrop />
+              <DialogPanel>
+                <button id="inside">Inside</button>
+                <TabSentinel />
+              </DialogPanel>
+            </Dialog>
+          </div>
+        `,
+        setup() {
+          let isOpen = ref(false)
+          return {
+            isOpen,
+            setIsOpen(value: boolean) {
+              isOpen.value = value
+            },
+            toggleOpen() {
+              isOpen.value = !isOpen.value
+            },
+          }
+        },
+      })
+
+      await click(document.getElementById('trigger'))
+
+      assertDialog({ state: DialogState.Visible })
+
+      await click(document.getElementById('inside'))
+
+      assertDialog({ state: DialogState.Visible })
+    })
+  )
 })
 
 describe('Nesting', () => {

--- a/packages/@headlessui-vue/src/components/dialog/dialog.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.ts
@@ -140,6 +140,7 @@ export let Dialog = defineComponent({
     )
     useStackProvider({
       type: 'Dialog',
+      enabled: computed(() => dialogState.value === DialogStates.Open),
       element: internalDialogRef,
       onUpdate: (message, type, element) => {
         if (type !== 'Dialog') return

--- a/packages/@headlessui-vue/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-vue/src/hooks/use-outside-click.ts
@@ -95,8 +95,8 @@ export function useOutsideClick(
         return
       }
 
-      handleOutsideClick(event, (event) => {
-        return event.target as HTMLElement
+      handleOutsideClick(event, () => {
+        return initialClickTarget.value as HTMLElement
       })
 
       initialClickTarget.value = null

--- a/packages/@headlessui-vue/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-vue/src/hooks/use-outside-click.ts
@@ -1,5 +1,5 @@
 import { useWindowEvent } from './use-window-event'
-import { computed, Ref, ComputedRef } from 'vue'
+import { computed, Ref, ComputedRef, ref } from 'vue'
 import { FocusableMode, isFocusableElement } from '../utils/focus-management'
 import { dom } from '../utils/dom'
 
@@ -76,9 +76,31 @@ export function useOutsideClick(
     return cb(event, target)
   }
 
+  let initialClickTarget = ref<EventTarget | null>(null)
+
+  useWindowEvent(
+    'mousedown',
+    (event) => {
+      if (enabled.value) {
+        initialClickTarget.value = event.target
+      }
+    },
+    true
+  )
+
   useWindowEvent(
     'click',
-    (event) => handleOutsideClick(event, (event) => event.target as HTMLElement),
+    (event) => {
+      if (!initialClickTarget.value) {
+        return
+      }
+
+      handleOutsideClick(event, (event) => {
+        return event.target as HTMLElement
+      })
+
+      initialClickTarget.value = null
+    },
 
     // We will use the `capture` phase so that layers in between with `event.stopPropagation()`
     // don't "cancel" this outside click check. E.g.: A `Menu` inside a `DialogPanel` if the `Menu`

--- a/packages/@headlessui-vue/src/test-utils/interactions.ts
+++ b/packages/@headlessui-vue/src/test-utils/interactions.ts
@@ -338,6 +338,74 @@ export async function mouseLeave(element: Document | Element | Window | null) {
   }
 }
 
+export async function mouseDrag(
+  startingElement: Document | Element | Window | Node | null,
+  endingElement: Document | Element | Window | Node | null
+) {
+  let button = MouseButton.Left
+
+  try {
+    if (startingElement === null) return expect(startingElement).not.toBe(null)
+    if (endingElement === null) return expect(endingElement).not.toBe(null)
+    if (startingElement instanceof HTMLButtonElement && startingElement.disabled) return
+
+    let options = { button }
+
+    // Cancel in pointerDown cancels mouseDown, mouseUp
+    let cancelled = !fireEvent.pointerDown(startingElement, options)
+
+    if (!cancelled) {
+      cancelled = !fireEvent.mouseDown(startingElement, options)
+    }
+
+    // Ensure to trigger a `focus` event if the element is focusable, or within a focusable element
+    if (!cancelled) {
+      let next: HTMLElement | null = startingElement as HTMLElement | null
+      while (next !== null) {
+        if (next.matches(focusableSelector)) {
+          next.focus()
+          break
+        }
+        next = next.parentElement
+      }
+    }
+
+    fireEvent.pointerMove(startingElement, options)
+    if (!cancelled) {
+      fireEvent.mouseMove(startingElement, options)
+    }
+
+    fireEvent.pointerOut(startingElement, options)
+    if (!cancelled) {
+      fireEvent.mouseOut(startingElement, options)
+    }
+
+    // crosses over to the ending element
+
+    fireEvent.pointerOver(endingElement, options)
+    if (!cancelled) {
+      fireEvent.mouseOver(endingElement, options)
+    }
+
+    fireEvent.pointerMove(endingElement, options)
+    if (!cancelled) {
+      fireEvent.mouseMove(endingElement, options)
+    }
+
+    fireEvent.pointerUp(endingElement, options)
+    if (!cancelled) {
+      fireEvent.mouseUp(endingElement, options)
+    }
+
+    fireEvent.click(endingElement, options)
+
+    await new Promise(nextFrame)
+  } catch (err) {
+    if (err instanceof Error) Error.captureStackTrace(err, click)
+    throw err
+  }
+}
+
 // ---
 
 function focusNext(event: Partial<KeyboardEvent>) {


### PR DESCRIPTION
Right now we use the `click` event for "outside" clicks to close the dialog. However, this is a problem in two situations:
1. If a user opens a dialog during the mousedown or mouseup events the dialog will end up closing because the dialog will get mounted in the DOM before the click event is delivered. This causes it to see the click event as an outside click and fires its close event.
2. If you started a click inside the dialog (e.g. when selecting text) and it ended outside the dialog the click event is delivered _outside_ which we saw as an outside click when it shouldn't be considered as such.

We can fix both of these with a small tweak to `useOutsideClick`:
- Record the element that's clicked in the `mousedown` capture phase
- If we _don't_ have a recorded element then that means that a dialog was opened in a mousedown/mouseup event and we don't want to consider that event for outside click testing.
- Otherwise we  test the recorded element instead of the click event's target for container inclusion to determine if it is or is not an outside click

Fixes #1646
Fixes #1647
Fixes #1657