### PR TITLE
Ensure we handle the `static` prop in `Tab.Panel` components correctly

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Prevent option selection in `Combobox.Input` while composing ([#1850](https://github.com/tailwindlabs/headlessui/issues/1850))
+- Ensure we handle the `static` prop in `Tab.Panel` components correctly ([#1856](https://github.com/tailwindlabs/headlessui/pull/1856))
 
 ## [1.7.1] - 2022-09-12
 

--- a/packages/@headlessui-react/src/components/tabs/tabs.tsx
+++ b/packages/@headlessui-react/src/components/tabs/tabs.tsx
@@ -502,7 +502,7 @@ let Panel = forwardRefWithAs(function Panel<TTag extends ElementType = typeof DE
     tabIndex: selected ? 0 : -1,
   }
 
-  if (!selected && (props.unmount ?? true)) {
+  if (!selected && (props.unmount ?? true) && !(props.static ?? false)) {
     return <Hidden as="span" {...ourProps} />
   }
 

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Prevent option selection in `ComboboxInput` while composing ([#1850](https://github.com/tailwindlabs/headlessui/issues/1850))
+- Ensure we handle the `static` prop in `TabPanel` components correctly ([#1856](https://github.com/tailwindlabs/headlessui/pull/1856))
 
 ## [1.7.1] - 2022-09-12
 

--- a/packages/@headlessui-vue/src/components/tabs/tabs.ts
+++ b/packages/@headlessui-vue/src/components/tabs/tabs.ts
@@ -395,7 +395,7 @@ export let TabPanel = defineComponent({
         tabIndex: selected.value ? 0 : -1,
       }
 
-      if (!selected.value && props.unmount) {
+      if (!selected.value && props.unmount && !props.static) {
         return h(Hidden, { as: 'span', ...ourProps })
       }
 


### PR DESCRIPTION
This PR fixes an issue where `static` Tab Panels didn't take the `static` prop into account when
rendering the "hidden" panel (to guarantee tab order and matching tab panels).

Fixes: #1323

