### PR TITLE
Close `Menu` component when using `tab` key

### DIFF
--- a/packages/@headlessui-react/src/components/menu/menu.test.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.test.tsx
@@ -1359,7 +1359,7 @@ describe('Keyboard interactions', () => {
 
   describe('`Tab` key', () => {
     it(
-      'should focus trap when we use Tab',
+      'should close when we use Tab',
       suppressConsoleLogs(async () => {
         render(
           <Menu>
@@ -1401,9 +1401,9 @@ describe('Keyboard interactions', () => {
         // Try to tab
         await press(Keys.Tab)
 
-        // Verify it is still open
-        assertMenuButton({ state: MenuState.Visible })
-        assertMenu({ state: MenuState.Visible })
+        // Verify it is closed
+        assertMenuButton({ state: MenuState.InvisibleUnmounted })
+        assertMenu({ state: MenuState.InvisibleUnmounted })
       })
     )
 
@@ -1450,9 +1450,9 @@ describe('Keyboard interactions', () => {
         // Try to Shift+Tab
         await press(shift(Keys.Tab))
 
-        // Verify it is still open
-        assertMenuButton({ state: MenuState.Visible })
-        assertMenu({ state: MenuState.Visible })
+        // Verify it is closed
+        assertMenuButton({ state: MenuState.InvisibleUnmounted })
+        assertMenu({ state: MenuState.InvisibleUnmounted })
       })
     )
   })

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -490,8 +490,7 @@ let Items = forwardRefWithAs(function Items<TTag extends ElementType = typeof DE
         break
 
       case Keys.Tab:
-        event.preventDefault()
-        event.stopPropagation()
+        dispatch({ type: ActionTypes.CloseMenu })
         break
 
       default:

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -29,7 +29,13 @@ import { useId } from '../../hooks/use-id'
 import { Keys } from '../keyboard'
 import { Focus, calculateActiveIndex } from '../../utils/calculate-active-index'
 import { isDisabledReactIssue7711 } from '../../utils/bugs'
-import { isFocusableElement, FocusableMode, sortByDomNode } from '../../utils/focus-management'
+import {
+  isFocusableElement,
+  FocusableMode,
+  sortByDomNode,
+  Focus as FocusManagementFocus,
+  focusFrom,
+} from '../../utils/focus-management'
 import { useOutsideClick } from '../../hooks/use-outside-click'
 import { useTreeWalker } from '../../hooks/use-tree-walker'
 import { useOpenClosed, State, OpenClosedProvider } from '../../internal/open-closed'
@@ -490,7 +496,15 @@ let Items = forwardRefWithAs(function Items<TTag extends ElementType = typeof DE
         break
 
       case Keys.Tab:
+        event.preventDefault()
+        event.stopPropagation()
         dispatch({ type: ActionTypes.CloseMenu })
+        disposables().nextFrame(() => {
+          focusFrom(
+            state.buttonRef.current!,
+            event.shiftKey ? FocusManagementFocus.Previous : FocusManagementFocus.Next
+          )
+        })
         break
 
       default:

--- a/packages/@headlessui-react/src/utils/focus-management.ts
+++ b/packages/@headlessui-react/src/utils/focus-management.ts
@@ -129,7 +129,16 @@ export function sortByDomNode<T>(
   })
 }
 
-export function focusIn(container: HTMLElement | HTMLElement[], focus: Focus, sorted = true) {
+export function focusFrom(current: HTMLElement | null, focus: Focus) {
+  return focusIn(getFocusableElements(), focus, true, current)
+}
+
+export function focusIn(
+  container: HTMLElement | HTMLElement[],
+  focus: Focus,
+  sorted = true,
+  active: HTMLElement | null = null
+) {
   let ownerDocument = Array.isArray(container)
     ? container.length > 0
       ? container[0].ownerDocument
@@ -141,7 +150,7 @@ export function focusIn(container: HTMLElement | HTMLElement[], focus: Focus, so
       ? sortByDomNode(container)
       : container
     : getFocusableElements(container)
-  let active = ownerDocument.activeElement as HTMLElement
+  active = active ?? (ownerDocument.activeElement as HTMLElement)
 
   let direction = (() => {
     if (focus & (Focus.First | Focus.Next)) return Direction.Next

--- a/packages/@headlessui-vue/src/components/menu/menu.test.tsx
+++ b/packages/@headlessui-vue/src/components/menu/menu.test.tsx
@@ -1656,7 +1656,7 @@ describe('Keyboard interactions', () => {
   })
 
   describe('`Tab` key', () => {
-    it('should focus trap when we use Tab', async () => {
+    it('should not focus trap when we use Tab', async () => {
       renderTemplate(jsx`
         <Menu>
           <MenuButton>Trigger</MenuButton>
@@ -1697,12 +1697,12 @@ describe('Keyboard interactions', () => {
       // Try to tab
       await press(Keys.Tab)
 
-      // Verify it is still open
-      assertMenuButton({ state: MenuState.Visible })
-      assertMenu({ state: MenuState.Visible })
+      // Verify it is closed
+      assertMenuButton({ state: MenuState.InvisibleUnmounted })
+      assertMenu({ state: MenuState.InvisibleUnmounted })
     })
 
-    it('should focus trap when we use Shift+Tab', async () => {
+    it('should not focus trap when we use Shift+Tab', async () => {
       renderTemplate(jsx`
         <Menu>
           <MenuButton>Trigger</MenuButton>
@@ -1743,9 +1743,9 @@ describe('Keyboard interactions', () => {
       // Try to Shift+Tab
       await press(shift(Keys.Tab))
 
-      // Verify it is still open
-      assertMenuButton({ state: MenuState.Visible })
-      assertMenu({ state: MenuState.Visible })
+      // Verify it is closed
+      assertMenuButton({ state: MenuState.InvisibleUnmounted })
+      assertMenu({ state: MenuState.InvisibleUnmounted })
     })
   })
 

--- a/packages/@headlessui-vue/src/components/menu/menu.ts
+++ b/packages/@headlessui-vue/src/components/menu/menu.ts
@@ -411,8 +411,7 @@ export let MenuItems = defineComponent({
           break
 
         case Keys.Tab:
-          event.preventDefault()
-          event.stopPropagation()
+          api.closeMenu()
           break
 
         default:

--- a/packages/@headlessui-vue/src/components/menu/menu.ts
+++ b/packages/@headlessui-vue/src/components/menu/menu.ts
@@ -22,7 +22,13 @@ import { useTreeWalker } from '../../hooks/use-tree-walker'
 import { useOpenClosedProvider, State, useOpenClosed } from '../../internal/open-closed'
 import { match } from '../../utils/match'
 import { useResolveButtonType } from '../../hooks/use-resolve-button-type'
-import { FocusableMode, isFocusableElement, sortByDomNode } from '../../utils/focus-management'
+import {
+  FocusableMode,
+  isFocusableElement,
+  sortByDomNode,
+  Focus as FocusManagementFocus,
+  focusFrom,
+} from '../../utils/focus-management'
 import { useOutsideClick } from '../../hooks/use-outside-click'
 
 enum MenuStates {
@@ -411,7 +417,15 @@ export let MenuItems = defineComponent({
           break
 
         case Keys.Tab:
+          event.preventDefault()
+          event.stopPropagation()
           api.closeMenu()
+          nextTick(() =>
+            focusFrom(
+              dom(api.buttonRef),
+              event.shiftKey ? FocusManagementFocus.Previous : FocusManagementFocus.Next
+            )
+          )
           break
 
         default:


### PR DESCRIPTION
This is a bit of an odd one, we always used to focus trap when the `Menu` component is open and I'm
pretty sure this was also recommend on some pages.

Looking at the new [ARIA Authoring Practices Guide (APG)](https://www.w3.org/WAI/ARIA/apg/) pages this is now recommended https://www.w3.org/WAI/ARIA/apg/patterns/menu/ 

> When focus is on a menuitem in a menu or menubar, **move focus out** of the menu or menubar, and close all menus and submenus.

This is also what was mentioned by @eriese on the original issue #1634 and #1639

This PR is a continuation of #1639 with a few more improvements and cleanup, but I started from the
original PR just so that the original work from @eriese is includes (Thanks for starting this!)


I also did some digging around the internet and other libraries implement it either using focus
trapping or with the new proper "move focus out" code.


Closes: #1639
Fixes: #1634

