### PR TITLE
Fix incorrect scrolling to the bottom when opening a `Dialog`

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't scroll lock when a Transition + Dialog is mounted but hidden ([#1681](https://github.com/tailwindlabs/headlessui/pull/1681))
 - Improve outside click on Safari iOS ([#1712](https://github.com/tailwindlabs/headlessui/pull/1712))
 - Improve event handler merging ([#1715](https://github.com/tailwindlabs/headlessui/pull/1715))
+- Fix incorrect scrolling to the bottom when opening a `Dialog` ([#1716](https://github.com/tailwindlabs/headlessui/pull/1716))
 
 ## [1.6.6] - 2022-07-07
 

--- a/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
@@ -32,8 +32,18 @@ global.IntersectionObserver = class FakeIntersectionObserver {
 
 afterAll(() => jest.restoreAllMocks())
 
-function TabSentinel(props: PropsOf<'div'>) {
-  return <div tabIndex={0} {...props} />
+function nextFrame() {
+  return new Promise<void>((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        resolve()
+      })
+    })
+  })
+}
+
+function TabSentinel(props: PropsOf<'button'>) {
+  return <button {...props} />
 }
 
 describe('Safe guards', () => {
@@ -167,7 +177,7 @@ describe('Rendering', () => {
       })
     )
 
-    it('should be possible to always render the Dialog if we provide it a `static` prop (and enable focus trapping based on `open`)', () => {
+    it('should be possible to always render the Dialog if we provide it a `static` prop (and enable focus trapping based on `open`)', async () => {
       let focusCounter = jest.fn()
       render(
         <>
@@ -178,6 +188,8 @@ describe('Rendering', () => {
           </Dialog>
         </>
       )
+
+      await nextFrame()
 
       // Let's verify that the Dialog is already there
       expect(getDialog()).not.toBe(null)
@@ -217,7 +229,10 @@ describe('Rendering', () => {
           </>
         )
       }
+
       render(<Example />)
+
+      await nextFrame()
 
       assertDialog({ state: DialogState.InvisibleHidden })
       expect(focusCounter).toHaveBeenCalledTimes(0)
@@ -463,6 +478,8 @@ describe('Rendering', () => {
           </Dialog>
         )
 
+        await nextFrame()
+
         assertDialog({
           state: DialogState.Visible,
           attributes: { id: 'headlessui-dialog-1' },
@@ -485,6 +502,8 @@ describe('Rendering', () => {
             <TabSentinel />
           </Dialog>
         )
+
+        await nextFrame()
 
         assertDialog({
           state: DialogState.Visible,
@@ -512,6 +531,8 @@ describe('Composition', () => {
         </Transition>
       )
 
+      await nextFrame()
+
       assertDialog({ state: DialogState.Visible })
       assertDialogDescription({
         state: DialogState.Visible,
@@ -531,6 +552,8 @@ describe('Composition', () => {
           </Dialog>
         </Transition>
       )
+
+      await nextFrame()
 
       assertDialog({ state: DialogState.InvisibleUnmounted })
     })
@@ -870,7 +893,10 @@ describe('Mouse interactions', () => {
           </div>
         )
       }
+
       render(<Example />)
+
+      await nextFrame()
 
       // Verify it is open
       assertDialog({ state: DialogState.Visible })
@@ -905,7 +931,10 @@ describe('Mouse interactions', () => {
           </Dialog>
         )
       }
+
       render(<Example />)
+
+      await nextFrame()
 
       // Verify it is open
       assertDialog({ state: DialogState.Visible })
@@ -936,7 +965,10 @@ describe('Mouse interactions', () => {
           </div>
         )
       }
+
       render(<Example />)
+
+      await nextFrame()
 
       // Verify it is open
       assertDialog({ state: DialogState.Visible })
@@ -979,7 +1011,10 @@ describe('Mouse interactions', () => {
           </Dialog>
         )
       }
+
       render(<Example />)
+
+      await nextFrame()
 
       // Verify it is open
       assertDialog({ state: DialogState.Visible })
@@ -1023,7 +1058,10 @@ describe('Mouse interactions', () => {
           </div>
         )
       }
+
       render(<Example />)
+
+      await nextFrame()
 
       // Verify it is open
       assertDialog({ state: DialogState.Visible })

--- a/packages/@headlessui-react/src/components/focus-trap/focus-trap.test.tsx
+++ b/packages/@headlessui-react/src/components/focus-trap/focus-trap.test.tsx
@@ -6,17 +6,29 @@ import { assertActiveElement } from '../../test-utils/accessibility-assertions'
 import { suppressConsoleLogs } from '../../test-utils/suppress-console-logs'
 import { click, press, shift, Keys } from '../../test-utils/interactions'
 
-it('should focus the first focusable element inside the FocusTrap', () => {
+function nextFrame() {
+  return new Promise<void>((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        resolve()
+      })
+    })
+  })
+}
+
+it('should focus the first focusable element inside the FocusTrap', async () => {
   render(
     <FocusTrap>
       <button>Trigger</button>
     </FocusTrap>
   )
 
+  await nextFrame()
+
   assertActiveElement(screen.getByText('Trigger'))
 })
 
-it('should focus the autoFocus element inside the FocusTrap if that exists', () => {
+it('should focus the autoFocus element inside the FocusTrap if that exists', async () => {
   render(
     <FocusTrap>
       <input id="a" type="text" />
@@ -25,10 +37,12 @@ it('should focus the autoFocus element inside the FocusTrap if that exists', () 
     </FocusTrap>
   )
 
+  await nextFrame()
+
   assertActiveElement(document.getElementById('b'))
 })
 
-it('should focus the initialFocus element inside the FocusTrap if that exists', () => {
+it('should focus the initialFocus element inside the FocusTrap if that exists', async () => {
   function Example() {
     let initialFocusRef = useRef<HTMLInputElement | null>(null)
 
@@ -40,12 +54,15 @@ it('should focus the initialFocus element inside the FocusTrap if that exists', 
       </FocusTrap>
     )
   }
+
   render(<Example />)
+
+  await nextFrame()
 
   assertActiveElement(document.getElementById('c'))
 })
 
-it('should focus the initialFocus element inside the FocusTrap even if another element has autoFocus', () => {
+it('should focus the initialFocus element inside the FocusTrap even if another element has autoFocus', async () => {
   function Example() {
     let initialFocusRef = useRef<HTMLInputElement | null>(null)
 
@@ -57,12 +74,15 @@ it('should focus the initialFocus element inside the FocusTrap even if another e
       </FocusTrap>
     )
   }
+
   render(<Example />)
+
+  await nextFrame()
 
   assertActiveElement(document.getElementById('c'))
 })
 
-it('should warn when there is no focusable element inside the FocusTrap', () => {
+it('should warn when there is no focusable element inside the FocusTrap', async () => {
   let spy = jest.spyOn(console, 'warn').mockImplementation(jest.fn())
 
   function Example() {
@@ -72,7 +92,11 @@ it('should warn when there is no focusable element inside the FocusTrap', () => 
       </FocusTrap>
     )
   }
+
   render(<Example />)
+
+  await nextFrame()
+
   expect(spy.mock.calls[0][0]).toBe('There are no focusable elements inside the <FocusTrap />')
   spy.mockReset()
 })
@@ -95,6 +119,8 @@ it(
     }
 
     render(<Example />)
+
+    await nextFrame()
 
     let [a, b, c, d] = Array.from(document.querySelectorAll('input'))
 
@@ -163,6 +189,8 @@ it('should restore the previously focused element, before entering the FocusTrap
 
   render(<Example />)
 
+  await nextFrame()
+
   // The input should have focus by default because of the autoFocus prop
   assertActiveElement(document.getElementById('item-1'))
 
@@ -192,6 +220,8 @@ it('should be possible tab to the next focusable element within the focus trap',
     </>
   )
 
+  await nextFrame()
+
   // Item A should be focused because the FocusTrap will focus the first item
   assertActiveElement(document.getElementById('item-a'))
 
@@ -220,6 +250,8 @@ it('should be possible shift+tab to the previous focusable element within the fo
       <button>After</button>
     </>
   )
+
+  await nextFrame()
 
   // Item A should be focused because the FocusTrap will focus the first item
   assertActiveElement(document.getElementById('item-a'))
@@ -255,6 +287,8 @@ it('should skip the initial "hidden" elements within the focus trap', async () =
     </>
   )
 
+  await nextFrame()
+
   // Item C should be focused because the FocusTrap had to skip the first 2
   assertActiveElement(document.getElementById('item-c'))
 })
@@ -274,6 +308,8 @@ it('should be possible skip "hidden" elements within the focus trap', async () =
       <button>After</button>
     </>
   )
+
+  await nextFrame()
 
   // Item A should be focused because the FocusTrap will focus the first item
   assertActiveElement(document.getElementById('item-a'))
@@ -308,6 +344,8 @@ it('should be possible skip disabled elements within the focus trap', async () =
       <button>After</button>
     </>
   )
+
+  await nextFrame()
 
   // Item A should be focused because the FocusTrap will focus the first item
   assertActiveElement(document.getElementById('item-a'))
@@ -357,6 +395,8 @@ it('should try to focus all focusable items (and fail)', async () => {
     </>
   )
 
+  await nextFrame()
+
   expect(focusHandler.mock.calls).toEqual([['item-a'], ['item-b'], ['item-c'], ['item-d']])
   expect(spy).toHaveBeenCalledWith('There are no focusable elements inside the <FocusTrap />')
   spy.mockReset()
@@ -390,6 +430,8 @@ it('should end up at the last focusable element', async () => {
       <button>After</button>
     </>
   )
+
+  await nextFrame()
 
   expect(focusHandler.mock.calls).toEqual([['item-a'], ['item-b'], ['item-c']])
   assertActiveElement(screen.getByText('Item D'))

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure controlled `Tabs` don't change automagically ([#1680](https://github.com/tailwindlabs/headlessui/pull/1680))
 - Improve outside click on Safari iOS ([#1712](https://github.com/tailwindlabs/headlessui/pull/1712))
 - Improve event handler merging ([#1715](https://github.com/tailwindlabs/headlessui/pull/1715))
+- Fix incorrect scrolling to the bottom when opening a `Dialog` ([#1716](https://github.com/tailwindlabs/headlessui/pull/1716))
 
 ## [1.6.7] - 2022-07-12
 

--- a/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
@@ -48,7 +48,7 @@ function nextFrame() {
 
 let TabSentinel = defineComponent({
   name: 'TabSentinel',
-  template: html`<div :tabindex="0"></div>`,
+  template: html`<button></button>`,
 })
 
 jest.mock('../../hooks/use-id')
@@ -253,7 +253,7 @@ describe('Rendering', () => {
 
       await click(document.getElementById('trigger'))
 
-      await new Promise<void>(nextTick)
+      await nextFrame()
 
       assertDialog({ state: DialogState.Visible, attributes: { class: 'relative bg-blue-500' } })
     })
@@ -299,7 +299,7 @@ describe('Rendering', () => {
         },
       })
 
-      await new Promise<void>(nextTick)
+      await nextFrame()
 
       // Let's verify that the Dialog is already there
       expect(getDialog()).not.toBe(null)
@@ -329,7 +329,7 @@ describe('Rendering', () => {
         },
       })
 
-      await new Promise<void>(nextTick)
+      await nextFrame()
 
       assertDialog({ state: DialogState.InvisibleHidden })
       expect(focusCounter).toHaveBeenCalledTimes(0)
@@ -637,7 +637,7 @@ describe('Rendering', () => {
           `
         )
 
-        await new Promise<void>(nextTick)
+        await nextFrame()
 
         assertDialog({
           state: DialogState.Visible,
@@ -664,7 +664,7 @@ describe('Rendering', () => {
           `
         )
 
-        await new Promise<void>(nextTick)
+        await nextFrame()
 
         assertDialog({
           state: DialogState.Visible,
@@ -695,7 +695,7 @@ describe('Composition', () => {
         `,
       })
 
-      await new Promise<void>(nextTick)
+      await nextFrame()
 
       assertDialog({ state: DialogState.Visible })
       assertDialogDescription({
@@ -719,6 +719,8 @@ describe('Composition', () => {
           </Transition>
         `,
       })
+
+      await nextFrame()
 
       assertDialog({ state: DialogState.InvisibleUnmounted })
     })
@@ -1214,7 +1216,7 @@ describe('Mouse interactions', () => {
         },
       })
 
-      await new Promise<void>(nextTick)
+      await nextFrame()
 
       // Verify it is open
       assertDialog({ state: DialogState.Visible })
@@ -1259,7 +1261,7 @@ describe('Mouse interactions', () => {
         },
       })
 
-      await new Promise<void>(nextTick)
+      await nextFrame()
 
       // Verify it is open
       assertDialog({ state: DialogState.Visible })
@@ -1298,7 +1300,7 @@ describe('Mouse interactions', () => {
         },
       })
 
-      await new Promise<void>(nextTick)
+      await nextFrame()
 
       // Verify it is open
       assertDialog({ state: DialogState.Visible })
@@ -1344,7 +1346,7 @@ describe('Mouse interactions', () => {
         },
       })
 
-      await new Promise<void>(nextTick)
+      await nextFrame()
 
       // Verify it is open
       assertDialog({ state: DialogState.Visible })
@@ -1396,7 +1398,7 @@ describe('Mouse interactions', () => {
         },
       })
 
-      await new Promise<void>(nextTick)
+      await nextFrame()
 
       // Verify it is open
       assertDialog({ state: DialogState.Visible })

--- a/packages/playground-react/pages/_app.tsx
+++ b/packages/playground-react/pages/_app.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import Head from 'next/head'
 
 import 'tailwindcss/tailwind.css'
+import { useRouter } from 'next/router'
 
 function disposables() {
   let disposables: Function[] = []
@@ -138,6 +139,11 @@ function KeyCaster() {
 }
 
 function MyApp({ Component, pageProps }) {
+  let router = useRouter()
+  if (router.query.raw !== undefined) {
+    return <Component {...pageProps} />
+  }
+
   return (
     <>
       <div className="flex h-screen flex-col overflow-hidden bg-gray-700 font-sans text-gray-900 antialiased">


### PR DESCRIPTION
This PR fixes an issue where the page is scrolled down before opening a Dialog. 

This is because we tried to focus the first focusable element within the dialog before any
transition happens or whatsoever, this means that technically the dialog is still at the very bottom
of the page (because we render it at the end of the `document.body` via a Portal). 

Focusing the element causes the browser to scroll the page down.

With the `queueMicroTask` we can delay that just enough to let the browser do its job.

Fixes: #1708

