### PR TITLE
Make form components uncontrollable

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -901,6 +901,134 @@ describe('Rendering', () => {
     // Verify that the third combobox option is active
     assertActiveComboboxOption(options[2])
   })
+
+  describe('Uncontrolled', () => {
+    it('should be possible to use in an uncontrolled way', async () => {
+      let handleSubmission = jest.fn()
+
+      render(
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleSubmission(Object.fromEntries(new FormData(e.target as HTMLFormElement)))
+          }}
+        >
+          <Combobox name="assignee">
+            <Combobox.Input onChange={NOOP} />
+            <Combobox.Button>Trigger</Combobox.Button>
+            <Combobox.Options>
+              <Combobox.Option value="alice">Alice</Combobox.Option>
+              <Combobox.Option value="bob">Bob</Combobox.Option>
+              <Combobox.Option value="charlie">Charlie</Combobox.Option>
+            </Combobox.Options>
+          </Combobox>
+          <button id="submit">submit</button>
+        </form>
+      )
+
+      await click(document.getElementById('submit'))
+
+      // No values
+      expect(handleSubmission).toHaveBeenLastCalledWith({})
+
+      // Open combobox
+      await click(getComboboxButton())
+
+      // Choose alice
+      await click(getComboboxOptions()[0])
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Alice should be submitted
+      expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'alice' })
+
+      // Open combobox
+      await click(getComboboxButton())
+
+      // Choose charlie
+      await click(getComboboxOptions()[2])
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Charlie should be submitted
+      expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'charlie' })
+    })
+
+    it('should be possible to provide a default value', async () => {
+      let handleSubmission = jest.fn()
+
+      render(
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleSubmission(Object.fromEntries(new FormData(e.target as HTMLFormElement)))
+          }}
+        >
+          <Combobox name="assignee" defaultValue="bob">
+            <Combobox.Input onChange={NOOP} />
+            <Combobox.Button>Trigger</Combobox.Button>
+            <Combobox.Options>
+              <Combobox.Option value="alice">Alice</Combobox.Option>
+              <Combobox.Option value="bob">Bob</Combobox.Option>
+              <Combobox.Option value="charlie">Charlie</Combobox.Option>
+            </Combobox.Options>
+          </Combobox>
+          <button id="submit">submit</button>
+        </form>
+      )
+
+      await click(document.getElementById('submit'))
+
+      // Bob is the defaultValue
+      expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'bob' })
+
+      // Open combobox
+      await click(getComboboxButton())
+
+      // Choose alice
+      await click(getComboboxOptions()[0])
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Alice should be submitted
+      expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'alice' })
+    })
+
+    it('should still call the onChange listeners when choosing new values', async () => {
+      let handleChange = jest.fn()
+
+      render(
+        <Combobox name="assignee" onChange={handleChange}>
+          <Combobox.Input onChange={NOOP} />
+          <Combobox.Button>Trigger</Combobox.Button>
+          <Combobox.Options>
+            <Combobox.Option value="alice">Alice</Combobox.Option>
+            <Combobox.Option value="bob">Bob</Combobox.Option>
+            <Combobox.Option value="charlie">Charlie</Combobox.Option>
+          </Combobox.Options>
+        </Combobox>
+      )
+
+      // Open combobox
+      await click(getComboboxButton())
+
+      // Choose alice
+      await click(getComboboxOptions()[0])
+
+      // Open combobox
+      await click(getComboboxButton())
+
+      // Choose bob
+      await click(getComboboxOptions()[1])
+
+      // Change handler should have been called twice
+      expect(handleChange).toHaveBeenNthCalledWith(1, 'alice')
+      expect(handleChange).toHaveBeenNthCalledWith(2, 'bob')
+    })
+  })
 })
 
 describe('Rendering composition', () => {

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -302,6 +302,7 @@ interface ComboboxRenderPropArg<T> {
   disabled: boolean
   activeIndex: number | null
   activeOption: T | null
+  value: T
 }
 
 let ComboboxRoot = forwardRefWithAs(function Combobox<

--- a/packages/@headlessui-react/src/components/listbox/listbox.test.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.test.tsx
@@ -719,6 +719,131 @@ describe('Rendering', () => {
     // Verify that the third menu item is active
     assertActiveListboxOption(options[2])
   })
+
+  describe('Uncontrolled', () => {
+    it('should be possible to use in an uncontrolled way', async () => {
+      let handleSubmission = jest.fn()
+
+      render(
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleSubmission(Object.fromEntries(new FormData(e.target as HTMLFormElement)))
+          }}
+        >
+          <Listbox name="assignee">
+            <Listbox.Button>Trigger</Listbox.Button>
+            <Listbox.Options>
+              <Listbox.Option value="alice">Alice</Listbox.Option>
+              <Listbox.Option value="bob">Bob</Listbox.Option>
+              <Listbox.Option value="charlie">Charlie</Listbox.Option>
+            </Listbox.Options>
+          </Listbox>
+          <button id="submit">submit</button>
+        </form>
+      )
+
+      await click(document.getElementById('submit'))
+
+      // No values
+      expect(handleSubmission).toHaveBeenLastCalledWith({})
+
+      // Open listbox
+      await click(getListboxButton())
+
+      // Choose alice
+      await click(getListboxOptions()[0])
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Alice should be submitted
+      expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'alice' })
+
+      // Open listbox
+      await click(getListboxButton())
+
+      // Choose charlie
+      await click(getListboxOptions()[2])
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Charlie should be submitted
+      expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'charlie' })
+    })
+
+    it('should be possible to provide a default value', async () => {
+      let handleSubmission = jest.fn()
+
+      render(
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleSubmission(Object.fromEntries(new FormData(e.target as HTMLFormElement)))
+          }}
+        >
+          <Listbox name="assignee" defaultValue="bob">
+            <Listbox.Button>Trigger</Listbox.Button>
+            <Listbox.Options>
+              <Listbox.Option value="alice">Alice</Listbox.Option>
+              <Listbox.Option value="bob">Bob</Listbox.Option>
+              <Listbox.Option value="charlie">Charlie</Listbox.Option>
+            </Listbox.Options>
+          </Listbox>
+          <button id="submit">submit</button>
+        </form>
+      )
+
+      await click(document.getElementById('submit'))
+
+      // Bob is the defaultValue
+      expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'bob' })
+
+      // Open listbox
+      await click(getListboxButton())
+
+      // Choose alice
+      await click(getListboxOptions()[0])
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Alice should be submitted
+      expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'alice' })
+    })
+
+    it('should still call the onChange listeners when choosing new values', async () => {
+      let handleChange = jest.fn()
+
+      render(
+        <Listbox name="assignee" onChange={handleChange}>
+          <Listbox.Button>Trigger</Listbox.Button>
+          <Listbox.Options>
+            <Listbox.Option value="alice">Alice</Listbox.Option>
+            <Listbox.Option value="bob">Bob</Listbox.Option>
+            <Listbox.Option value="charlie">Charlie</Listbox.Option>
+          </Listbox.Options>
+        </Listbox>
+      )
+
+      // Open listbox
+      await click(getListboxButton())
+
+      // Choose alice
+      await click(getListboxOptions()[0])
+
+      // Open listbox
+      await click(getListboxButton())
+
+      // Choose bob
+      await click(getListboxOptions()[1])
+
+      // Change handler should have been called twice
+      expect(handleChange).toHaveBeenNthCalledWith(1, 'alice')
+      expect(handleChange).toHaveBeenNthCalledWith(2, 'bob')
+    })
+  })
 })
 
 describe('Rendering composition', () => {

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -299,9 +299,10 @@ function stateReducer(state: StateDefinition, action: Actions) {
 // ---
 
 let DEFAULT_LISTBOX_TAG = Fragment
-interface ListboxRenderPropArg {
+interface ListboxRenderPropArg<TType> {
   open: boolean
   disabled: boolean
+  value: TType
 }
 
 let ListboxRoot = forwardRefWithAs(function Listbox<
@@ -311,7 +312,7 @@ let ListboxRoot = forwardRefWithAs(function Listbox<
 >(
   props: Props<
     TTag,
-    ListboxRenderPropArg,
+    ListboxRenderPropArg<TType>,
     'value' | 'defaultValue' | 'onChange' | 'by' | 'disabled' | 'horizontal' | 'name' | 'multiple'
   > & {
     value?: TType
@@ -417,7 +418,7 @@ let ListboxRoot = forwardRefWithAs(function Listbox<
     listboxState === ListboxStates.Open
   )
 
-  let slot = useMemo<ListboxRenderPropArg>(
+  let slot = useMemo<ListboxRenderPropArg<TType>>(
     () => ({ open: listboxState === ListboxStates.Open, disabled, value }),
     [listboxState, disabled, value]
   )

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -37,6 +37,7 @@ import { Hidden, Features as HiddenFeatures } from '../../internal/hidden'
 import { objectToFormEntries } from '../../utils/form'
 import { getOwnerDocument } from '../../utils/owner'
 import { useEvent } from '../../hooks/use-event'
+import { useControllable } from '../../hooks/use-controllable'
 
 enum ListboxStates {
   Open,
@@ -311,10 +312,11 @@ let ListboxRoot = forwardRefWithAs(function Listbox<
   props: Props<
     TTag,
     ListboxRenderPropArg,
-    'value' | 'onChange' | 'disabled' | 'horizontal' | 'name' | 'multiple' | 'by'
+    'value' | 'defaultValue' | 'onChange' | 'by' | 'disabled' | 'horizontal' | 'name' | 'multiple'
   > & {
-    value: TType
-    onChange(value: TType): void
+    value?: TType
+    defaultValue?: TType
+    onChange?(value: TType): void
     by?: (keyof TActualType & string) | ((a: TActualType, z: TActualType) => boolean)
     disabled?: boolean
     horizontal?: boolean
@@ -324,9 +326,10 @@ let ListboxRoot = forwardRefWithAs(function Listbox<
   ref: Ref<TTag>
 ) {
   let {
-    value,
+    value: controlledValue,
+    defaultValue,
     name,
-    onChange,
+    onChange: controlledOnChange,
     by = (a, z) => a === z,
     disabled = false,
     horizontal = false,
@@ -335,6 +338,8 @@ let ListboxRoot = forwardRefWithAs(function Listbox<
   } = props
   const orientation = horizontal ? 'horizontal' : 'vertical'
   let listboxRef = useSyncRefs(ref)
+
+  let [value, onChange] = useControllable(controlledValue, controlledOnChange, defaultValue)
 
   let reducerBag = useReducer(stateReducer, {
     listboxState: ListboxStates.Closed,
@@ -413,8 +418,8 @@ let ListboxRoot = forwardRefWithAs(function Listbox<
   )
 
   let slot = useMemo<ListboxRenderPropArg>(
-    () => ({ open: listboxState === ListboxStates.Open, disabled }),
-    [listboxState, disabled]
+    () => ({ open: listboxState === ListboxStates.Open, disabled, value }),
+    [listboxState, disabled, value]
   )
 
   let ourProps = { ref: listboxRef }

--- a/packages/@headlessui-react/src/components/radio-group/radio-group.test.tsx
+++ b/packages/@headlessui-react/src/components/radio-group/radio-group.test.tsx
@@ -458,6 +458,116 @@ describe('Rendering', () => {
       })
     )
   })
+
+  describe('Uncontrolled', () => {
+    it(
+      'should be possible to use in an uncontrolled way',
+      suppressConsoleLogs(async () => {
+        let handleSubmission = jest.fn()
+
+        render(
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              handleSubmission(Object.fromEntries(new FormData(e.target as HTMLFormElement)))
+            }}
+          >
+            <RadioGroup name="assignee">
+              <RadioGroup.Option value="alice">Alice</RadioGroup.Option>
+              <RadioGroup.Option value="bob">Bob</RadioGroup.Option>
+              <RadioGroup.Option value="charlie">Charlie</RadioGroup.Option>
+            </RadioGroup>
+            <button id="submit">submit</button>
+          </form>
+        )
+
+        await click(document.getElementById('submit'))
+
+        // No values
+        expect(handleSubmission).toHaveBeenLastCalledWith({})
+
+        // Choose alice
+        await click(getRadioGroupOptions()[0])
+
+        // Submit
+        await click(document.getElementById('submit'))
+
+        // Alice should be submitted
+        expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'alice' })
+
+        // Choose charlie
+        await click(getRadioGroupOptions()[2])
+
+        // Submit
+        await click(document.getElementById('submit'))
+
+        // Charlie should be submitted
+        expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'charlie' })
+      })
+    )
+
+    it(
+      'should be possible to provide a default value',
+      suppressConsoleLogs(async () => {
+        let handleSubmission = jest.fn()
+
+        render(
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              handleSubmission(Object.fromEntries(new FormData(e.target as HTMLFormElement)))
+            }}
+          >
+            <RadioGroup name="assignee" defaultValue="bob">
+              <RadioGroup.Option value="alice">Alice</RadioGroup.Option>
+              <RadioGroup.Option value="bob">Bob</RadioGroup.Option>
+              <RadioGroup.Option value="charlie">Charlie</RadioGroup.Option>
+            </RadioGroup>
+            <button id="submit">submit</button>
+          </form>
+        )
+
+        await click(document.getElementById('submit'))
+
+        // Bob is the defaultValue
+        expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'bob' })
+
+        // Choose alice
+        await click(getRadioGroupOptions()[0])
+
+        // Submit
+        await click(document.getElementById('submit'))
+
+        // Alice should be submitted
+        expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'alice' })
+      })
+    )
+
+    it(
+      'should still call the onChange listeners when choosing new values',
+      suppressConsoleLogs(async () => {
+        let handleChange = jest.fn()
+
+        render(
+          <RadioGroup name="assignee" onChange={handleChange}>
+            <RadioGroup.Option value="alice">Alice</RadioGroup.Option>
+            <RadioGroup.Option value="bob">Bob</RadioGroup.Option>
+            <RadioGroup.Option value="charlie">Charlie</RadioGroup.Option>
+          </RadioGroup>
+        )
+
+        // Choose alice
+        await click(getRadioGroupOptions()[0])
+
+        // Choose bob
+        await click(getRadioGroupOptions()[1])
+
+        // Change handler should have been called twice
+        expect(handleChange).toHaveBeenNthCalledWith(1, 'alice')
+        expect(handleChange).toHaveBeenNthCalledWith(2, 'bob')
+      })
+    )
+  })
 })
 
 describe('Keyboard interactions', () => {

--- a/packages/@headlessui-react/src/components/switch/switch.test.tsx
+++ b/packages/@headlessui-react/src/components/switch/switch.test.tsx
@@ -119,6 +119,136 @@ describe('Rendering', () => {
       expect(getSwitch()).not.toHaveAttribute('type')
     })
   })
