### PR TITLE
feat(Menu): add `onClose` prop and `@close` event

### DIFF
--- a/packages/@headlessui-react/src/components/menu/menu.test.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.test.tsx
@@ -390,8 +390,10 @@ describe('Rendering', () => {
     it(
       'should be possible to manually close the Menu using the exposed close function',
       suppressConsoleLogs(async () => {
+        let onClose = jest.fn()
+
         render(
-          <Menu>
+          <Menu onClose={onClose}>
             <Menu.Button>Trigger</Menu.Button>
             <Menu.Items>
               <Menu.Item>
@@ -419,6 +421,9 @@ describe('Rendering', () => {
         await click(getByText('Close'))
 
         assertMenu({ state: MenuState.InvisibleUnmounted })
+
+        // Verify `onClose` prop has been called
+        expect(onClose).toHaveBeenCalled()
       })
     )
   })
@@ -941,8 +946,10 @@ describe('Keyboard interactions', () => {
     it(
       'should be possible to close the menu with Enter when there is no active menuitem',
       suppressConsoleLogs(async () => {
+        let onClose = jest.fn()
+
         render(
-          <Menu>
+          <Menu onClose={onClose}>
             <Menu.Button>Trigger</Menu.Button>
             <Menu.Items>
               <Menu.Item as="a">Item A</Menu.Item>
@@ -971,6 +978,9 @@ describe('Keyboard interactions', () => {
         assertMenuButton({ state: MenuState.InvisibleUnmounted })
         assertMenu({ state: MenuState.InvisibleUnmounted })
 
+        // Verify `onClose` prop has been called
+        expect(onClose).toHaveBeenCalled()
+
         // Verify the button is focused again
         assertActiveElement(getMenuButton())
       })
@@ -980,8 +990,9 @@ describe('Keyboard interactions', () => {
       'should be possible to close the menu with Enter and invoke the active menu item',
       suppressConsoleLogs(async () => {
         let clickHandler = jest.fn()
+        let onClose = jest.fn()
         render(
-          <Menu>
+          <Menu onClose={onClose}>
             <Menu.Button>Trigger</Menu.Button>
             <Menu.Items>
               <Menu.Item as="a" onClick={clickHandler}>
@@ -1016,6 +1027,9 @@ describe('Keyboard interactions', () => {
         assertMenuButton({ state: MenuState.InvisibleUnmounted })
         assertMenu({ state: MenuState.InvisibleUnmounted })
 
+        // Verify `onClose` prop has been called
+        expect(onClose).toHaveBeenCalled()
+
         // Verify the button is focused again
         assertActiveElement(getMenuButton())
 
@@ -1029,9 +1043,10 @@ describe('Keyboard interactions', () => {
     'should be possible to use a button as a menu item and invoke it upon Enter',
     suppressConsoleLogs(async () => {
       let clickHandler = jest.fn()
+      let onClose = jest.fn()
 
       render(
-        <Menu>
+        <Menu onClose={onClose}>
           <Menu.Button>Trigger</Menu.Button>
           <Menu.Items>
             <Menu.Item as="a">Item A</Menu.Item>
@@ -1067,6 +1082,9 @@ describe('Keyboard interactions', () => {
       // Verify it is closed
       assertMenuButton({ state: MenuState.InvisibleUnmounted })
       assertMenu({ state: MenuState.InvisibleUnmounted })
+
+      // Verify `onClose` prop has been called
+      expect(onClose).toHaveBeenCalled()
 
       // Verify the button got "clicked"
       expect(clickHandler).toHaveBeenCalledTimes(1)
@@ -1303,8 +1321,9 @@ describe('Keyboard interactions', () => {
     it(
       'should be possible to close the menu with Space when there is no active menuitem',
       suppressConsoleLogs(async () => {
+        let onClose = jest.fn()
         render(
-          <Menu>
+          <Menu onClose={onClose}>
             <Menu.Button>Trigger</Menu.Button>
             <Menu.Items>
               <Menu.Item as="a">Item A</Menu.Item>
@@ -1333,6 +1352,9 @@ describe('Keyboard interactions', () => {
         assertMenuButton({ state: MenuState.InvisibleUnmounted })
         assertMenu({ state: MenuState.InvisibleUnmounted })
 
+        // Verify `onClose` prop has been called
+        expect(onClose).toHaveBeenCalled()
+
         // Verify the button is focused again
         assertActiveElement(getMenuButton())
       })
@@ -1342,8 +1364,9 @@ describe('Keyboard interactions', () => {
       'should be possible to close the menu with Space and invoke the active menu item',
       suppressConsoleLogs(async () => {
         let clickHandler = jest.fn()
+        let onClose = jest.fn()
         render(
-          <Menu>
+          <Menu onClose={onClose}>
             <Menu.Button>Trigger</Menu.Button>
             <Menu.Items>
               <Menu.Item as="a" onClick={clickHandler}>
@@ -1378,6 +1401,9 @@ describe('Keyboard interactions', () => {
         assertMenuButton({ state: MenuState.InvisibleUnmounted })
         assertMenu({ state: MenuState.InvisibleUnmounted })
 
+        // Verify `onClose` prop has been called
+        expect(onClose).toHaveBeenCalled()
+
         // Verify the "click" went through on the `a` tag
         expect(clickHandler).toHaveBeenCalled()
 
@@ -1391,8 +1417,9 @@ describe('Keyboard interactions', () => {
     it(
       'should be possible to close an open menu with Escape',
       suppressConsoleLogs(async () => {
+        let onClose = jest.fn()
         render(
-          <Menu>
+          <Menu onClose={onClose}>
             <Menu.Button>Trigger</Menu.Button>
             <Menu.Items>
               <Menu.Item as="a">Item A</Menu.Item>
@@ -1423,6 +1450,9 @@ describe('Keyboard interactions', () => {
         assertMenuButton({ state: MenuState.InvisibleUnmounted })
         assertMenu({ state: MenuState.InvisibleUnmounted })
 
+        // Verify `onClose` prop has been called
+        expect(onClose).toHaveBeenCalled()
+
         // Verify the button is focused again
         assertActiveElement(getMenuButton())
       })
@@ -1433,8 +1463,9 @@ describe('Keyboard interactions', () => {
     it(
       'should close when we use Tab',
       suppressConsoleLogs(async () => {
+        let onClose = jest.fn()
         render(
-          <Menu>
+          <Menu onClose={onClose}>
             <Menu.Button>Trigger</Menu.Button>
             <Menu.Items>
               <Menu.Item as="a">Item A</Menu.Item>
@@ -1476,14 +1507,18 @@ describe('Keyboard interactions', () => {
         // Verify it is closed
         assertMenuButton({ state: MenuState.InvisibleUnmounted })
         assertMenu({ state: MenuState.InvisibleUnmounted })
+
+        // Verify `onClose` prop has been called
+        expect(onClose).toHaveBeenCalled()
       })
     )
 
     it(
       'should focus trap when we use Shift+Tab',
       suppressConsoleLogs(async () => {
+        let onClose = jest.fn()
         render(
-          <Menu>
+          <Menu onClose={onClose}>
             <Menu.Button>Trigger</Menu.Button>
             <Menu.Items>
               <Menu.Item as="a">Item A</Menu.Item>
@@ -1525,6 +1560,9 @@ describe('Keyboard interactions', () => {
         // Verify it is closed
         assertMenuButton({ state: MenuState.InvisibleUnmounted })
         assertMenu({ state: MenuState.InvisibleUnmounted })
+
+        // Verify `onClose` prop has been called
+        expect(onClose).toHaveBeenCalled()
       })
     )
   })
@@ -2948,8 +2986,9 @@ describe('Mouse interactions', () => {
   it(
     'should be possible to close a menu on click',
     suppressConsoleLogs(async () => {
+      let onClose = jest.fn()
       render(
-        <Menu>
+        <Menu onClose={onClose}>
           <Menu.Button>Trigger</Menu.Button>
           <Menu.Items>
             <Menu.Item as="a">Item A</Menu.Item>
@@ -2971,6 +3010,9 @@ describe('Mouse interactions', () => {
       // Verify it is closed
       assertMenuButton({ state: MenuState.InvisibleUnmounted })
       assertMenu({ state: MenuState.InvisibleUnmounted })
+
+      // Verify `onClose` prop has been called
+      expect(onClose).toHaveBeenCalled()
     })
   )
 
@@ -3002,8 +3044,9 @@ describe('Mouse interactions', () => {
   it(
     'should be possible to click outside of the menu which should close the menu',
     suppressConsoleLogs(async () => {
+      let onClose = jest.fn()
       render(
-        <Menu>
+        <Menu onClose={onClose}>
           <Menu.Button>Trigger</Menu.Button>
           <Menu.Items>
             <Menu.Item as="a">alice</Menu.Item>
@@ -3023,6 +3066,9 @@ describe('Mouse interactions', () => {
       // Should be closed now
       assertMenu({ state: MenuState.InvisibleUnmounted })
 
+      // Verify `onClose` prop has been called
+      expect(onClose).toHaveBeenCalled()
+
       // Verify the button is focused again
       assertActiveElement(getMenuButton())
     })
@@ -3031,8 +3077,9 @@ describe('Mouse interactions', () => {
   it(
     'should be possible to click outside of the menu which should close the menu (even if we press the menu button)',
     suppressConsoleLogs(async () => {
+      let onClose = jest.fn()
       render(
-        <Menu>
+        <Menu onClose={onClose}>
           <Menu.Button>Trigger</Menu.Button>
           <Menu.Items>
             <Menu.Item as="a">alice</Menu.Item>
@@ -3051,6 +3098,9 @@ describe('Mouse interactions', () => {
 
       // Should be closed now
       assertMenu({ state: MenuState.InvisibleUnmounted })
+
+      // Verify `onClose` prop has been called
+      expect(onClose).toHaveBeenCalled()
 
       // Verify the button is focused again
       assertActiveElement(getMenuButton())
@@ -3105,9 +3155,10 @@ describe('Mouse interactions', () => {
     'should be possible to click outside of the menu, on an element which is within a focusable element, which closes the menu',
     suppressConsoleLogs(async () => {
       let focusFn = jest.fn()
+      let onClose = jest.fn()
       render(
         <div>
-          <Menu>
+          <Menu onClose={onClose}>
             <Menu.Button onFocus={focusFn}>Trigger</Menu.Button>
             <Menu.Items>
               <Menu.Item as="a">alice</Menu.Item>
@@ -3134,6 +3185,9 @@ describe('Mouse interactions', () => {
       // Ensure the menu is closed
       assertMenu({ state: MenuState.InvisibleUnmounted })
 
+      // Verify `onClose` prop has been called
+      expect(onClose).toHaveBeenCalled()
+
       // Ensure the outside button is focused
       assertActiveElement(document.getElementById('btn'))
 
@@ -3146,9 +3200,10 @@ describe('Mouse interactions', () => {
   it.skip(
     'should be possible to click outside of the menu into an iframe and which should close the menu',
     suppressConsoleLogs(async () => {
+      let onClose = jest.fn()
       render(
         <div>
-          <Menu>
+          <Menu onClose={onClose}>
             <Menu.Button>Trigger</Menu.Button>
             <Menu.Items>
               <Menu.Item as="a">alice</Menu.Item>
@@ -3174,6 +3229,9 @@ describe('Mouse interactions', () => {
 
       // Should be closed now
       assertMenu({ state: MenuState.InvisibleUnmounted })
+
+      // Verify `onClose` prop has been called
+      expect(onClose).toHaveBeenCalled()
 
       // Verify the button is focused again
       assertActiveElement(getMenuButton())
@@ -3397,8 +3455,9 @@ describe('Mouse interactions', () => {
     'should be possible to click a menu item, which closes the menu',
     suppressConsoleLogs(async () => {
       let clickHandler = jest.fn()
+      let onClose = jest.fn()
       render(
-        <Menu>
+        <Menu onClose={onClose}>
           <Menu.Button>Trigger</Menu.Button>
           <Menu.Items>
             <Menu.Item as="a">alice</Menu.Item>
@@ -3420,6 +3479,10 @@ describe('Mouse interactions', () => {
       await click(items[1])
 
       assertMenu({ state: MenuState.InvisibleUnmounted })
+
+      // Verify `onClose` prop has been called
+      expect(onClose).toHaveBeenCalled()
+
       expect(clickHandler).toHaveBeenCalled()
     })
   )
@@ -3428,8 +3491,9 @@ describe('Mouse interactions', () => {
     'should be possible to click a menu item, which closes the menu and invokes the @click handler',
     suppressConsoleLogs(async () => {
       let clickHandler = jest.fn()
+      let onClose = jest.fn()
       render(
-        <Menu>
+        <Menu onClose={onClose}>
           <Menu.Button>Trigger</Menu.Button>
           <Menu.Items>
             <Menu.Item as="a">alice</Menu.Item>
@@ -3460,6 +3524,9 @@ describe('Mouse interactions', () => {
       // Click the last item, which should close and invoke the handler
       await click(getMenuItems()[2])
       assertMenu({ state: MenuState.InvisibleUnmounted })
+
+      // Verify `onClose` prop has been called two times
+      expect(onClose).toHaveBeenCalledTimes(2)
 
       // Verify the callback has been called
       expect(clickHandler).toHaveBeenCalledTimes(2)

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -43,6 +43,7 @@ import { useOpenClosed, State, OpenClosedProvider } from '../../internal/open-cl
 import { useResolveButtonType } from '../../hooks/use-resolve-button-type'
 import { useOwnerDocument } from '../../hooks/use-owner'
 import { useEvent } from '../../hooks/use-event'
+import { useWatch } from '../../hooks/use-watch'
 
 enum MenuStates {
   Open,
@@ -231,7 +232,9 @@ interface MenuRenderPropArg {
 }
 
 let MenuRoot = forwardRefWithAs(function Menu<TTag extends ElementType = typeof DEFAULT_MENU_TAG>(
-  props: Props<TTag, MenuRenderPropArg>,
+  props: Props<TTag, MenuRenderPropArg> & {
+    onClose?: () => void
+  },
   ref: Ref<HTMLElement>
 ) {
   let reducerBag = useReducer(stateReducer, {
@@ -269,8 +272,21 @@ let MenuRoot = forwardRefWithAs(function Menu<TTag extends ElementType = typeof 
     [menuState, close]
   )
 
-  let theirProps = props
+  let { onClose, ...theirProps } = props
   let ourProps = { ref: menuRef }
+
+  useWatch(
+    ([currentMenuState], [oldMenuState]) => {
+      if (!onClose) {
+        return
+      }
+
+      if (currentMenuState === MenuStates.Closed && oldMenuState === MenuStates.Open) {
+        onClose()
+      }
+    },
+    [menuState]
+  )
 
   return (
     <MenuContext.Provider value={reducerBag}>

--- a/packages/@headlessui-vue/src/components/menu/menu.test.tsx
+++ b/packages/@headlessui-vue/src/components/menu/menu.test.tsx
@@ -195,9 +195,10 @@ describe('Rendering', () => {
     )
 
     it('should be possible to manually close the Menu using the exposed close function', async () => {
+      let closeHandler = jest.fn()
       renderTemplate({
         template: jsx`
-          <Menu v-slot="{ close }">
+          <Menu v-slot="{ close }" @close="closeHandler">
             <MenuButton>Trigger</MenuButton>
             <MenuItems>
               <MenuItem>
@@ -206,6 +207,7 @@ describe('Rendering', () => {
             </MenuItems>
           </Menu>
         `,
+        setup: () => ({ closeHandler }),
       })
 
       assertMenu({ state: MenuState.InvisibleUnmounted })
@@ -217,6 +219,9 @@ describe('Rendering', () => {
       await click(getByText('Close'))
 
       assertMenu({ state: MenuState.InvisibleUnmounted })
+
+      // Verify `close` event is fired
+      expect(closeHandler).toHaveBeenCalled()
     })
   })
 
@@ -1026,10 +1031,11 @@ describe('Composition', () => {
 
   it('should be possible to render a TransitionChild that inherits state from the Menu', async () => {
     let readFn = jest.fn()
+    let closeHandler = jest.fn()
     renderTemplate({
       components: { TransitionChild },
       template: jsx`
-        <Menu>
+        <Menu @close="closeHandler">
           <MenuButton>Trigger</MenuButton>
           <TransitionChild
             as="template"
@@ -1043,7 +1049,7 @@ describe('Composition', () => {
         </Menu>
       `,
       setup() {
-        return { readFn }
+        return { readFn, closeHandler }
       },
     })
 
@@ -1072,6 +1078,9 @@ describe('Composition', () => {
 
     // Verify the Menu is hidden
     assertMenu({ state: MenuState.InvisibleUnmounted })
+
+    // Verify `close` event is fired
+    expect(closeHandler).toHaveBeenCalled()
   })
 })
 
@@ -1258,16 +1267,21 @@ describe('Keyboard interactions', () => {
     })
 
     it('should be possible to close the menu with Enter when there is no active menuitem', async () => {
-      renderTemplate(jsx`
-        <Menu>
-          <MenuButton>Trigger</MenuButton>
-          <MenuItems>
-            <MenuItem as="a">Item A</MenuItem>
-            <MenuItem as="a">Item B</MenuItem>
-            <MenuItem as="a">Item C</MenuItem>
-          </MenuItems>
-        </Menu>
-      `)
+      let closeHandler = jest.fn()
+
+      renderTemplate({
+        template: jsx`
+          <Menu @close="closeHandler">
+            <MenuButton>Trigger</MenuButton>
+            <MenuItems>
+              <MenuItem as="a">Item A</MenuItem>
+              <MenuItem as="a">Item B</MenuItem>
+              <MenuItem as="a">Item C</MenuItem>
+            </MenuItems>
+          </Menu>
+        `,
+        setup: () => ({ closeHandler }),
+      })
 
       assertMenuButton({
         state: MenuState.InvisibleUnmounted,
@@ -1288,15 +1302,19 @@ describe('Keyboard interactions', () => {
       assertMenuButton({ state: MenuState.InvisibleUnmounted })
       assertMenu({ state: MenuState.InvisibleUnmounted })
 
+      // Verify `close` event is fired
+      expect(closeHandler).toHaveBeenCalled()
+
       // Verify the button is focused again
       assertActiveElement(getMenuButton())
     })
 
     it('should be possible to close the menu with Enter and invoke the active menu item', async () => {
       let clickHandler = jest.fn()
+      let closeHandler = jest.fn()
       renderTemplate({
         template: jsx`
-          <Menu>
+          <Menu @close="closeHandler">
             <MenuButton>Trigger</MenuButton>
             <MenuItems>
               <MenuItem as="a" @click="clickHandler">Item A</MenuItem>
@@ -1305,7 +1323,7 @@ describe('Keyboard interactions', () => {
             </MenuItems>
           </Menu>
         `,
-        setup: () => ({ clickHandler }),
+        setup: () => ({ clickHandler, closeHandler }),
       })
 
       assertMenuButton({
@@ -1331,6 +1349,9 @@ describe('Keyboard interactions', () => {
       assertMenuButton({ state: MenuState.InvisibleUnmounted })
       assertMenu({ state: MenuState.InvisibleUnmounted })
 
+      // Verify `close` event is fired
+      expect(closeHandler).toHaveBeenCalled()
+
       // Verify the button is focused again
       assertActiveElement(getMenuButton())
 
@@ -1341,10 +1362,11 @@ describe('Keyboard interactions', () => {
 
   it('should be possible to use a button as a menu item and invoke it upon Enter', async () => {
     let clickHandler = jest.fn()
+    let closeHandler = jest.fn()
 
     renderTemplate({
       template: jsx`
-        <Menu>
+        <Menu @close="closeHandler">
           <MenuButton>Trigger</MenuButton>
           <MenuItems>
             <MenuItem as="a">Item A</MenuItem>
@@ -1357,7 +1379,7 @@ describe('Keyboard interactions', () => {
           </MenuItems>
         </Menu>
       `,
-      setup: () => ({ clickHandler }),
+      setup: () => ({ clickHandler, closeHandler }),
     })
 
     assertMenuButton({
@@ -1382,6 +1404,9 @@ describe('Keyboard interactions', () => {
     // Verify it is closed
     assertMenuButton({ state: MenuState.InvisibleUnmounted })
     assertMenu({ state: MenuState.InvisibleUnmounted })
+
+    // Verify `close` event is fired
+    expect(closeHandler).toHaveBeenCalled()
 
     // Verify the button got "clicked"
     expect(clickHandler).toHaveBeenCalledTimes(1)
@@ -1587,16 +1612,20 @@ describe('Keyboard interactions', () => {
     it(
       'should be possible to close the menu with Space when there is no active menuitem',
       suppressConsoleLogs(async () => {
-        renderTemplate(jsx`
-          <Menu>
-            <MenuButton>Trigger</MenuButton>
-            <MenuItems>
-              <MenuItem as="a">Item A</MenuItem>
-              <MenuItem as="a">Item B</MenuItem>
-              <MenuItem as="a">Item C</MenuItem>
-            </MenuItems>
-          </Menu>
-        `)
+        let closeHandler = jest.fn()
+        renderTemplate({
+          template: jsx`
+            <Menu @close="closeHandler">
+              <MenuButton>Trigger</MenuButton>
+              <MenuItems>
+                <MenuItem as="a">Item A</MenuItem>
+                <MenuItem as="a">Item B</MenuItem>
+                <MenuItem as="a">Item C</MenuItem>
+              </MenuItems>
+            </Menu>
+          `,
+          setup: () => ({ closeHandler }),
+        })
 
         assertMenuButton({
           state: MenuState.InvisibleUnmounted,
@@ -1617,6 +1646,9 @@ describe('Keyboard interactions', () => {
         assertMenuButton({ state: MenuState.InvisibleUnmounted })
         assertMenu({ state: MenuState.InvisibleUnmounted })
 
+        // Verify `close` event is fired
+        expect(closeHandler).toHaveBeenCalled()
+
         // Verify the button is focused again
         assertActiveElement(getMenuButton())
       })
@@ -1626,9 +1658,10 @@ describe('Keyboard interactions', () => {
       'should be possible to close the menu with Space and invoke the active menu item',
       suppressConsoleLogs(async () => {
         let clickHandler = jest.fn()
+        let closeHandler = jest.fn()
         renderTemplate({
           template: jsx`
-            <Menu>
+            <Menu @close="closeHandler">
               <MenuButton>Trigger</MenuButton>
               <MenuItems>
                 <MenuItem as="a" @click="clickHandler">Item A</MenuItem>
@@ -1637,7 +1670,7 @@ describe('Keyboard interactions', () => {
               </MenuItems>
             </Menu>
           `,
-          setup: () => ({ clickHandler }),
+          setup: () => ({ clickHandler, closeHandler }),
         })
 
         assertMenuButton({
@@ -1663,6 +1696,9 @@ describe('Keyboard interactions', () => {
         assertMenuButton({ state: MenuState.InvisibleUnmounted })
         assertMenu({ state: MenuState.InvisibleUnmounted })
 
+        // Verify `close` event is fired
+        expect(closeHandler).toHaveBeenCalled()
+
         // Verify the "click" went through on the `a` tag
         expect(clickHandler).toHaveBeenCalled()
 
@@ -1674,16 +1710,20 @@ describe('Keyboard interactions', () => {
 
   describe('`Escape` key', () => {
     it('should be possible to close an open menu with Escape', async () => {
-      renderTemplate(jsx`
-        <Menu>
-          <MenuButton>Trigger</MenuButton>
-          <MenuItems>
-            <MenuItem as="a">Item A</MenuItem>
-            <MenuItem as="a">Item B</MenuItem>
-            <MenuItem as="a">Item C</MenuItem>
-          </MenuItems>
-        </Menu>
-      `)
+      let closeHandler = jest.fn()
+      renderTemplate({
+        template: jsx`
+          <Menu @close="closeHandler">
+            <MenuButton>Trigger</MenuButton>
+            <MenuItems>
+              <MenuItem as="a">Item A</MenuItem>
+              <MenuItem as="a">Item B</MenuItem>
+              <MenuItem as="a">Item C</MenuItem>
+            </MenuItems>
+          </Menu>
+        `,
+        setup: () => ({ closeHandler }),
+      })
 
       // Focus the button
       getMenuButton()?.focus()
@@ -1706,6 +1746,9 @@ describe('Keyboard interactions', () => {
       assertMenuButton({ state: MenuState.InvisibleUnmounted })
       assertMenu({ state: MenuState.InvisibleUnmounted })
 
+      // Verify `close` event is fired
+      expect(closeHandler).toHaveBeenCalled()
+
       // Verify the button is focused again
       assertActiveElement(getMenuButton())
     })
@@ -1713,16 +1756,20 @@ describe('Keyboard interactions', () => {
 
   describe('`Tab` key', () => {
     it('should not focus trap when we use Tab', async () => {
-      renderTemplate(jsx`
-        <Menu>
-          <MenuButton>Trigger</MenuButton>
-          <MenuItems>
-            <MenuItem as="a">Item A</MenuItem>
-            <MenuItem as="a">Item B</MenuItem>
-            <MenuItem as="a">Item C</MenuItem>
-          </MenuItems>
-        </Menu>
-      `)
+      let closeHandler = jest.fn()
+      renderTemplate({
+        template: jsx`
+          <Menu @close="closeHandler">
+            <MenuButton>Trigger</MenuButton>
+            <MenuItems>
+              <MenuItem as="a">Item A</MenuItem>
+              <MenuItem as="a">Item B</MenuItem>
+              <MenuItem as="a">Item C</MenuItem>
+            </MenuItems>
+          </Menu>
+        `,
+        setup: () => ({ closeHandler }),
+      })
 
       assertMenuButton({
         state: MenuState.InvisibleUnmounted,
@@ -1756,19 +1803,26 @@ describe('Keyboard interactions', () => {
       // Verify it is closed
       assertMenuButton({ state: MenuState.InvisibleUnmounted })
       assertMenu({ state: MenuState.InvisibleUnmounted })
+
+      // Verify `close` event is fired
+      expect(closeHandler).toHaveBeenCalled()
     })
 
     it('should not focus trap when we use Shift+Tab', async () => {
-      renderTemplate(jsx`
-        <Menu>
-          <MenuButton>Trigger</MenuButton>
-          <MenuItems>
-            <MenuItem as="a">Item A</MenuItem>
-            <MenuItem as="a">Item B</MenuItem>
-            <MenuItem as="a">Item C</MenuItem>
-          </MenuItems>
-        </Menu>
-      `)
+      let closeHandler = jest.fn()
+      renderTemplate({
+        template: jsx`
+          <Menu @close="closeHandler">
+            <MenuButton>Trigger</MenuButton>
+            <MenuItems>
+              <MenuItem as="a">Item A</MenuItem>
+              <MenuItem as="a">Item B</MenuItem>
+              <MenuItem as="a">Item C</MenuItem>
+            </MenuItems>
+          </Menu>
+        `,
+        setup: () => ({ closeHandler }),
+      })
 
       assertMenuButton({
         state: MenuState.InvisibleUnmounted,
@@ -1802,6 +1856,9 @@ describe('Keyboard interactions', () => {
       // Verify it is closed
       assertMenuButton({ state: MenuState.InvisibleUnmounted })
       assertMenu({ state: MenuState.InvisibleUnmounted })
+
+      // Verify `close` event is fired
+      expect(closeHandler).toHaveBeenCalled()
     })
   })
 
@@ -2997,16 +3054,20 @@ describe('Mouse interactions', () => {
   })
 
   it('should be possible to close a menu on click', async () => {
-    renderTemplate(jsx`
-      <Menu>
-        <MenuButton>Trigger</MenuButton>
-        <MenuItems>
-          <MenuItem as="a">Item A</MenuItem>
-          <MenuItem as="a">Item B</MenuItem>
-          <MenuItem as="a">Item C</MenuItem>
-        </MenuItems>
-      </Menu>
-    `)
+    let closeHandler = jest.fn()
+    renderTemplate({
+      template: jsx`
+        <Menu @close="closeHandler">
+          <MenuButton>Trigger</MenuButton>
+          <MenuItems>
+            <MenuItem as="a">Item A</MenuItem>
+            <MenuItem as="a">Item B</MenuItem>
+            <MenuItem as="a">Item C</MenuItem>
+          </MenuItems>
+        </Menu>
+      `,
+      setup: () => ({ closeHandler }),
+    })
 
     // Open menu
     await click(getMenuButton())
@@ -3020,6 +3081,9 @@ describe('Mouse interactions', () => {
     // Verify it is closed
     assertMenuButton({ state: MenuState.InvisibleUnmounted })
     assertMenu({ state: MenuState.InvisibleUnmounted })
+
+    // Verify `close` event is fired
+    expect(closeHandler).toHaveBeenCalled()
   })
 
   it('should be a no-op when we click outside of a closed menu', async () => {
@@ -3045,16 +3109,20 @@ describe('Mouse interactions', () => {
   })
 
   it('should be possible to click outside of the menu which should close the menu', async () => {
-    renderTemplate(jsx`
-      <Menu>
-        <MenuButton>Trigger</MenuButton>
-        <MenuItems>
-          <MenuItem as="a">alice</MenuItem>
-          <MenuItem as="a">bob</MenuItem>
-          <MenuItem as="a">charlie</MenuItem>
-        </MenuItems>
-      </Menu>
-    `)
+    let closeHandler = jest.fn()
+    renderTemplate({
+      template: jsx`
+        <Menu @close="closeHandler">
+          <MenuButton>Trigger</MenuButton>
+          <MenuItems>
+            <MenuItem as="a">alice</MenuItem>
+            <MenuItem as="a">bob</MenuItem>
+            <MenuItem as="a">charlie</MenuItem>
+          </MenuItems>
+        </Menu>
+      `,
+      setup: () => ({ closeHandler }),
+    })
 
     // Open menu
     await click(getMenuButton())
@@ -3066,21 +3134,28 @@ describe('Mouse interactions', () => {
     // Should be closed now
     assertMenu({ state: MenuState.InvisibleUnmounted })
 
+    // Verify `close` event is fired
+    expect(closeHandler).toHaveBeenCalled()
+
     // Verify the button is focused again
     assertActiveElement(getMenuButton())
   })
 
   it('should be possible to click outside of the menu which should close the menu (even if we press the menu button)', async () => {
-    renderTemplate(jsx`
-      <Menu>
-        <MenuButton>Trigger</MenuButton>
-        <MenuItems>
-          <MenuItem as="a">alice</MenuItem>
-          <MenuItem as="a">bob</MenuItem>
-          <MenuItem as="a">charlie</MenuItem>
-        </MenuItems>
-      </Menu>
-    `)
+    let closeHandler = jest.fn()
+    renderTemplate({
+      template: jsx`
+        <Menu @close="closeHandler">
+          <MenuButton>Trigger</MenuButton>
+          <MenuItems>
+            <MenuItem as="a">alice</MenuItem>
+            <MenuItem as="a">bob</MenuItem>
+            <MenuItem as="a">charlie</MenuItem>
+          </MenuItems>
+        </Menu>
+      `,
+      setup: () => ({ closeHandler }),
+    })
 
     // Open menu
     await click(getMenuButton())
@@ -3091,6 +3166,9 @@ describe('Mouse interactions', () => {
 
     // Should be closed now
     assertMenu({ state: MenuState.InvisibleUnmounted })
+
+    // Verify `close` event is fired
+    expect(closeHandler).toHaveBeenCalled()
 
     // Verify the button is focused again
     assertActiveElement(getMenuButton())
@@ -3144,19 +3222,23 @@ describe('Mouse interactions', () => {
   it.skip(
     'should be possible to click outside of the menu into an iframe and which should close the menu',
     suppressConsoleLogs(async () => {
-      renderTemplate(`
-        <div>
-          <Menu>
-            <MenuButton>Trigger</MenuButton>
-            <MenuItems>
-              <menuitem as="a">alice</menuitem>
-              <menuitem as="a">bob</menuitem>
-              <menuitem as="a">charlie</menuitem>
-            </MenuItems>
-          </Menu>
-          <iframe :srcdoc="'<button>Trigger</button>'" frameborder="0" width="300" height="300"></iframe>
-        </div>
-      `)
+      let closeHandler = jest.fn()
+      renderTemplate({
+        template: `
+          <div>
+            <Menu @close="closeHandler">
+              <MenuButton>Trigger</MenuButton>
+              <MenuItems>
+                <menuitem as="a">alice</menuitem>
+                <menuitem as="a">bob</menuitem>
+                <menuitem as="a">charlie</menuitem>
+              </MenuItems>
+            </Menu>
+            <iframe :srcdoc="'<button>Trigger</button>'" frameborder="0" width="300" height="300"></iframe>
+          </div>
+        `,
+        setup: () => ({ closeHandler }),
+      })
 
       // Open menu
       await click(getMenuButton())
@@ -3167,6 +3249,9 @@ describe('Mouse interactions', () => {
 
       // Should be closed now
       assertMenu({ state: MenuState.InvisibleUnmounted })
+
+      // Verify `close` event is fired
+      expect(closeHandler).toHaveBeenCalled()
 
       // Verify the button is focused again
       assertActiveElement(getMenuButton())
@@ -3390,9 +3475,10 @@ describe('Mouse interactions', () => {
 
   it('should be possible to click a menu item, which closes the menu and invokes the @click handler', async () => {
     let clickHandler = jest.fn()
+    let closeHandler = jest.fn()
     renderTemplate({
       template: jsx`
-        <Menu>
+        <Menu @close="closeHandler">
           <MenuButton>Trigger</MenuButton>
           <MenuItems>
             <MenuItem as="a">alice</MenuItem>
@@ -3403,7 +3489,7 @@ describe('Mouse interactions', () => {
           </MenuItems>
         </Menu>
       `,
-      setup: () => ({ clickHandler }),
+      setup: () => ({ clickHandler, closeHandler }),
     })
 
     // Open menu
@@ -3423,6 +3509,9 @@ describe('Mouse interactions', () => {
     // Click the last item, which should close and invoke the handler
     await click(getMenuItems()[2])
     assertMenu({ state: MenuState.InvisibleUnmounted })
+
+    // Verify `close` event is fired two times
+    expect(closeHandler).toHaveBeenCalledTimes(2)
 
     // Verify the callback has been called
     expect(clickHandler).toHaveBeenCalledTimes(2)

--- a/packages/@headlessui-vue/src/components/menu/menu.ts
+++ b/packages/@headlessui-vue/src/components/menu/menu.ts
@@ -88,7 +88,8 @@ function useMenuContext(component: string) {
 export let Menu = defineComponent({
   name: 'Menu',
   props: { as: { type: [Object, String], default: 'template' } },
-  setup(props, { slots, attrs }) {
+  emits: { close: () => true },
+  setup(props, { slots, attrs, emit }) {
     let menuState = ref<StateDefinition['menuState']['value']>(MenuStates.Closed)
     let buttonRef = ref<StateDefinition['buttonRef']['value']>(null)
     let itemsRef = ref<StateDefinition['itemsRef']['value']>(null)
@@ -139,6 +140,7 @@ export let Menu = defineComponent({
       closeMenu: () => {
         menuState.value = MenuStates.Closed
         activeItemIndex.value = null
+        emit('close')
       },
       openMenu: () => (menuState.value = MenuStates.Open),
       goToItem(focus: Focus, id?: string, trigger?: ActivationTrigger) {


### PR DESCRIPTION
Fixes https://github.com/tailwindlabs/headlessui/issues/1948

So I apologize, I started hacking away at this to see how hard it was going to be and then by the time I read https://github.com/tailwindlabs/headlessui/blob/main/.github/CONTRIBUTING.md#pull-requests I had a working change 🤦‍♂️. I enjoyed working on this codebase and learned a lot so not a loss and no hard feelings if this PR gets denied 🙂 

Let me know what you think of this change when you have time!