### PR TITLE
Feat/dialog props

### DIFF
--- a/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
@@ -947,6 +947,37 @@ describe('Mouse interactions', () => {
   )
 
   it(
+    'should not be possible to close the dialog, when we click outside on the body element and closeOnOutsideClick is false',
+    suppressConsoleLogs(async () => {
+      function Example() {
+        let [isOpen, setIsOpen] = useState(false)
+        return (
+          <>
+            <button onClick={() => setIsOpen((v) => !v)}>Trigger</button>
+            <Dialog open={isOpen} onClose={setIsOpen} closeOnOutsideClick={false}>
+              Contents
+              <TabSentinel />
+            </Dialog>
+          </>
+        )
+      }
+      render(<Example />)
+
+      // Open dialog
+      await click(getByText('Trigger'))
+
+      // Verify it is open
+      assertDialog({ state: DialogState.Visible })
+
+      // Click the body to close
+      await click(document.body)
+
+      // Verify it is still open
+      assertDialog({ state: DialogState.Visible })
+    })
+  )
+
+  it(
     'should be possible to close the dialog, and keep focus on the focusable element',
     suppressConsoleLogs(async () => {
       function Example() {

--- a/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
@@ -630,7 +630,7 @@ describe('Composition', () => {
 describe('Keyboard interactions', () => {
   describe('`Escape` key', () => {
     it(
-      'should be possible to close the dialog with Escape',
+      'should be possible to close the dialog with Escape by default',
       suppressConsoleLogs(async () => {
         function Example() {
           let [isOpen, setIsOpen] = useState(false)
@@ -664,6 +664,43 @@ describe('Keyboard interactions', () => {
 
         // Verify it is close
         assertDialog({ state: DialogState.InvisibleUnmounted })
+      })
+    )
+    it(
+      'should not be possible to close the dialog with Escape, when a closeOnEsc is false',
+      suppressConsoleLogs(async () => {
+        function Example() {
+          let [isOpen, setIsOpen] = useState(false)
+          return (
+            <>
+              <button id="trigger" onClick={() => setIsOpen((v) => !v)}>
+                Trigger
+              </button>
+              <Dialog open={isOpen} onClose={setIsOpen} closeOnEsc={false}>
+                Contents
+                <TabSentinel />
+              </Dialog>
+            </>
+          )
+        }
+        render(<Example />)
+
+        assertDialog({ state: DialogState.InvisibleUnmounted })
+
+        // Open dialog
+        await click(document.getElementById('trigger'))
+
+        // Verify it is open
+        assertDialog({
+          state: DialogState.Visible,
+          attributes: { id: 'headlessui-dialog-1' },
+        })
+
+        // Close dialog
+        await press(Keys.Escape)
+
+        // Verify it is still open
+        assertDialog({ state: DialogState.Visible })
       })
     )
 

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -153,10 +153,11 @@ let DialogRoot = forwardRefWithAs(function Dialog<
       onClose(value: boolean): void
       initialFocus?: MutableRefObject<HTMLElement | null>
       __demoMode?: boolean
+      closeOnEsc?: boolean
     },
   ref: Ref<HTMLDivElement>
 ) {
-  let { open, onClose, initialFocus, __demoMode = false, ...theirProps } = props
+  let { open, onClose, initialFocus, __demoMode = false, closeOnEsc = true, ...theirProps } = props
   let [nestedDialogCount, setNestedDialogCount] = useState(0)
 
   let usesOpenClosedState = useOpenClosed()
@@ -258,6 +259,7 @@ let DialogRoot = forwardRefWithAs(function Dialog<
 
   // Handle `Escape` to close
   useEventListener(ownerDocument?.defaultView, 'keydown', (event) => {
+    if (!closeOnEsc) return
     if (event.defaultPrevented) return
     if (event.key !== Keys.Escape) return
     if (dialogState !== DialogStates.Open) return

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -154,10 +154,19 @@ let DialogRoot = forwardRefWithAs(function Dialog<
       initialFocus?: MutableRefObject<HTMLElement | null>
       __demoMode?: boolean
       closeOnEsc?: boolean
+      closeOnOutsideClick?: boolean
     },
   ref: Ref<HTMLDivElement>
 ) {
-  let { open, onClose, initialFocus, __demoMode = false, closeOnEsc = true, ...theirProps } = props
+  let {
+    open,
+    onClose,
+    initialFocus,
+    __demoMode = false,
+    closeOnEsc = true,
+    closeOnOutsideClick = true,
+    ...theirProps
+  } = props
   let [nestedDialogCount, setNestedDialogCount] = useState(0)
 
   let usesOpenClosedState = useOpenClosed()
@@ -254,7 +263,7 @@ let DialogRoot = forwardRefWithAs(function Dialog<
       ] as HTMLElement[]
     },
     close,
-    enabled && !hasNestedDialogs
+    enabled && !hasNestedDialogs && closeOnOutsideClick
   )
 
   // Handle `Escape` to close

--- a/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
@@ -797,7 +797,7 @@ describe('Composition', () => {
 describe('Keyboard interactions', () => {
   describe('`Escape` key', () => {
     it(
-      'should be possible to close the dialog with Escape',
+      'should be possible to close the dialog with Escape by Default',
       suppressConsoleLogs(async () => {
         renderTemplate({
           template: `
@@ -841,6 +841,54 @@ describe('Keyboard interactions', () => {
 
         // Verify it is close
         assertDialog({ state: DialogState.InvisibleUnmounted })
+      })
+    )
+
+    it(
+      'should not be possible to close the dialog with Escape, when a closeOnEsc is false',
+      suppressConsoleLogs(async () => {
+        renderTemplate({
+          template: `
+            <div>
+              <button id="trigger" @click="toggleOpen">
+                Trigger
+              </button>
+              <Dialog :open="isOpen" @close="setIsOpen" :close-on-esc="closeOnEsc">
+                Contents
+              </Dialog>
+            </div>
+          `,
+          setup() {
+            let isOpen = ref(false)
+            return {
+              isOpen,
+              closeOnEsc: false,
+              setIsOpen(value: boolean) {
+                isOpen.value = value
+              },
+              toggleOpen() {
+                isOpen.value = !isOpen.value
+              },
+            }
+          },
+        })
+
+        assertDialog({ state: DialogState.InvisibleUnmounted })
+
+        // Open dialog
+        await click(document.getElementById('trigger'))
+
+        // Verify it is open
+        assertDialog({
+          state: DialogState.Visible,
+          attributes: { id: 'headlessui-dialog-1' },
+        })
+
+        // Try to close the dialog
+        await press(Keys.Escape)
+
+        // Verify it is still open
+        assertDialog({ state: DialogState.Visible })
       })
     )
 

--- a/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
@@ -1264,6 +1264,45 @@ describe('Mouse interactions', () => {
   )
 
   it(
+    'should not be possible to close the dialog, when we click outside on the body element and closeOnOutsideClick is false',
+    suppressConsoleLogs(async () => {
+      renderTemplate({
+        template: `
+          <div>
+            <button @click="isOpen = !isOpen">Trigger</button>
+            <Dialog :open="isOpen" @close="setIsOpen" :close-on-outside-click="closeOnOutsideClick">
+              Contents
+              <TabSentinel />
+            </Dialog>
+          </div>
+        `,
+        setup() {
+          let isOpen = ref(false)
+          return {
+            isOpen,
+            setIsOpen(value: boolean) {
+              isOpen.value = value
+            },
+            closeOnOutsideClick: false,
+          }
+        },
+      })
+
+      // Open dialog
+      await click(getByText('Trigger'))
+
+      // Verify it is open
+      assertDialog({ state: DialogState.Visible })
+
+      // Click the body to close
+      await click(document.body)
+
+      // Verify it is still open
+      assertDialog({ state: DialogState.Visible })
+    })
+  )
+
+  it(
     'should be possible to close the dialog, and keep focus on the focusable element',
     suppressConsoleLogs(async () => {
       renderTemplate({

--- a/packages/@headlessui-vue/src/components/dialog/dialog.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.ts
@@ -78,6 +78,7 @@ export let Dialog = defineComponent({
     open: { type: [Boolean, String], default: Missing },
     initialFocus: { type: Object as PropType<HTMLElement | null>, default: null },
     closeOnEsc: { type: Boolean, default: true },
+    closeOnOutsideClick: { type: Boolean, default: true },
   },
   emits: { close: (_close: boolean) => true },
   setup(props, { emit, attrs, slots, expose }) {
@@ -205,7 +206,12 @@ export let Dialog = defineComponent({
         api.close()
         nextTick(() => target?.focus())
       },
-      computed(() => dialogState.value === DialogStates.Open && !hasNestedDialogs.value)
+      computed(
+        () =>
+          dialogState.value === DialogStates.Open &&
+          !hasNestedDialogs.value &&
+          props.closeOnOutsideClick
+      )
     )
 
     // Handle `Escape` to close

--- a/packages/@headlessui-vue/src/components/dialog/dialog.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.ts
@@ -77,6 +77,7 @@ export let Dialog = defineComponent({
     unmount: { type: Boolean, default: true },
     open: { type: [Boolean, String], default: Missing },
     initialFocus: { type: Object as PropType<HTMLElement | null>, default: null },
+    closeOnEsc: { type: Boolean, default: true },
   },
   emits: { close: (_close: boolean) => true },
   setup(props, { emit, attrs, slots, expose }) {
@@ -209,6 +210,7 @@ export let Dialog = defineComponent({
 
     // Handle `Escape` to close
     useEventListener(ownerDocument.value?.defaultView, 'keydown', (event) => {
+      if (!props.closeOnEsc) return
       if (event.defaultPrevented) return
       if (event.key !== Keys.Escape) return
       if (dialogState.value !== DialogStates.Open) return


### PR DESCRIPTION
In this pull request I introduce 2 Dialog props:
1. closeOnEsc - by default is `true`. Does not change the current behavior.
When it is `false` it disables closing the Dialog by pressing the Escape button.
Useful when we want users to close a Dialog only by clicking a cancel button. E.g. when we render a form and don't want to lose the data in the form by accidentally pressing Esc.

2. closeOnOutsideClick - by default is `true`. Does not change the current behavior.
When it is `false` it disables closing the Dialog on the outside click. As useful as `clickOnEsc`. Also, it addressed the issues

https://github.com/tailwindlabs/headlessui/discussions/1700
https://github.com/tailwindlabs/headlessui/issues/1751


