### PR TITLE
Only select the active option when using "singular" mode

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make form components uncontrollable ([#1683](https://github.com/tailwindlabs/headlessui/pull/1683))
 - Improve `Combobox` re-opening keyboard issue on mobile ([#1732](https://github.com/tailwindlabs/headlessui/pull/1732))
 - Ensure `Disclosure.Panel` is properly linked ([#1747](https://github.com/tailwindlabs/headlessui/pull/1747))
+- Only select the active option when using "singular" mode when pressing `<tab>` in the `Combobox` component ([#1750](https://github.com/tailwindlabs/headlessui/pull/1750))
 
 ## Changed
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -710,7 +710,7 @@ let Input = forwardRefWithAs(function Input<
 
       case Keys.Tab:
         if (data.comboboxState !== ComboboxState.Open) return
-        actions.selectActiveOption()
+        if (data.mode === ValueMode.Single) actions.selectActiveOption()
         actions.closeCombobox()
         break
     }

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't overwrite `element.focus()` on `<PopoverPanel>` ([#1719](https://github.com/tailwindlabs/headlessui/pull/1719))
 - Make form components uncontrollable ([#1683](https://github.com/tailwindlabs/headlessui/pull/1683))
 - Improve `Combobox` re-opening keyboard issue on mobile ([#1732](https://github.com/tailwindlabs/headlessui/pull/1732))
+- Only select the active option when using "singular" mode when pressing `<tab>` in the `Combobox` component ([#1750](https://github.com/tailwindlabs/headlessui/pull/1750))
 
 ## [1.6.7] - 2022-07-12
 

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -738,7 +738,7 @@ export let ComboboxInput = defineComponent({
 
         case Keys.Tab:
           if (api.comboboxState.value !== ComboboxStates.Open) return
-          api.selectActiveOption()
+          if (api.mode.value === ValueMode.Single) api.selectActiveOption()
           api.closeCombobox()
           break
       }


### PR DESCRIPTION
This PR improves the UX when using multiple value mode for the `Combobox` component. Now when
pressing `<Tab>` the active item won't be selected/unselected and you have to explicitly select it
via `<Enter>` or clicking/tapping.

Fixes: #1628

