### PR TITLE
Improve the types of the `Combobox` component

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve `Combobox` re-opening keyboard issue on mobile ([#1732](https://github.com/tailwindlabs/headlessui/pull/1732))
 - Ensure `Disclosure.Panel` is properly linked ([#1747](https://github.com/tailwindlabs/headlessui/pull/1747))
 - Only select the active option when using "singular" mode when pressing `<tab>` in the `Combobox` component ([#1750](https://github.com/tailwindlabs/headlessui/pull/1750))
+- Improve the types of the `Combobox` component ([#1761](https://github.com/tailwindlabs/headlessui/pull/1761))
 
 ## Changed
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -280,7 +280,7 @@ describe('Rendering', () => {
             let [value, setValue] = useState({ id: 2, name: 'Bob' })
 
             return (
-              <Combobox value={value} onChange={setValue} by="id">
+              <Combobox value={value} onChange={(value) => setValue(value)} by="id">
                 <Combobox.Button>Trigger</Combobox.Button>
                 <Combobox.Options>
                   <Combobox.Option value={{ id: 1, name: 'alice' }}>alice</Combobox.Option>
@@ -322,7 +322,7 @@ describe('Rendering', () => {
             let [value, setValue] = useState([{ id: 2, name: 'Bob' }])
 
             return (
-              <Combobox value={value} onChange={setValue} by="id" multiple>
+              <Combobox value={value} onChange={(value) => setValue(value)} by="id" multiple>
                 <Combobox.Button>Trigger</Combobox.Button>
                 <Combobox.Options>
                   <Combobox.Option value={{ id: 1, name: 'alice' }}>alice</Combobox.Option>
@@ -2231,7 +2231,7 @@ describe('Keyboard interactions', () => {
       suppressConsoleLogs(async () => {
         let handleChange = jest.fn()
         function Example() {
-          let [value, setValue] = useState<string>('bob')
+          let [value, setValue] = useState<string | null>('bob')
           let [, setQuery] = useState<string>('')
 
           return (
@@ -5095,7 +5095,7 @@ describe('Multi-select', () => {
         let [value, setValue] = useState<string[]>(['bob', 'charlie'])
 
         return (
-          <Combobox value={value} onChange={setValue} multiple>
+          <Combobox value={value} onChange={(value) => setValue(value)} multiple>
             <Combobox.Input onChange={() => {}} />
             <Combobox.Button>Trigger</Combobox.Button>
             <Combobox.Options>
@@ -5131,7 +5131,7 @@ describe('Multi-select', () => {
         let [value, setValue] = useState<string[]>(['bob', 'charlie'])
 
         return (
-          <Combobox value={value} onChange={setValue} multiple>
+          <Combobox value={value} onChange={(value) => setValue(value)} multiple>
             <Combobox.Input onChange={() => {}} />
             <Combobox.Button>Trigger</Combobox.Button>
             <Combobox.Options>
@@ -5160,7 +5160,7 @@ describe('Multi-select', () => {
         let [value, setValue] = useState<string[]>(['bob', 'charlie'])
 
         return (
-          <Combobox value={value} onChange={setValue} multiple>
+          <Combobox value={value} onChange={(value) => setValue(value)} multiple>
             <Combobox.Input onChange={() => {}} />
             <Combobox.Button>Trigger</Combobox.Button>
             <Combobox.Options>
@@ -5193,7 +5193,7 @@ describe('Multi-select', () => {
         let [value, setValue] = useState<string[]>(['bob', 'charlie'])
 
         return (
-          <Combobox value={value} onChange={setValue} multiple>
+          <Combobox value={value} onChange={(value) => setValue(value)} multiple>
             <Combobox.Input onChange={() => {}} />
             <Combobox.Button>Trigger</Combobox.Button>
             <Combobox.Options>

--- a/packages/@headlessui-react/src/components/transitions/transition.tsx
+++ b/packages/@headlessui-react/src/components/transitions/transition.tsx
@@ -12,7 +12,7 @@ import React, {
   MutableRefObject,
   Ref,
 } from 'react'
-import { Props } from '../../types'
+import { Props, ReactTag } from '../../types'
 import {
   Features,
   forwardRefWithAs,
@@ -68,7 +68,7 @@ export interface TransitionEvents {
   afterLeave?: () => void
 }
 
-type TransitionChildProps<TTag> = Props<TTag, TransitionChildRenderPropArg> &
+type TransitionChildProps<TTag extends ReactTag> = Props<TTag, TransitionChildRenderPropArg> &
   PropsForFeatures<typeof TransitionChildRenderFeatures> &
   TransitionClasses &
   TransitionEvents & { appear?: boolean }

--- a/packages/playground-react/pages/combobox/multi-select.tsx
+++ b/packages/playground-react/pages/combobox/multi-select.tsx
@@ -39,7 +39,12 @@ function MultiPeopleList() {
             console.log([...new FormData(e.currentTarget).entries()])
           }}
         >
-          <Combobox value={activePersons} onChange={setActivePersons} name="people" multiple>
+          <Combobox
+            value={activePersons}
+            onChange={(people) => setActivePersons(people)}
+            name="people"
+            multiple
+          >
             <Combobox.Label className="block text-sm font-medium leading-5 text-gray-700">
               Assigned to
             </Combobox.Label>


### PR DESCRIPTION
The `Combobox` types weren't super well defined and the were especially confusing in combination with the `nullable` and `multiple` props.

Now given the `multiple` and/or `nullable` props we ensure that the types for the `value`, `defaultValue`, `onChange`, `by`, render prop, ... are all correct.

You will also be able to easily tell which type to use instead of inferring it by doing something like this:

```ts
<Combobox<ExplicitTypeHere>
  value={...}
  onChange={...}
  ...
>
 ...
</Combobox>
```

Fixes: #1702
