### PR TITLE
fixes tailwindlabs/headlessui#1733

### DIFF
--- a/packages/@headlessui-react/src/components/disclosure/disclosure.tsx
+++ b/packages/@headlessui-react/src/components/disclosure/disclosure.tsx
@@ -168,7 +168,7 @@ let DisclosureRoot = forwardRefWithAs(function Disclosure<
       },
       props.as === undefined ||
         // @ts-expect-error The `as` prop _can_ be a Fragment
-        props.as === React.Fragment
+        props.as === Fragment
     )
   )
 


### PR DESCRIPTION
Instead of React.Fragment use Fragment since it is already imported by name and it fixes an issue with Vite3+React+new JXS transform, see https://github.com/tailwindlabs/headlessui/issues/1733