### PR TITLE
Pass default slot instead of raw children to components

### DIFF
--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Expose `close` function for `Menu` and `MenuItem` components ([#1897](https://github.com/tailwindlabs/headlessui/pull/1897))
 - Fix `useOutsideClick`, add improvements for ShadowDOM ([#1914](https://github.com/tailwindlabs/headlessui/pull/1914))
+- Prevent default slot warning when using a component for `as` prop ([#1915](https://github.com/tailwindlabs/headlessui/pull/1915))
 
 ## [1.7.3] - 2022-09-30
 

--- a/packages/@headlessui-vue/src/utils/render.ts
+++ b/packages/@headlessui-vue/src/utils/render.ts
@@ -147,7 +147,9 @@ function _render({
     return children
   }
 
-  return h(as, Object.assign({}, incomingProps, dataAttributes), children)
+  return h(as, Object.assign({}, incomingProps, dataAttributes), {
+    default: () => children,
+  })
 }
 
 /**


### PR DESCRIPTION
This is essentially how the internal implementation of `<component>` works. This works even for element VNodes.

The old implementation wasn't _wrong_ but this normally lets Vue defer rendering of the slot (or even allow it to skip it in some cases). Given that we're calling the slot function ourselves that's not really the case. However, there's a potential future perf optimization where we only do this when `as="template"` (which we still still need because we have to flatten the VNode list for error checking)

Fixes #1892