+
+  describe('Uncontrolled', () => {
+    it('should be possible to use in an uncontrolled way', async () => {
+      let handleSubmission = jest.fn()
+
+      render(
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleSubmission(Object.fromEntries(new FormData(e.target as HTMLFormElement)))
+          }}
+        >
+          <Switch name="notifications" />
+          <button id="submit">submit</button>
+        </form>
+      )
+
+      await click(document.getElementById('submit'))
+
+      // No values
+      expect(handleSubmission).toHaveBeenLastCalledWith({})
+
+      // Toggle
+      await click(getSwitch())
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Notifications should be on
+      expect(handleSubmission).toHaveBeenLastCalledWith({ notifications: 'on' })
+
+      // Toggle
+      await click(getSwitch())
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Notifications should be off (or in this case, non-existant)
+      expect(handleSubmission).toHaveBeenLastCalledWith({})
+    })
+
+    it('should be possible to use in an uncontrolled way with a value', async () => {
+      let handleSubmission = jest.fn()
+
+      render(
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleSubmission(Object.fromEntries(new FormData(e.target as HTMLFormElement)))
+          }}
+        >
+          <Switch name="notifications" value="enabled" />
+          <button id="submit">submit</button>
+        </form>
+      )
+
+      await click(document.getElementById('submit'))
+
+      // No values
+      expect(handleSubmission).toHaveBeenLastCalledWith({})
+
+      // Toggle
+      await click(getSwitch())
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Notifications should be on
+      expect(handleSubmission).toHaveBeenLastCalledWith({ notifications: 'enabled' })
+
+      // Toggle
+      await click(getSwitch())
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Notifications should be off (or in this case, non-existant)
+      expect(handleSubmission).toHaveBeenLastCalledWith({})
+    })
+
+    it('should be possible to provide a default value', async () => {
+      let handleSubmission = jest.fn()
+
+      render(
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleSubmission(Object.fromEntries(new FormData(e.target as HTMLFormElement)))
+          }}
+        >
+          <Switch name="notifications" defaultChecked />
+          <button id="submit">submit</button>
+        </form>
+      )
+
+      await click(document.getElementById('submit'))
+
+      // Notifications should be on by default
+      expect(handleSubmission).toHaveBeenLastCalledWith({ notifications: 'on' })
+
+      // Toggle
+      await click(getSwitch())
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Notifications should be off (or in this case non-existant)
+      expect(handleSubmission).toHaveBeenLastCalledWith({})
+    })
+
+    it('should still call the onChange listeners when choosing new values', async () => {
+      let handleChange = jest.fn()
+
+      render(<Switch name="notifications" onChange={handleChange} />)
+
+      // Toggle
+      await click(getSwitch())
+
+      // Toggle
+      await click(getSwitch())
+
+      // Toggle
+      await click(getSwitch())
+
+      // Change handler should have been called 3 times
+      expect(handleChange).toHaveBeenNthCalledWith(1, true)
+      expect(handleChange).toHaveBeenNthCalledWith(2, false)
+      expect(handleChange).toHaveBeenNthCalledWith(3, true)
+    })
+  })
 })
 
 describe('Render composition', () => {

--- a/packages/@headlessui-react/src/components/switch/switch.tsx
+++ b/packages/@headlessui-react/src/components/switch/switch.tsx
@@ -25,6 +25,7 @@ import { useSyncRefs } from '../../hooks/use-sync-refs'
 import { Hidden, Features as HiddenFeatures } from '../../internal/hidden'
 import { attemptSubmit } from '../../utils/form'
 import { useEvent } from '../../hooks/use-event'
+import { useControllable } from '../../hooks/use-controllable'
 
 interface StateDefinition {
   switch: HTMLButtonElement | null
@@ -101,16 +102,24 @@ let SwitchRoot = forwardRefWithAs(function Switch<
   props: Props<
     TTag,
     SwitchRenderPropArg,
-    SwitchPropsWeControl | 'checked' | 'onChange' | 'name' | 'value'
+    SwitchPropsWeControl | 'checked' | 'defaultChecked' | 'onChange' | 'name' | 'value'
   > & {
-    checked: boolean
-    onChange(checked: boolean): void
+    checked?: boolean
+    defaultChecked?: boolean
+    onChange?(checked: boolean): void
     name?: string
     value?: string
   },
   ref: Ref<HTMLElement>
 ) {
-  let { checked, onChange, name, value, ...theirProps } = props
+  let {
+    checked: controlledChecked,
+    defaultChecked = false,
+    onChange: controlledOnChange,
+    name,
+    value,
+    ...theirProps
+  } = props
   let id = `headlessui-switch-${useId()}`
   let groupContext = useContext(GroupContext)
   let internalSwitchRef = useRef<HTMLButtonElement | null>(null)
@@ -121,7 +130,9 @@ let SwitchRoot = forwardRefWithAs(function Switch<
     groupContext === null ? null : groupContext.setSwitch
   )
 
-  let toggle = useEvent(() => onChange(!checked))
+  let [checked, onChange] = useControllable(controlledChecked, controlledOnChange, defaultChecked)
+
+  let toggle = useEvent(() => onChange?.(!checked))
   let handleClick = useEvent((event: ReactMouseEvent) => {
     if (isDisabledReactIssue7711(event.currentTarget)) return event.preventDefault()
     event.preventDefault()

--- a/packages/@headlessui-react/src/hooks/use-controllable.ts
+++ b/packages/@headlessui-react/src/hooks/use-controllable.ts
@@ -1,0 +1,23 @@
+import { useState } from 'react'
+import { useEvent } from './use-event'
+
+export function useControllable<T>(
+  controlledValue: T | undefined,
+  onChange?: (value: T) => void,
+  defaultValue?: T
+) {
+  let [internalValue, setInternalValue] = useState(defaultValue)
+  let isControlled = controlledValue !== undefined
+
+  return [
+    (isControlled ? controlledValue : internalValue)!,
+    useEvent((value) => {
+      if (isControlled) {
+        return onChange?.(value)
+      } else {
+        setInternalValue(value)
+        return onChange?.(value)
+      }
+    }),
+  ] as const
+}

--- a/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
@@ -982,6 +982,145 @@ describe('Rendering', () => {
     // Verify that the third combobox option is active
     assertActiveComboboxOption(options[2])
   })
+
+  describe('Uncontrolled', () => {
+    it('should be possible to use in an uncontrolled way', async () => {
+      let handleSubmission = jest.fn()
+
+      renderTemplate({
+        template: html`
+          <form @submit="handleSubmit">
+            <Combobox name="assignee">
+              <ComboboxInput />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="alice">Alice</ComboboxOption>
+                <ComboboxOption value="bob">Bob</ComboboxOption>
+                <ComboboxOption value="charlie">Charlie</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+            <button id="submit">submit</button>
+          </form>
+        `,
+        setup: () => ({
+          handleSubmit(e: SubmitEvent) {
+            e.preventDefault()
+            handleSubmission(Object.fromEntries(new FormData(e.target as HTMLFormElement)))
+          },
+        }),
+      })
+
+      await click(document.getElementById('submit'))
+
+      // No values
+      expect(handleSubmission).toHaveBeenLastCalledWith({})
+
+      // Open combobox
+      await click(getComboboxButton())
+
+      // Choose alice
+      await click(getComboboxOptions()[0])
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Alice should be submitted
+      expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'alice' })
+
+      // Open combobox
+      await click(getComboboxButton())
+
+      // Choose charlie
+      await click(getComboboxOptions()[2])
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Charlie should be submitted
+      expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'charlie' })
+    })
+
+    it('should be possible to provide a default value', async () => {
+      let handleSubmission = jest.fn()
+
+      renderTemplate({
+        template: html`
+          <form @submit="handleSubmit">
+            <Combobox name="assignee" defaultValue="bob">
+              <ComboboxInput />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="alice">Alice</ComboboxOption>
+                <ComboboxOption value="bob">Bob</ComboboxOption>
+                <ComboboxOption value="charlie">Charlie</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+            <button id="submit">submit</button>
+          </form>
+        `,
+        setup: () => ({
+          handleSubmit(e: SubmitEvent) {
+            e.preventDefault()
+            handleSubmission(Object.fromEntries(new FormData(e.target as HTMLFormElement)))
+          },
+        }),
+      })
+
+      await click(document.getElementById('submit'))
+
+      // Bob is the defaultValue
+      expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'bob' })
+
+      // Open combobox
+      await click(getComboboxButton())
+
+      // Choose alice
+      await click(getComboboxOptions()[0])
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Alice should be submitted
+      expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'alice' })
+    })
+
+    it('should still call the onChange listeners when choosing new values', async () => {
+      let handleChange = jest.fn()
+
+      renderTemplate({
+        template: html`
+          <Combobox name="assignee" @update:modelValue="handleChange">
+            <ComboboxInput />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="alice">Alice</ComboboxOption>
+              <ComboboxOption value="bob">Bob</ComboboxOption>
+              <ComboboxOption value="charlie">Charlie</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+        `,
+        setup: () => ({
+          handleChange,
+        }),
+      })
+
+      // Open combobox
+      await click(getComboboxButton())
+
+      // Choose alice
+      await click(getComboboxOptions()[0])
+
+      // Open combobox
+      await click(getComboboxButton())
+
+      // Choose bob
+      await click(getComboboxOptions()[1])
+
+      // Change handler should have been called twice
+      expect(handleChange).toHaveBeenNthCalledWith(1, 'alice')
+      expect(handleChange).toHaveBeenNthCalledWith(2, 'bob')
+    })
+  })
 })
 
 describe('Rendering composition', () => {

--- a/packages/@headlessui-vue/src/components/listbox/listbox.test.tsx
+++ b/packages/@headlessui-vue/src/components/listbox/listbox.test.tsx
@@ -806,6 +806,140 @@ describe('Rendering', () => {
     // Verify that the third listbox option is active
     assertActiveListboxOption(options[2])
   })
+
+  describe('Uncontrolled', () => {
+    it('should be possible to use in an uncontrolled way', async () => {
+      let handleSubmission = jest.fn()
+
+      renderTemplate({
+        template: html`
+          <form @submit="handleSubmit">
+            <Listbox name="assignee">
+              <ListboxButton>Trigger</ListboxButton>
+              <ListboxOptions>
+                <ListboxOption value="alice">Alice</ListboxOption>
+                <ListboxOption value="bob">Bob</ListboxOption>
+                <ListboxOption value="charlie">Charlie</ListboxOption>
+              </ListboxOptions>
+            </Listbox>
+            <button id="submit">submit</button>
+          </form>
+        `,
+        setup: () => ({
+          handleSubmit(e: SubmitEvent) {
+            e.preventDefault()
+            handleSubmission(Object.fromEntries(new FormData(e.target as HTMLFormElement)))
+          },
+        }),
+      })
+
+      await click(document.getElementById('submit'))
+
+      // No values
+      expect(handleSubmission).toHaveBeenLastCalledWith({})
+
+      // Open listbox
+      await click(getListboxButton())
+
+      // Choose alice
+      await click(getListboxOptions()[0])
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Alice should be submitted
+      expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'alice' })
+
+      // Open listbox
+      await click(getListboxButton())
+
+      // Choose charlie
+      await click(getListboxOptions()[2])
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Charlie should be submitted
+      expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'charlie' })
+    })
+
+    it('should be possible to provide a default value', async () => {
+      let handleSubmission = jest.fn()
+
+      renderTemplate({
+        template: html`
+          <form @submit="handleSubmit">
+            <Listbox name="assignee" defaultValue="bob">
+              <ListboxButton>Trigger</ListboxButton>
+              <ListboxOptions>
+                <ListboxOption value="alice">Alice</ListboxOption>
+                <ListboxOption value="bob">Bob</ListboxOption>
+                <ListboxOption value="charlie">Charlie</ListboxOption>
+              </ListboxOptions>
+            </Listbox>
+            <button id="submit">submit</button>
+          </form>
+        `,
+        setup: () => ({
+          handleSubmit(e: SubmitEvent) {
+            e.preventDefault()
+            handleSubmission(Object.fromEntries(new FormData(e.target as HTMLFormElement)))
+          },
+        }),
+      })
+
+      await click(document.getElementById('submit'))
+
+      // Bob is the defaultValue
+      expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'bob' })
+
+      // Open listbox
+      await click(getListboxButton())
+
+      // Choose alice
+      await click(getListboxOptions()[0])
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Alice should be submitted
+      expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'alice' })
+    })
+
+    it('should still call the onChange listeners when choosing new values', async () => {
+      let handleChange = jest.fn()
+
+      renderTemplate({
+        template: html`
+          <Listbox name="assignee" @update:modelValue="handleChange">
+            <ListboxButton>Trigger</ListboxButton>
+            <ListboxOptions>
+              <ListboxOption value="alice">Alice</ListboxOption>
+              <ListboxOption value="bob">Bob</ListboxOption>
+              <ListboxOption value="charlie">Charlie</ListboxOption>
+            </ListboxOptions>
+          </Listbox>
+        `,
+        setup: () => ({ handleChange }),
+      })
+
+      // Open listbox
+      await click(getListboxButton())
+
+      // Choose alice
+      await click(getListboxOptions()[0])
+
+      // Open listbox
+      await click(getListboxButton())
+
+      // Choose bob
+      await click(getListboxOptions()[1])
+
+      // Change handler should have been called twice
+      expect(handleChange).toHaveBeenNthCalledWith(1, 'alice')
+      expect(handleChange).toHaveBeenNthCalledWith(2, 'bob')
+    })
+  })
 })
 
 describe('Rendering composition', () => {

--- a/packages/@headlessui-vue/src/components/radio-group/radio-group.test.ts
+++ b/packages/@headlessui-vue/src/components/radio-group/radio-group.test.ts
@@ -590,6 +590,125 @@ describe('Rendering', () => {
       })
     )
   })
