### PR TITLE
fix(RadioGroup): defaultValue type definition

### DIFF
--- a/packages/@headlessui-react/src/components/radio-group/radio-group.tsx
+++ b/packages/@headlessui-react/src/components/radio-group/radio-group.tsx
@@ -119,7 +119,7 @@ let RadioGroupRoot = forwardRefWithAs(function RadioGroup<
   props: Props<
     TTag,
     RadioGroupRenderPropArg<TType>,
-    RadioGroupPropsWeControl | 'value' | 'onChange' | 'disabled' | 'name' | 'by'
+    RadioGroupPropsWeControl | 'value' | 'defaultValue' | 'onChange' | 'disabled' | 'name' | 'by'
   > & {
     value?: TType
     defaultValue?: TType


### PR DESCRIPTION
While trying to create a custom `RadioChipGroup` component based upon Headless UI’s `RadioGroup`, I’ve noticed that `defaultValue` can’t be set to `T` as it clashes with `defaultValue` as defined by React.

<img width="1179" alt="image" src="https://user-images.githubusercontent.com/14854048/195167466-fa430df3-783c-4c7a-9b94-8af0b155fef7.png">

This PR aims to resolve that problem by explicitly omitting `defaultValue` from the inherited props.