### PR TITLE
fix: adds the MouseEventHandler type to close in Popover

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure controlled `Tabs` don't change automagically ([#1680](https://github.com/tailwindlabs/headlessui/pull/1680))
 - Don't scroll lock when a Transition + Dialog is mounted but hidden ([#1681](https://github.com/tailwindlabs/headlessui/pull/1681))
 
+## Changed
+
+- Allow `Popover` `close` to be passed directly to `onClick` handlers ([#1696](https://github.com/tailwindlabs/headlessui/pull/1696))
+
 ## [1.6.6] - 2022-07-07
 
 ### Fixed

--- a/packages/@headlessui-react/src/components/popover/popover.test.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.test.tsx
@@ -260,6 +260,50 @@ describe('Rendering', () => {
       })
     )
 
+    it(
+      'should expose a close function that closes the popover and takes an event',
+      suppressConsoleLogs(async () => {
+        function Example() {
+          let elementRef = useRef(null)
+          return (
+            <>
+              <button ref={elementRef}>restoreable</button>
+              <Popover>
+                {({ close }) => (
+                  <>
+                    <Popover.Button>Trigger</Popover.Button>
+                    <Popover.Panel>
+                      <button onClick={close}>Close me</button>
+                    </Popover.Panel>
+                  </>
+                )}
+              </Popover>
+            </>
+          )
+        }
+
+        render(<Example />)
+
+        // Focus the button
+        await focus(getPopoverButton())
+
+        // Ensure the button is focused
+        assertActiveElement(getPopoverButton())
+
+        // Open the popover
+        await click(getPopoverButton())
+
+        // Ensure we can click the close button
+        await click(getByText('Close me'))
+
+        // Ensure the popover is closed
+        assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
+
+        // Ensure the restoreable button got the restored focus
+        assertActiveElement(getByText('restoreable'))
+      })
+    )
+
     describe('refs', () => {
       it(
         'should be possible to get a ref to the Popover',

--- a/packages/@headlessui-react/src/components/popover/popover.test.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.test.tsx
@@ -264,10 +264,8 @@ describe('Rendering', () => {
       'should expose a close function that closes the popover and takes an event',
       suppressConsoleLogs(async () => {
         function Example() {
-          let elementRef = useRef(null)
           return (
             <>
-              <button ref={elementRef}>restoreable</button>
               <Popover>
                 {({ close }) => (
                   <>
@@ -299,8 +297,8 @@ describe('Rendering', () => {
         // Ensure the popover is closed
         assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
 
-        // Ensure the restoreable button got the restored focus
-        assertActiveElement(getByText('restoreable'))
+        // Ensure the Popover.Button got the restored focus
+        assertActiveElement(getByText('Trigger'))
       })
     )
 

--- a/packages/@headlessui-react/src/components/popover/popover.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.tsx
@@ -17,6 +17,7 @@ import React, {
   MouseEvent as ReactMouseEvent,
   MutableRefObject,
   Ref,
+  MouseEventHandler,
 } from 'react'
 
 import { Props } from '../../types'
@@ -128,7 +129,12 @@ function usePopoverContext(component: string) {
 }
 
 let PopoverAPIContext = createContext<{
-  close(focusableElement?: HTMLElement | MutableRefObject<HTMLElement | null>): void
+  close(
+    focusableElement?:
+      | HTMLElement
+      | MutableRefObject<HTMLElement | null>
+      | MouseEventHandler<HTMLElement>
+  ): void
   isPortalled: boolean
 } | null>(null)
 PopoverAPIContext.displayName = 'PopoverAPIContext'


### PR DESCRIPTION
Currently to use the `close` function within a `button` I need to invoke a new function:

```tsx
<button onClick={() => close}>...</button>
```

It would be nice to be able to just call the close function directly from the `onClick` of an element so that we are not invoking this new function every time we call the component:

```tsx
<button onClick={close}>...</button>
```
---

The reason for this is that the types for `close` and `onClick` do not quite line up. The `button` requires an `MouseEventHandler` type from `React`

![image](https://user-images.githubusercontent.com/46460840/179630198-05283521-d4d9-4686-905d-299ad86bddab.png)

This PR allows for that type to be added to the `close` function so that the example above will be valid.