### PR TITLE
fix: the order of compositionend events varies by browser

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -690,11 +690,11 @@ let Input = forwardRefWithAs(function Input<
     [currentValue, data.comboboxState]
   )
 
-  const isComposing = useRef(false)
-  const handleCompositionStart = useEvent((_: ReactKeyboardEvent<CompositionEvent>) => {
+  let isComposing = useRef(false)
+  let handleCompositionStart = useEvent(() => {
     isComposing.current = true
   })
-  const handleCompositionEnd = useEvent((_: ReactKeyboardEvent<CompositionEvent>) => {
+  let handleCompositionEnd = useEvent(() => {
     setTimeout(() => {
       isComposing.current = false
     })

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -690,6 +690,16 @@ let Input = forwardRefWithAs(function Input<
     [currentValue, data.comboboxState]
   )
 
+  const isComposing = useRef(false)
+  const handleCompositionStart = useEvent((_: ReactKeyboardEvent<CompositionEvent>) => {
+    isComposing.current = true
+  })
+  const handleCompositionEnd = useEvent((_: ReactKeyboardEvent<CompositionEvent>) => {
+    setTimeout(() => {
+      isComposing.current = false
+    })
+  })
+
   let handleKeyDown = useEvent((event: ReactKeyboardEvent<HTMLInputElement>) => {
     switch (event.key) {
       // Ref: https://www.w3.org/TR/wai-aria-practices-1.2/#keyboard-interaction-12
@@ -713,7 +723,7 @@ let Input = forwardRefWithAs(function Input<
 
       case Keys.Enter:
         if (data.comboboxState !== ComboboxState.Open) return
-        if (event.nativeEvent.isComposing) return
+        if (isComposing.current) return
 
         event.preventDefault()
         event.stopPropagation()
@@ -815,6 +825,8 @@ let Input = forwardRefWithAs(function Input<
     'aria-multiselectable': data.mode === ValueMode.Multi ? true : undefined,
     'aria-labelledby': labelledby,
     disabled: data.disabled,
+    onCompositionStart: handleCompositionStart,
+    onCompositionEnd: handleCompositionEnd,
     onKeyDown: handleKeyDown,
     onChange: handleChange,
   }

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -630,7 +630,7 @@ export let ComboboxInput = defineComponent({
     }
 
     // Workaround Vue bug where watching [ref(undefined)] is not fired immediately even when value is true
-    const __fixVueImmediateWatchBug__ = ref('')
+    let __fixVueImmediateWatchBug__ = ref('')
 
     onMounted(() => {
       watch(
@@ -659,7 +659,7 @@ export let ComboboxInput = defineComponent({
       )
     })
 
-    const isComposing = ref(false)
+    let isComposing = ref(false)
     function handleCompositionstart() {
       isComposing.value = true
     }

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -659,6 +659,16 @@ export let ComboboxInput = defineComponent({
       )
     })
 
+    const isComposing = ref(false)
+    function handleCompositionstart() {
+      isComposing.value = true
+    }
+    function handleCompositionend() {
+      setTimeout(() => {
+        isComposing.value = false
+      })
+    }
+
     function handleKeyDown(event: KeyboardEvent) {
       switch (event.key) {
         // Ref: https://www.w3.org/TR/wai-aria-practices-1.2/#keyboard-interaction-12
@@ -683,7 +693,7 @@ export let ComboboxInput = defineComponent({
 
         case Keys.Enter:
           if (api.comboboxState.value !== ComboboxStates.Open) return
-          if (event.isComposing) return
+          if (isComposing.value) return
 
           event.preventDefault()
           event.stopPropagation()
@@ -774,6 +784,8 @@ export let ComboboxInput = defineComponent({
         'aria-multiselectable': api.mode.value === ValueMode.Multi ? true : undefined,
         'aria-labelledby': dom(api.labelRef)?.id ?? dom(api.buttonRef)?.id,
         id,
+        onCompositionstart: handleCompositionstart,
+        onCompositionend: handleCompositionend,
         onKeydown: handleKeyDown,
         onChange: handleChange,
         onInput: handleInput,


### PR DESCRIPTION
Related issue: https://github.com/tailwindlabs/headlessui/issues/1849