### PR TITLE
Fix `useOutsideClick`, add improvements for ShadowDOM

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `<Popover.Button as={Fragment} />` crash ([#1889](https://github.com/tailwindlabs/headlessui/pull/1889))
 - Expose `close` function for `Menu` and `Menu.Item` components ([#1897](https://github.com/tailwindlabs/headlessui/pull/1897))
+- Fix `useOutsideClick`, add improvements for ShadowDOM ([#1914](https://github.com/tailwindlabs/headlessui/pull/1914))
 
 ### Added
 

--- a/packages/@headlessui-react/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-react/src/hooks/use-outside-click.ts
@@ -60,7 +60,7 @@ export function useOutsideClick(
     }
 
     // Ignore if the target doesn't exist in the DOM anymore
-    if(!target.getRootNode().contains(target)) return
+    if (!target.getRootNode().contains(target)) return
 
     // Ignore if the target exists in one of the containers
     for (let container of _containers) {

--- a/packages/@headlessui-react/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-react/src/hooks/use-outside-click.ts
@@ -60,7 +60,7 @@ export function useOutsideClick(
     }
 
     // Ignore if the target doesn't exist in the DOM anymore
-    if (!target.ownerDocument.documentElement.contains(target)) return
+    if(!target.getRootNode().contains(target)) return
 
     // Ignore if the target exists in one of the containers
     for (let container of _containers) {

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Expose `close` function for `Menu` and `MenuItem` components ([#1897](https://github.com/tailwindlabs/headlessui/pull/1897))
+- Fix `useOutsideClick`, add improvements for ShadowDOM ([#1914](https://github.com/tailwindlabs/headlessui/pull/1914))
 
 ## [1.7.3] - 2022-09-30
 

--- a/packages/@headlessui-vue/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-vue/src/hooks/use-outside-click.ts
@@ -30,7 +30,7 @@ export function useOutsideClick(
     }
 
     // Ignore if the target doesn't exist in the DOM anymore
-    if (!target.ownerDocument.documentElement.contains(target)) return
+    if (!target.getRootNode().contains(target)) return
 
     let _containers = (function resolve(containers): ContainerCollection {
       if (typeof containers === 'function') {


### PR DESCRIPTION
This PR is a rebased continuation of #1913 which also added the same fix for the Vue implementation.

Closes: #1913
