### PR TITLE
Only restore focus to the `Menu.Button` if necessary when activating a `Menu.Option`

### DIFF
--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -35,6 +35,7 @@ import {
   sortByDomNode,
   Focus as FocusManagementFocus,
   focusFrom,
+  restoreFocusIfNecessary,
 } from '../../utils/focus-management'
 import { useOutsideClick } from '../../hooks/use-outside-click'
 import { useTreeWalker } from '../../hooks/use-tree-walker'
@@ -463,7 +464,7 @@ let Items = forwardRefWithAs(function Items<TTag extends ElementType = typeof DE
           let { dataRef } = state.items[state.activeItemIndex]
           dataRef.current?.domRef.current?.click()
         }
-        disposables().nextFrame(() => state.buttonRef.current?.focus({ preventScroll: true }))
+        restoreFocusIfNecessary(state.buttonRef.current)
         break
 
       case Keys.ArrowDown:
@@ -615,7 +616,7 @@ let Item = forwardRefWithAs(function Item<TTag extends ElementType = typeof DEFA
   let handleClick = useEvent((event: MouseEvent) => {
     if (disabled) return event.preventDefault()
     dispatch({ type: ActionTypes.CloseMenu })
-    disposables().nextFrame(() => state.buttonRef.current?.focus({ preventScroll: true }))
+    restoreFocusIfNecessary(state.buttonRef.current)
   })
 
   let handleFocus = useEvent(() => {

--- a/packages/@headlessui-react/src/utils/focus-management.ts
+++ b/packages/@headlessui-react/src/utils/focus-management.ts
@@ -1,3 +1,4 @@
+import { disposables } from './disposables'
 import { match } from './match'
 import { getOwnerDocument } from './owner'
 
@@ -96,6 +97,18 @@ export function isFocusableElement(
 
       return false
     },
+  })
+}
+
+export function restoreFocusIfNecessary(element: HTMLElement | null) {
+  let ownerDocument = getOwnerDocument(element)
+  disposables().nextFrame(() => {
+    if (
+      ownerDocument &&
+      !isFocusableElement(ownerDocument.activeElement as HTMLElement, FocusableMode.Strict)
+    ) {
+      focusElement(element)
+    }
   })
 }
 

--- a/packages/@headlessui-vue/src/components/menu/menu.ts
+++ b/packages/@headlessui-vue/src/components/menu/menu.ts
@@ -28,6 +28,7 @@ import {
   sortByDomNode,
   Focus as FocusManagementFocus,
   focusFrom,
+  restoreFocusIfNecessary,
 } from '../../utils/focus-management'
 import { useOutsideClick } from '../../hooks/use-outside-click'
 
@@ -384,7 +385,7 @@ export let MenuItems = defineComponent({
             dom(_activeItem.dataRef.domRef)?.click()
           }
           api.closeMenu()
-          nextTick(() => dom(api.buttonRef)?.focus({ preventScroll: true }))
+          restoreFocusIfNecessary(dom(api.buttonRef))
           break
 
         case Keys.ArrowDown:
@@ -531,7 +532,7 @@ export let MenuItem = defineComponent({
     function handleClick(event: MouseEvent) {
       if (props.disabled) return event.preventDefault()
       api.closeMenu()
-      nextTick(() => dom(api.buttonRef)?.focus({ preventScroll: true }))
+      restoreFocusIfNecessary(dom(api.buttonRef))
     }
 
     function handleFocus() {

--- a/packages/@headlessui-vue/src/utils/focus-management.ts
+++ b/packages/@headlessui-vue/src/utils/focus-management.ts
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue'
 import { match } from './match'
 import { getOwnerDocument } from './owner'
 
@@ -89,6 +90,18 @@ export function isFocusableElement(
 
       return false
     },
+  })
+}
+
+export function restoreFocusIfNecessary(element: HTMLElement | null) {
+  let ownerDocument = getOwnerDocument(element)
+  nextTick(() => {
+    if (
+      ownerDocument &&
+      !isFocusableElement(ownerDocument.activeElement as HTMLElement, FocusableMode.Strict)
+    ) {
+      focusElement(element)
+    }
   })
 }
 


### PR DESCRIPTION
This PR will fix a bug where the focus was incorrectly moved to the `Menu.Button` even though the focus already moved. If you happen to open a Dialog then the focus would incorrectly be moved back to the `Menu.Button`. Instead we now check wether the focus was already moved, if that's the case then we don't return the focus to the `Menu.Button`.

Fixes: #1641
