### PR TITLE
Ensure enter transitions work when using `unmount={false}`

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Only restore focus to the `Menu.Button` if necessary when activating a `Menu.Option` ([#1782](https://github.com/tailwindlabs/headlessui/pull/1782))
 - Don't scroll when wrapping around in focus trap ([#1789](https://github.com/tailwindlabs/headlessui/pull/1789))
 - Fix `Transition` component's incorrect cleanup and order of events ([#1803](https://github.com/tailwindlabs/headlessui/pull/1803))
+- Ensure enter transitions work when using `unmount={false}` ([#1811](https://github.com/tailwindlabs/headlessui/pull/1811))
 
 ## Changed
 

--- a/packages/@headlessui-react/src/components/transitions/utils/transition.ts
+++ b/packages/@headlessui-react/src/components/transitions/utils/transition.ts
@@ -106,6 +106,15 @@ export function transition(
   let d = disposables()
   let _done = done !== undefined ? once(done) : () => {}
 
+  // When using unmount={false}, when the element is "hidden", then we apply a `style.display =
+  // 'none'` and a `hidden` attribute. Let's remove that in case we want to make an enter
+  // transition. It can happen that React is removing this a bit too late causing the element to not
+  // transition at all.
+  if (direction === 'enter') {
+    node.removeAttribute('hidden')
+    node.style.display = ''
+  }
+
   let base = match(direction, {
     enter: () => classes.enter,
     leave: () => classes.leave,


### PR DESCRIPTION
This PR will further improve a bug that happens at random on my machine, but can reproduce it when I
slowdown my CPU tremendously (or join a Zoom call...).

Fixes: #1557 (hopefully)
