### PR TITLE
Fix `useOutsideClick` swallowing events inside ShadowDOM

### DIFF
--- a/packages/@headlessui-react/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-react/src/hooks/use-outside-click.ts
@@ -96,7 +96,7 @@ export function useOutsideClick(
     'mousedown',
     (event) => {
       if (enabledRef.current) {
-        initialClickTarget.current = event.target
+        initialClickTarget.current = event.composedPath?.()?.[0] || event.target
       }
     },
     true

--- a/packages/@headlessui-vue/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-vue/src/hooks/use-outside-click.ts
@@ -82,7 +82,7 @@ export function useOutsideClick(
     'mousedown',
     (event) => {
       if (enabled.value) {
-        initialClickTarget.value = event.target
+        initialClickTarget.value = event.composedPath?.()?.[0] || event.target
       }
     },
     true


### PR DESCRIPTION
In our Project, we are heavily using web components for a Microfrontend Architecture. For our React Components, we are using tailwindcss and headlessui. After implementing ListBox and ComboBox Components, we quickly hit #874. I dug a little bit in to the code and it seems that the `useOutsideClick` hook swallows the ShadowDOM events.

For Example, a ListBox is inside an ShadowDOM and the user clicks on an ListBox item. The `useOutsideClick` hook gets the `mousedown` event. In this case, `event.target` is the ShadowDOM it selfe and not the ListBox item. So the code sets the `initialClickTarget` to the ShadowDOM and the following `useOutsideClick` Logic registered the event as an outside click instead of a click on the ListBox item. The fix, which works in our Project, is to give the real target inside the ShadowDOM, with `composePath` if it exists.

In #874 there was stated that there will properly be some clean up, regarding web components, so I decided to share this fix because it is not too big and doesn't let any test fail. Feel free to close the PR if there are other colliding plans.