+
+  describe('Uncontrolled', () => {
+    it(
+      'should be possible to use in an uncontrolled way',
+      suppressConsoleLogs(async () => {
+        let handleSubmission = jest.fn()
+
+        renderTemplate({
+          template: html`
+            <form @submit="handleSubmit">
+              <RadioGroup name="assignee">
+                <RadioGroupOption value="alice">Alice</RadioGroupOption>
+                <RadioGroupOption value="bob">Bob</RadioGroupOption>
+                <RadioGroupOption value="charlie">Charlie</RadioGroupOption>
+              </RadioGroup>
+              <button id="submit">submit</button>
+            </form>
+          `,
+          setup: () => ({
+            handleSubmit(e: SubmitEvent) {
+              e.preventDefault()
+              handleSubmission(Object.fromEntries(new FormData(e.target as HTMLFormElement)))
+            },
+          }),
+        })
+
+        await click(document.getElementById('submit'))
+
+        // No values
+        expect(handleSubmission).toHaveBeenLastCalledWith({})
+
+        // Choose alice
+        await click(getRadioGroupOptions()[0])
+
+        // Submit
+        await click(document.getElementById('submit'))
+
+        // Alice should be submitted
+        expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'alice' })
+
+        // Choose charlie
+        await click(getRadioGroupOptions()[2])
+
+        // Submit
+        await click(document.getElementById('submit'))
+
+        // Charlie should be submitted
+        expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'charlie' })
+      })
+    )
+
+    it(
+      'should be possible to provide a default value',
+      suppressConsoleLogs(async () => {
+        let handleSubmission = jest.fn()
+
+        renderTemplate({
+          template: html`
+            <form @submit="handleSubmit">
+              <RadioGroup name="assignee" defaultValue="bob">
+                <RadioGroupOption value="alice">Alice</RadioGroupOption>
+                <RadioGroupOption value="bob">Bob</RadioGroupOption>
+                <RadioGroupOption value="charlie">Charlie</RadioGroupOption>
+              </RadioGroup>
+              <button id="submit">submit</button>
+            </form>
+          `,
+          setup: () => ({
+            handleSubmit(e: SubmitEvent) {
+              e.preventDefault()
+              handleSubmission(Object.fromEntries(new FormData(e.target as HTMLFormElement)))
+            },
+          }),
+        })
+
+        await click(document.getElementById('submit'))
+
+        // Bob is the defaultValue
+        expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'bob' })
+
+        // Choose alice
+        await click(getRadioGroupOptions()[0])
+
+        // Submit
+        await click(document.getElementById('submit'))
+
+        // Alice should be submitted
+        expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: 'alice' })
+      })
+    )
+
+    it(
+      'should still call the onChange listeners when choosing new values',
+      suppressConsoleLogs(async () => {
+        let handleChange = jest.fn()
+
+        renderTemplate({
+          template: html`
+            <RadioGroup name="assignee" @update:modelValue="handleChange">
+              <RadioGroupOption value="alice">Alice</RadioGroupOption>
+              <RadioGroupOption value="bob">Bob</RadioGroupOption>
+              <RadioGroupOption value="charlie">Charlie</RadioGroupOption>
+            </RadioGroup>
+          `,
+          setup: () => ({ handleChange }),
+        })
+
+        // Choose alice
+        await click(getRadioGroupOptions()[0])
+
+        // Choose bob
+        await click(getRadioGroupOptions()[1])
+
+        // Change handler should have been called twice
+        expect(handleChange).toHaveBeenNthCalledWith(1, 'alice')
+        expect(handleChange).toHaveBeenNthCalledWith(2, 'bob')
+      })
+    )
+  })
 })
 
 describe('Keyboard interactions', () => {

--- a/packages/@headlessui-vue/src/components/switch/switch.test.tsx
+++ b/packages/@headlessui-vue/src/components/switch/switch.test.tsx
@@ -149,6 +149,148 @@ describe('Rendering', () => {
       })
     )
   })
