### PR TITLE
Ensure `Combobox.Label` is properly linked when rendered after `Combobox.Button` and `Combobox.Input` components

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve iOS scroll locking ([#1830](https://github.com/tailwindlabs/headlessui/pull/1830))
 - Add `<fieldset disabled>` check to radio group options in React ([#1835](https://github.com/tailwindlabs/headlessui/pull/1835))
 - Ensure `Tab` order stays consistent, and the currently active `Tab` stays active ([#1837](https://github.com/tailwindlabs/headlessui/pull/1837))
+- Ensure `Combobox.Label` is properly linked when rendered after `Combobox.Button` and `Combobox.Input` components ([#1838](https://github.com/tailwindlabs/headlessui/pull/1838))
 
 ## [1.7.0] - 2022-09-06
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -632,6 +632,22 @@ describe('Rendering', () => {
     )
 
     it(
+      'should be possible to link Input/Button and Label if Label is rendered last',
+      suppressConsoleLogs(async () => {
+        render(
+          <Combobox value="Test" onChange={console.log}>
+            <Combobox.Input onChange={NOOP} />
+            <Combobox.Button />
+            <Combobox.Label>Label</Combobox.Label>
+          </Combobox>
+        )
+
+        assertComboboxLabelLinkedWithCombobox()
+        assertComboboxButtonLinkedWithComboboxLabel()
+      })
+    )
+
+    it(
       'should be possible to render a Combobox.Label using a render prop and an `as` prop',
       suppressConsoleLogs(async () => {
         render(

--- a/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
@@ -655,6 +655,27 @@ describe('Rendering', () => {
     )
 
     it(
+      'should be possible to link Input/Button and Label if Label is rendered last',
+      suppressConsoleLogs(async () => {
+        renderTemplate({
+          template: html`
+            <Combobox v-model="value">
+              <ComboboxInput />
+              <ComboboxButton />
+              <ComboboxLabel>Label</ComboboxLabel>
+            </Combobox>
+          `,
+          setup: () => ({ value: ref(null) }),
+        })
+
+        await new Promise<void>(nextTick)
+
+        assertComboboxLabelLinkedWithCombobox()
+        assertComboboxButtonLinkedWithComboboxLabel()
+      })
+    )
+
+    it(
       'should be possible to render a ComboboxLabel using a render prop and an `as` prop',
       suppressConsoleLogs(async () => {
         renderTemplate({


### PR DESCRIPTION
Ensure `Combobox.Label` is properly linked with `Combobox.Input` and `Combobox.Button`, even when rendered after these components.
We do require an additional render, but now it happens automatically for you, before that you _had_ to make a change yourself in order to trigger a re-render and "fixing" the missing link.

Fixes: #1836
