### PR TITLE
Allow `multiple` and `nullable` to be typed as `boolean`

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -15,7 +15,7 @@ import React, {
   MutableRefObject,
   Ref,
 } from 'react'
-import { ByComparator, EnsureArray, Expand, Props } from '../../types'
+import { ByComparator, EnsureArray, Expand, Props, ExtractExact } from '../../types'
 
 import { useComputed } from '../../hooks/use-computed'
 import { useDisposables } from '../../hooks/use-disposables'
@@ -321,7 +321,7 @@ type ComboboxValueProps<
   TNullable extends boolean | undefined,
   TMultiple extends boolean | undefined,
   TTag extends ElementType
-> = Extract<
+> = ExtractExact<
   | ({
       value?: EnsureArray<TValue>
       defaultValue?: EnsureArray<TValue>
@@ -359,7 +359,7 @@ type ComboboxValueProps<
       nullable?: boolean
       multiple?: boolean
       defaultValue?: TValue
-      onChange?(value: TValue): void
+      onChange?(value: TValue | EnsureArray<TValue> | null): void
       by?: ByComparator<TValue>
     } & Props<TTag, ComboboxRenderPropArg<TValue>, O>),
   { nullable?: TNullable; multiple?: TMultiple }

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -353,6 +353,14 @@ type ComboboxValueProps<
       defaultValue?: TValue
       onChange?(value: TValue): void
       by?: ByComparator<TValue>
+    } & Props<TTag, ComboboxRenderPropArg<TValue>, O>)
+  | ({
+      value?: TValue
+      nullable?: boolean
+      multiple?: boolean
+      defaultValue?: TValue
+      onChange?(value: TValue): void
+      by?: ByComparator<TValue>
     } & Props<TTag, ComboboxRenderPropArg<TValue>, O>),
   { nullable?: TNullable; multiple?: TMultiple }
 >
@@ -382,6 +390,10 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
 ): JSX.Element
 function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG>(
   props: ComboboxProps<TValue, false, true, TTag>,
+  ref: Ref<TTag>
+): JSX.Element
+function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG>(
+  props: ComboboxProps<TValue, boolean, boolean, TTag>,
   ref: Ref<TTag>
 ): JSX.Element
 


### PR DESCRIPTION
Because this is true _and_ false I'm not 100% sure the types here are correct @RobinMalfait. Mind double checking my work here?

We could be more explicit here and add all 5 additional true/false + boolean combos for nullable and multiple but I think the one fallback of boolean + boolean is sufficient.

You can test this PR by dropping this into the `combobox.tsx` file:
```tsx
import { useState } from 'react'

function Foo() {
  const [isMultiple] = useState<boolean>(false)
  const [selectedOption, setSelectedOption] = useState()
  const onChange = useCallback((e: any) => setSelectedOption(e), [])

  return (
    <Combobox value={selectedOption} onChange={onChange} multiple={isMultiple}>
      <div>test</div>
    </Combobox>
  )
}
```

Fixes #1895