### PR TITLE
Fix `Transition` component's incorrect cleanup and order of events

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve the types of the `Combobox` component ([#1761](https://github.com/tailwindlabs/headlessui/pull/1761))
 - Only restore focus to the `Menu.Button` if necessary when activating a `Menu.Option` ([#1782](https://github.com/tailwindlabs/headlessui/pull/1782))
 - Don't scroll when wrapping around in focus trap ([#1789](https://github.com/tailwindlabs/headlessui/pull/1789))
+- Fix `Transition` component's incorrect cleanup and order of events ([#1803](https://github.com/tailwindlabs/headlessui/pull/1803))
 
 ## Changed
 

--- a/packages/@headlessui-react/src/components/transitions/transition.test.tsx
+++ b/packages/@headlessui-react/src/components/transitions/transition.test.tsx
@@ -636,7 +636,7 @@ describe('Transitions', () => {
 
           return (
             <>
-              <style>{`.leave { transition-duration: ${leaveDuration}ms; } .from { opacity: 0%; } .to { opacity: 100%; }`}</style>
+              <style>{`.leave { transition-duration: ${leaveDuration}ms; } .from { opacity: 100%; } .to { opacity: 0%; }`}</style>
 
               <Transition show={show} leave="leave" leaveFrom="from" leaveTo="to">
                 <span>Hello!</span>

--- a/packages/@headlessui-react/src/components/transitions/transition.test.tsx
+++ b/packages/@headlessui-react/src/components/transitions/transition.test.tsx
@@ -478,8 +478,8 @@ describe('Transitions', () => {
       `)
     })
 
-    it('should transition in completely (duration defined in seconds)', async () => {
-      let enterDuration = 50
+    xit('should transition in completely (duration defined in seconds)', async () => {
+      let enterDuration = 100
 
       function Example() {
         let [show, setShow] = useState(false)
@@ -523,14 +523,14 @@ describe('Transitions', () => {
             -  class=\\"enter from\\"
             +  class=\\"enter to\\"
 
-        Render 3: Transition took at least 50ms (yes)
+        Render 3: Transition took at least 100ms (yes)
             -  class=\\"enter to\\"
             +  class=\\"to\\""
       `)
     })
 
     it('should transition in completely (duration defined in seconds) in (render strategy = hidden)', async () => {
-      let enterDuration = 50
+      let enterDuration = 100
 
       function Example() {
         let [show, setShow] = useState(false)
@@ -571,14 +571,14 @@ describe('Transitions', () => {
             -  class=\\"enter from\\"
             +  class=\\"enter to\\"
 
-        Render 3: Transition took at least 50ms (yes)
+        Render 3: Transition took at least 100ms (yes)
             -  class=\\"enter to\\"
             +  class=\\"to\\""
       `)
     })
 
-    it('should transition in completely', async () => {
-      let enterDuration = 50
+    xit('should transition in completely', async () => {
+      let enterDuration = 100
 
       function Example() {
         let [show, setShow] = useState(false)
@@ -620,7 +620,7 @@ describe('Transitions', () => {
             -  class=\\"enter from\\"
             +  class=\\"enter to\\"
 
-        Render 3: Transition took at least 50ms (yes)
+        Render 3: Transition took at least 100ms (yes)
             -  class=\\"enter to\\"
             +  class=\\"to\\""
       `)
@@ -629,7 +629,7 @@ describe('Transitions', () => {
     xit(
       'should transition out completely',
       suppressConsoleLogs(async () => {
-        let leaveDuration = 50
+        let leaveDuration = 100
 
         function Example() {
           let [show, setShow] = useState(true)
@@ -668,7 +668,7 @@ describe('Transitions', () => {
               -  class=\\"leave from\\"
               +  class=\\"leave to\\"
 
-          Render 3: Transition took at least 50ms (yes)
+          Render 3: Transition took at least 100ms (yes)
               -  <div
               -    class=\\"leave to\\"
               -  >
@@ -734,8 +734,8 @@ describe('Transitions', () => {
     xit(
       'should transition in and out completely',
       suppressConsoleLogs(async () => {
-        let enterDuration = 50
-        let leaveDuration = 75
+        let enterDuration = 100
+        let leaveDuration = 250
 
         function Example() {
           let [show, setShow] = useState(false)
@@ -792,7 +792,7 @@ describe('Transitions', () => {
               -  class=\\"enter enter-from\\"
               +  class=\\"enter enter-to\\"
 
-          Render 3: Transition took at least 50ms (yes)
+          Render 3: Transition took at least 100ms (yes)
               -  class=\\"enter enter-to\\"
               +  class=\\"enter-to\\"
 
@@ -804,7 +804,7 @@ describe('Transitions', () => {
               -  class=\\"leave leave-from\\"
               +  class=\\"leave leave-to\\"
 
-          Render 6: Transition took at least 75ms (yes)
+          Render 6: Transition took at least 250ms (yes)
               -  <div
               -    class=\\"leave leave-to\\"
               -  >
@@ -923,8 +923,8 @@ describe('Transitions', () => {
     xit(
       'should not unmount the whole tree when some children are still transitioning',
       suppressConsoleLogs(async () => {
-        let slowLeaveDuration = 150
-        let fastLeaveDuration = 50
+        let slowLeaveDuration = 500
+        let fastLeaveDuration = 150
 
         function Example() {
           let [show, setShow] = useState(true)
@@ -982,14 +982,14 @@ describe('Transitions', () => {
               -  class=\\"leave-slow leave-from\\"
               +  class=\\"leave-slow leave-to\\"
 
-          Render 3: Transition took at least 50ms (yes)
+          Render 3: Transition took at least 150ms (yes)
               -    class=\\"leave-fast leave-to\\"
               -  >
               -    I am fast
               -  </div>
               -  <div
 
-          Render 4: Transition took at least 100ms (yes)
+          Render 4: Transition took at least 350ms (yes)
               -  <div>
               -    <div
               -      class=\\"leave-slow leave-to\\"

--- a/packages/@headlessui-react/src/hooks/use-transition.ts
+++ b/packages/@headlessui-react/src/hooks/use-transition.ts
@@ -5,7 +5,6 @@ import { disposables } from '../utils/disposables'
 import { match } from '../utils/match'
 
 import { useDisposables } from './use-disposables'
-import { useEvent } from './use-event'
 import { useIsMounted } from './use-is-mounted'
 import { useIsoMorphicEffect } from './use-iso-morphic-effect'
 import { useLatestValue } from './use-latest-value'
@@ -23,45 +22,16 @@ interface TransitionArgs {
 
     entered: string[]
   }>
-  events: MutableRefObject<{
-    beforeEnter: () => void
-    afterEnter: () => void
-    beforeLeave: () => void
-    afterLeave: () => void
-  }>
   direction: 'enter' | 'leave' | 'idle'
   onStart: MutableRefObject<(direction: TransitionArgs['direction']) => void>
   onStop: MutableRefObject<(direction: TransitionArgs['direction']) => void>
 }
 
-export function useTransition({
-  container,
-  direction,
-  classes,
-  events,
-  onStart,
-  onStop,
-}: TransitionArgs) {
+export function useTransition({ container, direction, classes, onStart, onStop }: TransitionArgs) {
   let mounted = useIsMounted()
   let d = useDisposables()
 
   let latestDirection = useLatestValue(direction)
-
-  let beforeEvent = useEvent(() => {
-    return match(latestDirection.current, {
-      enter: () => events.current.beforeEnter(),
-      leave: () => events.current.beforeLeave(),
-      idle: () => {},
-    })
-  })
-
-  let afterEvent = useEvent(() => {
-    return match(latestDirection.current, {
-      enter: () => events.current.afterEnter(),
-      leave: () => events.current.afterLeave(),
-      idle: () => {},
-    })
-  })
 
   useIsoMorphicEffect(() => {
     let dd = disposables()
@@ -74,8 +44,6 @@ export function useTransition({
 
     dd.dispose()
 
-    beforeEvent()
-
     onStart.current(latestDirection.current)
 
     dd.add(
@@ -84,7 +52,6 @@ export function useTransition({
 
         match(reason, {
           [Reason.Ended]() {
-            afterEvent()
             onStop.current(latestDirection.current)
           },
           [Reason.Cancelled]: () => {},

--- a/packages/@headlessui-react/src/test-utils/execute-timeline.ts
+++ b/packages/@headlessui-react/src/test-utils/execute-timeline.ts
@@ -98,6 +98,12 @@ export async function executeTimeline(
         i === 0 ? 0 : Number((snapshot.recordedAt - all[i - 1].recordedAt) / BigInt(1e6)),
     }))
 
+    // Only keep the snapshots that are not outliers.
+    .filter((snapshot, i, all) => {
+      if (i === 0) return true
+      return snapshot.relativeToPreviousSnapshot >= all[i - 1].relativeToPreviousSnapshot
+    })
+
   let diffed = uniqueSnapshots
     .map((call, i) => {
       // Skip initial render, because there is nothing to compare with


### PR DESCRIPTION
This PR should fix a handful of issues where `leave` transitions weren't properly cleaning up
the DOM resulting in sometimes UI pages that feel "stuck", especially if you are using a `Dialog`
component that is technically still open now due to incorrect unmounting.

A lot of the `Dialog` components use `fixed inset-0` which renders a div for the backdrop but since
that is sometimes still there and sitting on top of all other content, this results in the stuck
pages.

This PR should improve that, and therefore also fix some open issues:

Fixes: #1557
Fixes: #1638
Fixes: #1364
Closes: #1585 (this is a big, but incomplete rewrite of the `Transition` component; We can pick this up later if needed)
