### PR TITLE
Warn when changing `Combobox` between controlled and uncontrolled

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,9 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  push:
+    branches: [main]
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `<Popover.Button as={Fragment} />` crash ([#1889](https://github.com/tailwindlabs/headlessui/pull/1889))
 - Expose `close` function for `Menu` and `Menu.Item` components ([#1897](https://github.com/tailwindlabs/headlessui/pull/1897))
 
+### Added
+
+- Warn when changing components between controlled and uncontrolled ([#1878](https://github.com/tailwindlabs/headlessui/issues/1878))
+
 ## [1.7.3] - 2022-09-30
 
 ### Fixed

--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -5155,7 +5155,7 @@ describe('Mouse interactions', () => {
   )
 
   it(
-    'should sync the input field correctly and reset it when resetting the value from outside',
+    'should sync the input field correctly and reset it when resetting the value from outside (to null)',
     suppressConsoleLogs(async () => {
       function Example() {
         let [value, setValue] = useState<string | null>('bob')
@@ -5187,6 +5187,53 @@ describe('Mouse interactions', () => {
       // Override the input by typing something
       await type(word('test'), getComboboxInput())
       expect(getComboboxInput()?.value).toBe('test')
+
+      // Reset from outside
+      await click(getByText('reset'))
+
+      // Verify the input is reset correctly
+      expect(getComboboxInput()?.value).toBe('')
+    })
+  )
+
+  it(
+    'should sync the input field correctly and reset it when resetting the value from outside (to undefined)',
+    suppressConsoleLogs(async () => {
+      function Example() {
+        let [value, setValue] = useState<string | undefined>('bob')
+
+        return (
+          <>
+            <Combobox value={value} onChange={setValue}>
+              <Combobox.Input onChange={NOOP} />
+              <Combobox.Button>Trigger</Combobox.Button>
+              <Combobox.Options>
+                <Combobox.Option value="alice">alice</Combobox.Option>
+                <Combobox.Option value="bob">bob</Combobox.Option>
+                <Combobox.Option value="charlie">charlie</Combobox.Option>
+              </Combobox.Options>
+            </Combobox>
+            <button onClick={() => setValue(undefined)}>reset</button>
+          </>
+        )
+      }
+
+      render(<Example />)
+
+      // Open combobox
+      await click(getComboboxButton())
+
+      // Verify the input has the selected value
+      expect(getComboboxInput()?.value).toBe('bob')
+
+      // Override the input by typing something
+      await type(word('alice'), getComboboxInput())
+      expect(getComboboxInput()?.value).toBe('alice')
+
+      // Select the option
+      await press(Keys.ArrowUp)
+      await press(Keys.Enter)
+      expect(getComboboxInput()?.value).toBe('alice')
 
       // Reset from outside
       await click(getByText('reset'))

--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -396,7 +396,7 @@ describe('Rendering', () => {
       'selecting an option puts the value into Combobox.Input when displayValue is not provided',
       suppressConsoleLogs(async () => {
         function Example() {
-          let [value, setValue] = useState(undefined)
+          let [value, setValue] = useState(null)
 
           return (
             <Combobox value={value} onChange={setValue}>
@@ -430,7 +430,7 @@ describe('Rendering', () => {
       'selecting an option puts the display value into Combobox.Input when displayValue is provided',
       suppressConsoleLogs(async () => {
         function Example() {
-          let [value, setValue] = useState(undefined)
+          let [value, setValue] = useState(null)
 
           return (
             <Combobox value={value} onChange={setValue}>
@@ -558,7 +558,7 @@ describe('Rendering', () => {
       'should be possible to override the `type` on the input',
       suppressConsoleLogs(async () => {
         function Example() {
-          let [value, setValue] = useState(undefined)
+          let [value, setValue] = useState(null)
 
           return (
             <Combobox value={value} onChange={setValue}>

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -404,7 +404,8 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
   let [value, theirOnChange] = useControllable<any>(
     controlledValue,
     controlledOnChange,
-    defaultValue
+    defaultValue,
+    'value' in props
   )
 
   let [state, dispatch] = useReducer(stateReducer, {

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -404,8 +404,7 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
   let [value, theirOnChange] = useControllable<any>(
     controlledValue,
     controlledOnChange,
-    defaultValue,
-    'value' in props
+    defaultValue
   )
 
   let [state, dispatch] = useReducer(stateReducer, {

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -678,32 +678,13 @@ let Input = forwardRefWithAs(function Input<
     // displayValue is intentionally left out
   }, [data.value])
 
-  let shouldIgnoreOpenOnChange = false
-  function updateInputValue(newValue: string) {
-    let input = data.inputRef.current
-    if (!input) {
-      return
-    }
-
-    // Skip React's value setting which causes the input event to not be fired because it de-dupes input/change events
-    let descriptor = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')
-    descriptor?.set?.call(input, newValue)
-
-    // Fire an input event which causes the browser to trigger the user's `onChange` handler.
-    // We have to prevent the combobox from opening when this happens. Since these events
-    // fire synchronously `shouldIgnoreOpenOnChange` will be correct during `handleChange`
-    shouldIgnoreOpenOnChange = true
-    input.dispatchEvent(new Event('input', { bubbles: true }))
-    shouldIgnoreOpenOnChange = false
-  }
-
   useWatch(
     ([currentValue, state], [oldCurrentValue, oldState]) => {
       if (!data.inputRef.current) return
       if (oldState === ComboboxState.Open && state === ComboboxState.Closed) {
-        updateInputValue(currentValue)
+        data.inputRef.current.value = currentValue
       } else if (currentValue !== oldCurrentValue) {
-        updateInputValue(currentValue)
+        data.inputRef.current.value = currentValue
       }
     },
     [currentValue, data.comboboxState]
@@ -806,9 +787,7 @@ let Input = forwardRefWithAs(function Input<
   })
 
   let handleChange = useEvent((event: React.ChangeEvent<HTMLInputElement>) => {
-    if (!shouldIgnoreOpenOnChange) {
-      actions.openCombobox()
-    }
+    actions.openCombobox()
     onChange?.(event)
   })
 

--- a/packages/@headlessui-react/src/hooks/use-controllable.ts
+++ b/packages/@headlessui-react/src/hooks/use-controllable.ts
@@ -1,14 +1,31 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useEvent } from './use-event'
+
+let didWarnOnUncontrolledToControlled = false
+let didWarnOnControlledToUncontrolled = false
 
 export function useControllable<T>(
   controlledValue: T | undefined,
   onChange?: (value: T) => void,
-  defaultValue?: T,
-  isControlled?: boolean
+  defaultValue?: T
 ) {
   let [internalValue, setInternalValue] = useState(defaultValue)
-  isControlled = isControlled ?? controlledValue !== undefined
+  let isControlled = controlledValue !== undefined
+  let wasControlled = useRef(isControlled)
+
+  if (isControlled && !wasControlled.current && !didWarnOnUncontrolledToControlled) {
+    didWarnOnUncontrolledToControlled = true
+    wasControlled.current = isControlled
+    console.error(
+      'A component is changing from uncontrolled to controlled. This may be caused by the value changing from undefined to a defined value, which should not happen.'
+    )
+  } else if (!isControlled && wasControlled.current && !didWarnOnControlledToUncontrolled) {
+    didWarnOnControlledToUncontrolled = true
+    wasControlled.current = isControlled
+    console.error(
+      'A component is changing from controlled to uncontrolled. This may be caused by the value changing from a defined value to undefined, which should not happen.'
+    )
+  }
 
   return [
     (isControlled ? controlledValue : internalValue)!,

--- a/packages/@headlessui-react/src/hooks/use-controllable.ts
+++ b/packages/@headlessui-react/src/hooks/use-controllable.ts
@@ -4,10 +4,11 @@ import { useEvent } from './use-event'
 export function useControllable<T>(
   controlledValue: T | undefined,
   onChange?: (value: T) => void,
-  defaultValue?: T
+  defaultValue?: T,
+  isControlled?: boolean
 ) {
   let [internalValue, setInternalValue] = useState(defaultValue)
-  let isControlled = controlledValue !== undefined
+  isControlled = isControlled ?? controlledValue !== undefined
 
   return [
     (isControlled ? controlledValue : internalValue)!,

--- a/packages/@headlessui-react/src/hooks/use-controllable.ts
+++ b/packages/@headlessui-react/src/hooks/use-controllable.ts
@@ -1,26 +1,26 @@
 import { useRef, useState } from 'react'
 import { useEvent } from './use-event'
 
-let didWarnOnUncontrolledToControlled = false
-let didWarnOnControlledToUncontrolled = false
-
 export function useControllable<T>(
   controlledValue: T | undefined,
   onChange?: (value: T) => void,
   defaultValue?: T
 ) {
   let [internalValue, setInternalValue] = useState(defaultValue)
+
   let isControlled = controlledValue !== undefined
   let wasControlled = useRef(isControlled)
+  let didWarnOnUncontrolledToControlled = useRef(false)
+  let didWarnOnControlledToUncontrolled = useRef(false)
 
-  if (isControlled && !wasControlled.current && !didWarnOnUncontrolledToControlled) {
-    didWarnOnUncontrolledToControlled = true
+  if (isControlled && !wasControlled.current && !didWarnOnUncontrolledToControlled.current) {
+    didWarnOnUncontrolledToControlled.current = true
     wasControlled.current = isControlled
     console.error(
       'A component is changing from uncontrolled to controlled. This may be caused by the value changing from undefined to a defined value, which should not happen.'
     )
-  } else if (!isControlled && wasControlled.current && !didWarnOnControlledToUncontrolled) {
-    didWarnOnControlledToUncontrolled = true
+  } else if (!isControlled && wasControlled.current && !didWarnOnControlledToUncontrolled.current) {
+    didWarnOnControlledToUncontrolled.current = true
     wasControlled.current = isControlled
     console.error(
       'A component is changing from controlled to uncontrolled. This may be caused by the value changing from a defined value to undefined, which should not happen.'

--- a/packages/@headlessui-react/src/test-utils/suppress-console-logs.ts
+++ b/packages/@headlessui-react/src/test-utils/suppress-console-logs.ts
@@ -15,3 +15,16 @@ export function suppressConsoleLogs<T extends unknown[]>(
     }).finally(() => spy.mockRestore())
   }
 }
+
+export function mockingConsoleLogs<T extends unknown[]>(
+  cb: (spy: jest.SpyInstance, ...args: T) => unknown,
+  type: FunctionPropertyNames<typeof globalThis.console> = 'error'
+) {
+  return (...args: T) => {
+    let spy = jest.spyOn(globalThis.console, type).mockImplementation(jest.fn())
+
+    return new Promise<unknown>((resolve, reject) => {
+      Promise.resolve(cb(spy, ...args)).then(resolve, reject)
+    }).finally(() => spy.mockRestore())
+  }
+}

--- a/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
@@ -5381,7 +5381,7 @@ describe('Mouse interactions', () => {
   )
 
   it(
-    'should sync the input field correctly and reset it when resetting the value from outside',
+    'should sync the input field correctly and reset it when resetting the value from outside (to null)',
     suppressConsoleLogs(async () => {
       renderTemplate({
         template: html`
@@ -5408,6 +5408,48 @@ describe('Mouse interactions', () => {
       // Override the input by typing something
       await type(word('test'), getComboboxInput())
       expect(getComboboxInput()?.value).toBe('test')
+
+      // Reset from outside
+      await click(getByText('reset'))
+
+      // Verify the input is reset correctly
+      expect(getComboboxInput()?.value).toBe('')
+    })
+  )
+
+  it(
+    'should sync the input field correctly and reset it when resetting the value from outside (to undefined)',
+    suppressConsoleLogs(async () => {
+      renderTemplate({
+        template: html`
+          <Combobox v-model="value">
+            <ComboboxInput />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="alice">alice</ComboboxOption>
+              <ComboboxOption value="bob">bob</ComboboxOption>
+              <ComboboxOption value="charlie">charlie</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+          <button @click="value = undefined">reset</button>
+        `,
+        setup: () => ({ value: ref('bob') }),
+      })
+
+      // Open combobox
+      await click(getComboboxButton())
+
+      // Verify the input has the selected value
+      expect(getComboboxInput()?.value).toBe('bob')
+
+      // Override the input by typing something
+      await type(word('alice'), getComboboxInput())
+      expect(getComboboxInput()?.value).toBe('alice')
+
+      // Select the option
+      await press(Keys.ArrowUp)
+      await press(Keys.Enter)
+      expect(getComboboxInput()?.value).toBe('alice')
 
       // Reset from outside
       await click(getByText('reset'))


### PR DESCRIPTION
We currently don't handle changes to/from `undefined`. However this is _okay_. If you specify a value of `undefined` you're saying you want an uncontrolled component. This follows React's own conventions for inputs for example.

We'll warn when changing between a controlled and uncontrolled component as this can be considered an implementation error.

Fixes #1177