### PR TITLE
Fix crash when `children` are `undefined`

### DIFF
--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Call `displayValue` with a v-model of `ref(undefined)` on `ComboboxInput` ([#1865](https://github.com/tailwindlabs/headlessui/pull/1865))
 - Improve `Portal` detection for `Popover` components ([#1842](https://github.com/tailwindlabs/headlessui/pull/1842))
+- Fix crash when `children` are `undefined` ([#1885](https://github.com/tailwindlabs/headlessui/pull/1885))
 
 ## [1.7.2] - 2022-09-15
 

--- a/packages/@headlessui-vue/src/components/menu/menu.test.tsx
+++ b/packages/@headlessui-vue/src/components/menu/menu.test.tsx
@@ -91,6 +91,12 @@ describe('Safe guards', () => {
 
 describe('Rendering', () => {
   describe('Menu', () => {
+    it('should not crash when rendering no children at all', () => {
+      renderTemplate(jsx`
+        <Menu></Menu>
+      `)
+    })
+
     it('should be possible to render a Menu using a default render prop', async () => {
       renderTemplate(jsx`
         <Menu v-slot="{ open }">

--- a/packages/@headlessui-vue/src/utils/render.ts
+++ b/packages/@headlessui-vue/src/utils/render.ts
@@ -108,7 +108,7 @@ function _render({
   }
 
   if (as === 'template') {
-    children = flattenFragments(children as VNode[])
+    children = flattenFragments(children ?? [])
 
     if (Object.keys(incomingProps).length > 0 || Object.keys(attrs).length > 0) {
       let [firstChild, ...other] = children ?? []


### PR DESCRIPTION
This PR fixes an issue where if you render no children at all (probably user error because all our components require at least some form of child) the component crashes with an error. This PR ensures that `children` are always an error so that the issue should not occur anymore.

That said, if you just render something like:
```
<Menu></Menu>
```

It won't crash anymore, but it will also not work as expected since the `MenuButton`, `MenuItems` and `MenuItem` components are missing.

Fixes: #1884
