### PR TITLE
Don’t overwrite `element.focus` on popover panels

### DIFF
--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve outside click on Safari iOS ([#1712](https://github.com/tailwindlabs/headlessui/pull/1712))
 - Improve event handler merging ([#1715](https://github.com/tailwindlabs/headlessui/pull/1715))
 - Fix incorrect scrolling to the bottom when opening a `Dialog` ([#1716](https://github.com/tailwindlabs/headlessui/pull/1716))
+- Don't overwrite `element.focus()` on `<PopoverPanel>` ([#1719](https://github.com/tailwindlabs/headlessui/pull/1719))
 
 ## [1.6.7] - 2022-07-12
 

--- a/packages/@headlessui-vue/src/components/popover/popover.ts
+++ b/packages/@headlessui-vue/src/components/popover/popover.ts
@@ -14,7 +14,7 @@ import {
 } from 'vue'
 
 import { match } from '../../utils/match'
-import { render, Features } from '../../utils/render'
+import { render, omit, Features } from '../../utils/render'
 import { useId } from '../../hooks/use-id'
 import { Keys } from '../../keyboard'
 import {
@@ -620,7 +620,7 @@ export let PopoverPanel = defineComponent({
 
       return render({
         ourProps,
-        theirProps: { ...attrs, ...props },
+        theirProps: { ...attrs, ...omit(props, ['focus']) },
         attrs,
         slot,
         slots: {


### PR DESCRIPTION
Heh oops

Fixes #1701