### PR TITLE
Improve TypeScript 4.7 `NodeNext` compatibility

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -46,6 +46,7 @@ wait
 
 # Rewrite ESM imports 😤
 $rewriteImports "$DST" '/**/*.js'
+$rewriteImports "$DST" '/**/*.d.ts'
 
 # Remove test related files
 rm -rf `$resolver "$DST" '/**/*.{test,__mocks__,}.*'`

--- a/scripts/rewrite-imports.js
+++ b/scripts/rewrite-imports.js
@@ -9,6 +9,8 @@ fastGlob.sync([process.argv.slice(2).join('')]).forEach((file) => {
   file = path.resolve(process.cwd(), file)
   let content = fs.readFileSync(file, 'utf8')
   let result = content.replace(/(import|export)([^"']*?)(["'])\.(.*?)\3/g, (full, a, b, _, d) => {
+    // For idempotency reasons, if `.js` already exists, then we can skip this. This allows us to
+    // run this script over and over again without adding .js files every time.
     if (d.endsWith('.js')) {
       return full
     }

--- a/scripts/rewrite-imports.js
+++ b/scripts/rewrite-imports.js
@@ -8,7 +8,13 @@ console.time('Rewrote imports in')
 fastGlob.sync([process.argv.slice(2).join('')]).forEach((file) => {
   file = path.resolve(process.cwd(), file)
   let content = fs.readFileSync(file, 'utf8')
-  let result = content.replace(/(import|export)([^"']*?)(["'])\.(.*?)\3;/g, '$1$2".$4.js";')
+  let result = content.replace(/(import|export)([^"']*?)(["'])\.(.*?)\3/g, (full, a, b, _, d) => {
+    if (d.endsWith('.js')) {
+      return full
+    }
+
+    return `${a}${b}'.${d}.js'`
+  })
   if (result !== content) {
     fs.writeFileSync(file, result, 'utf8')
   }


### PR DESCRIPTION
This PR improves the compatibility of the `NodeNext` module resolution in TypeScript 4.7.

We already rewrote the imports to include the `.js` file, but we only did this for generated `.js`
files and not for generated `.d.ts` files.

Ideally we don't have to do this rewrite on build files at all, and that is possible if we add the
`.js` files to the actual source files. However this has some (annoying) issues:

- We then have to make sure that all tooling (Next.js, Jest, ...) works with `.js` files.
- We will introduce _a lot_ of changes, and this will cause annoying merge conflicts.
- We will have to make sure that we always think about adding the `.js` file extension in the imports.

Instead, for now, rewriting imports on `.d.ts` files as we already do with `.js` file should do the trick,
because then the `.js` extensiosn will be there in import/export statements.

Fixes: #1699
