### PR TITLE
Add open, onOpen, onClose props to Menu component

### DIFF
--- a/packages/@headlessui-react/src/components/menu/menu.test.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.test.tsx
@@ -1,4 +1,4 @@
-import React, { createElement, useEffect } from 'react'
+import React, { createElement, useEffect, useState } from 'react'
 import { render } from '@testing-library/react'
 
 import { Menu } from './menu'
@@ -141,6 +141,75 @@ describe('Rendering', () => {
             )}
           </Menu>
         )
+
+        assertMenu({ state: MenuState.InvisibleUnmounted })
+
+        await click(getMenuButton())
+
+        assertMenu({ state: MenuState.Visible })
+
+        await click(getByText('Close'))
+
+        assertMenu({ state: MenuState.InvisibleUnmounted })
+      })
+    )
+
+    it(
+      'should be possible to control the Menu using open prop and callbacks',
+      suppressConsoleLogs(async () => {
+        const Controller = () => {
+          const [open, setOpen] = useState(false)
+          const [disabled, setDisabled] = useState(false)
+          return (
+            <>
+              <button
+                onClick={(e) => {
+                  e.preventDefault()
+                  setOpen(!open)
+                }}
+              >
+                {open ? 'Close' : 'Open'}
+              </button>
+              <button
+                onClick={(e) => {
+                  e.preventDefault()
+                  setDisabled(!disabled)
+                }}
+              >
+                {disabled ? 'Enable trigger' : 'Disable trigger'}
+              </button>
+              <Menu
+                open={open}
+                onClose={() => !disabled && setOpen(false)}
+                onOpen={() => !disabled && setOpen(true)}
+              >
+                <>
+                  <Menu.Button>Trigger</Menu.Button>
+                  <Menu.Items>
+                    <Menu.Item as="a">Item A</Menu.Item>
+                    <Menu.Item as="a">Item B</Menu.Item>
+                    <Menu.Item as="a">Item C</Menu.Item>
+                  </Menu.Items>
+                </>
+              </Menu>
+            </>
+          )
+        }
+        render(<Controller />)
+
+        assertMenu({ state: MenuState.InvisibleUnmounted })
+
+        await click(getByText('Open'))
+
+        assertMenu({ state: MenuState.Visible })
+
+        await click(getByText('Disable trigger'))
+        await click(getMenuButton())
+
+        assertMenu({ state: MenuState.Visible })
+
+        await click(getByText('Enable trigger'))
+        await click(getMenuButton())
 
         assertMenu({ state: MenuState.InvisibleUnmounted })
 


### PR DESCRIPTION
Being able to control Menu visibility from the outside, using a prop and callbacks, opens up a lot of possibilities.

For example, one can use the Menu without a Button trigger as a context menu, while keeping all the great accessibility features `@headlessui/menu` provides.

It fixes https://github.com/tailwindlabs/headlessui/discussions/649, https://github.com/tailwindlabs/headlessui/discussions/1937 and similar PR for Popover will fix https://github.com/tailwindlabs/headlessui/discussions/828

I know you normally don't accept PRs from the outside, but since I'll be keeping the fork up to date for our internal usage, I thought it's worth considering.

Vue implementation is missing as I'm not fluent in Vue, but I think the implementation should be just as straightforward as for React.