+
+  describe('Uncontrolled', () => {
+    it('should be possible to use in an uncontrolled way', async () => {
+      let handleSubmission = jest.fn()
+
+      renderTemplate({
+        template: html`
+          <form @submit="handleSubmit">
+            <Switch name="notifications" />
+            <button id="submit">submit</button>
+          </form>
+        `,
+        setup: () => ({
+          handleSubmit(e: SubmitEvent) {
+            e.preventDefault()
+            handleSubmission(Object.fromEntries(new FormData(e.target as HTMLFormElement)))
+          },
+        }),
+      })
+
+      await click(document.getElementById('submit'))
+
+      // No values
+      expect(handleSubmission).toHaveBeenLastCalledWith({})
+
+      // Toggle
+      await click(getSwitch())
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Notifications should be on
+      expect(handleSubmission).toHaveBeenLastCalledWith({ notifications: 'on' })
+
+      // Toggle
+      await click(getSwitch())
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Notifications should be off (or in this case, non-existant)
+      expect(handleSubmission).toHaveBeenLastCalledWith({})
+    })
+
+    it('should be possible to use in an uncontrolled way with a value', async () => {
+      let handleSubmission = jest.fn()
+
+      renderTemplate({
+        template: html`
+          <form @submit="handleSubmit">
+            <Switch name="notifications" value="enabled" />
+            <button id="submit">submit</button>
+          </form>
+        `,
+        setup: () => ({
+          handleSubmit(e: SubmitEvent) {
+            e.preventDefault()
+            handleSubmission(Object.fromEntries(new FormData(e.target as HTMLFormElement)))
+          },
+        }),
+      })
+
+      await click(document.getElementById('submit'))
+
+      // No values
+      expect(handleSubmission).toHaveBeenLastCalledWith({})
+
+      // Toggle
+      await click(getSwitch())
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Notifications should be on
+      expect(handleSubmission).toHaveBeenLastCalledWith({ notifications: 'enabled' })
+
+      // Toggle
+      await click(getSwitch())
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Notifications should be off (or in this case, non-existant)
+      expect(handleSubmission).toHaveBeenLastCalledWith({})
+    })
+
+    it('should be possible to provide a default value', async () => {
+      let handleSubmission = jest.fn()
+
+      renderTemplate({
+        template: html`
+          <form @submit="handleSubmit">
+            <Switch name="notifications" defaultChecked />
+            <button id="submit">submit</button>
+          </form>
+        `,
+        setup: () => ({
+          handleSubmit(e: SubmitEvent) {
+            e.preventDefault()
+            handleSubmission(Object.fromEntries(new FormData(e.target as HTMLFormElement)))
+          },
+        }),
+      })
+
+      await click(document.getElementById('submit'))
+
+      // Notifications should be on by default
+      expect(handleSubmission).toHaveBeenLastCalledWith({ notifications: 'on' })
+
+      // Toggle
+      await click(getSwitch())
+
+      // Submit
+      await click(document.getElementById('submit'))
+
+      // Notifications should be off (or in this case non-existant)
+      expect(handleSubmission).toHaveBeenLastCalledWith({})
+    })
+
+    it('should still call the onChange listeners when choosing new values', async () => {
+      let handleChange = jest.fn()
+
+      renderTemplate({
+        template: html`<Switch name="notifications" @update:modelValue="handleChange" />`,
+        setup: () => ({ handleChange }),
+      })
+
+      // Toggle
+      await click(getSwitch())
+
+      // Toggle
+      await click(getSwitch())
+
+      // Toggle
+      await click(getSwitch())
+
+      // Change handler should have been called 3 times
+      expect(handleChange).toHaveBeenNthCalledWith(1, true)
+      expect(handleChange).toHaveBeenNthCalledWith(2, false)
+      expect(handleChange).toHaveBeenNthCalledWith(3, true)
+    })
+  })
 })
 
 describe('Render composition', () => {

--- a/packages/@headlessui-vue/src/hooks/use-controllable.ts
+++ b/packages/@headlessui-vue/src/hooks/use-controllable.ts
@@ -1,0 +1,22 @@
+import { computed, ComputedRef, ref } from 'vue'
+
+export function useControllable<T>(
+  controlledValue: ComputedRef<T | undefined>,
+  onChange?: (value: T) => void,
+  defaultValue?: ComputedRef<T>
+) {
+  let internalValue = ref(defaultValue?.value)
+  let isControlled = computed(() => controlledValue.value !== undefined)
+
+  return [
+    computed(() => (isControlled.value ? controlledValue.value : internalValue.value)),
+    function (value: unknown) {
+      if (isControlled.value) {
+        return onChange?.(value as T)
+      } else {
+        internalValue.value = value as T
+        return onChange?.(value as T)
+      }
+    },
+  ] as const
+}

--- a/packages/playground-react/pages/combinations/form.tsx
+++ b/packages/playground-react/pages/combinations/form.tsx
@@ -23,12 +23,6 @@ export default function App() {
   let [result, setResult] = useState(() =>
     typeof window === 'undefined' || typeof document === 'undefined' ? [] : new FormData()
   )
-  let [notifications, setNotifications] = useState(false)
-  let [apple, setApple] = useState(false)
-  let [banana, setBanana] = useState(false)
-  let [size, setSize] = useState(sizes[0])
-  let [person, setPerson] = useState(people[0])
-  let [activeLocation, setActiveLocation] = useState(locations[0])
   let [query, setQuery] = useState('')
 
   return (
@@ -47,8 +41,7 @@ export default function App() {
                 <Switch.Label>Enable notifications</Switch.Label>
 
                 <Switch
-                  checked={notifications}
-                  onChange={setNotifications}
+                  defaultChecked={true}
                   name="notifications"
                   className={({ checked }) =>
                     classNames(
@@ -74,8 +67,6 @@ export default function App() {
                 <Switch.Label>Apple</Switch.Label>
 
                 <Switch
-                  checked={apple}
-                  onChange={setApple}
                   name="fruit[]"
                   value="apple"
                   className={({ checked }) =>
@@ -99,8 +90,6 @@ export default function App() {
               <Switch.Group as="div" className="flex items-center justify-between space-x-4">
                 <Switch.Label>Banana</Switch.Label>
                 <Switch
-                  checked={banana}
-                  onChange={setBanana}
                   name="fruit[]"
                   value="banana"
                   className={({ checked }) =>
@@ -123,7 +112,7 @@ export default function App() {
             </Section>
           </Section>
           <Section title="Radio Group">
-            <RadioGroup value={size} onChange={setSize} name="size">
+            <RadioGroup defaultValue="sm" name="size">
               <div className="flex -space-x-px rounded-md bg-white">
                 {sizes.map((size) => {
                   return (
@@ -177,75 +166,83 @@ export default function App() {
           </Section>
           <Section title="Listbox">
             <div className="w-full space-y-1">
-              <Listbox value={person} onChange={setPerson} name="person">
-                <div className="relative">
-                  <span className="inline-block w-full rounded-md shadow-sm">
-                    <Listbox.Button className="relative w-full cursor-default rounded-md border border-gray-300 bg-white py-2 pl-3 pr-10 text-left focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 sm:text-sm sm:leading-5">
-                      <span className="block truncate">{person.name.first}</span>
-                      <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-                        <svg
-                          className="h-5 w-5 text-gray-400"
-                          viewBox="0 0 20 20"
-                          fill="none"
-                          stroke="currentColor"
-                        >
-                          <path
-                            d="M7 7l3-3 3 3m0 6l-3 3-3-3"
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                          />
-                        </svg>
+              <Listbox name="person" defaultValue={people[1]}>
+                {({ value }) => (
+                  <>
+                    <div className="relative">
+                      <span className="inline-block w-full rounded-md shadow-sm">
+                        <Listbox.Button className="relative w-full cursor-default rounded-md border border-gray-300 bg-white py-2 pl-3 pr-10 text-left focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 sm:text-sm sm:leading-5">
+                          <span className="block truncate">{value?.name?.first}</span>
+                          <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+                            <svg
+                              className="h-5 w-5 text-gray-400"
+                              viewBox="0 0 20 20"
+                              fill="none"
+                              stroke="currentColor"
+                            >
+                              <path
+                                d="M7 7l3-3 3 3m0 6l-3 3-3-3"
+                                strokeWidth="1.5"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                              />
+                            </svg>
+                          </span>
+                        </Listbox.Button>
                       </span>
-                    </Listbox.Button>
-                  </span>
 
-                  <div className="absolute z-10 mt-1 w-full rounded-md bg-white shadow-lg">
-                    <Listbox.Options className="shadow-xs max-h-60 overflow-auto rounded-md py-1 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5">
-                      {people.map((person) => (
-                        <Listbox.Option
-                          key={person.id}
-                          value={person}
-                          className={({ active }) => {
-                            return classNames(
-                              'relative cursor-default select-none py-2 pl-3 pr-9 ',
-                              active ? 'bg-blue-600 text-white' : 'text-gray-900'
-                            )
-                          }}
-                        >
-                          {({ active, selected }) => (
-                            <>
-                              <span
-                                className={classNames(
-                                  'block truncate',
-                                  selected ? 'font-semibold' : 'font-normal'
-                                )}
-                              >
-                                {person.name.first}
-                              </span>
-                              {selected && (
-                                <span
-                                  className={classNames(
-                                    'absolute inset-y-0 right-0 flex items-center pr-4',
-                                    active ? 'text-white' : 'text-blue-600'
+                      <div className="absolute z-10 mt-1 w-full rounded-md bg-white shadow-lg">
+                        <Listbox.Options className="shadow-xs max-h-60 overflow-auto rounded-md py-1 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5">
+                          {people.map((person) => (
+                            <Listbox.Option
+                              key={person.id}
+                              value={person}
+                              className={({ active }) => {
+                                return classNames(
+                                  'relative cursor-default select-none py-2 pl-3 pr-9 ',
+                                  active ? 'bg-blue-600 text-white' : 'text-gray-900'
+                                )
+                              }}
+                            >
+                              {({ active, selected }) => (
+                                <>
+                                  <span
+                                    className={classNames(
+                                      'block truncate',
+                                      selected ? 'font-semibold' : 'font-normal'
+                                    )}
+                                  >
+                                    {person.name.first}
+                                  </span>
+                                  {selected && (
+                                    <span
+                                      className={classNames(
+                                        'absolute inset-y-0 right-0 flex items-center pr-4',
+                                        active ? 'text-white' : 'text-blue-600'
+                                      )}
+                                    >
+                                      <svg
+                                        className="h-5 w-5"
+                                        viewBox="0 0 20 20"
+                                        fill="currentColor"
+                                      >
+                                        <path
+                                          fillRule="evenodd"
+                                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                                          clipRule="evenodd"
+                                        />
+                                      </svg>
+                                    </span>
                                   )}
-                                >
-                                  <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                                    <path
-                                      fillRule="evenodd"
-                                      d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                                      clipRule="evenodd"
-                                    />
-                                  </svg>
-                                </span>
+                                </>
                               )}
-                            </>
-                          )}
-                        </Listbox.Option>
-                      ))}
-                    </Listbox.Options>
-                  </div>
-                </div>
+                            </Listbox.Option>
+                          ))}
+                        </Listbox.Options>
+                      </div>
+                    </div>
+                  </>
+                )}
               </Listbox>
             </div>
           </Section>
@@ -253,13 +250,12 @@ export default function App() {
             <div className="w-full space-y-1">
               <Combobox
                 name="location"
-                value={activeLocation}
+                defaultValue={'New York'}
                 onChange={(location) => {
-                  setActiveLocation(location)
                   setQuery('')
                 }}
               >
-                {({ open }) => {
+                {({ open, value }) => {
                   return (
                     <div className="relative">
                       <div className="flex w-full flex-col">
@@ -271,7 +267,7 @@ export default function App() {
                         <div
                           className={classNames(
                             'flex border-t',
-                            activeLocation && !open ? 'border-transparent' : 'border-gray-200'
+                            value && !open ? 'border-transparent' : 'border-gray-200'
                           )}
                         >
                           <div className="absolute z-10 mt-1 w-full rounded-md bg-white shadow-lg">


### PR DESCRIPTION
This PR allows our form related components (Switch, RadioGroup, Listbox and Combobox) to be both controlled and uncontrolled (new).

This has the benefit that you don't have to do any wiring yourself if you just want to choose values from a know list and use the good old `<form>` element to submit your values.

Add a `name` prop to those components (more info: Listbox example https://headlessui.com/react/listbox#using-with-html-forms) and you should be good to go!
