### PR TITLE
Add `client-only` to mark everything as client components

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose `close` function for `Menu` and `Menu.Item` components ([#1897](https://github.com/tailwindlabs/headlessui/pull/1897))
 - Fix `useOutsideClick`, add improvements for ShadowDOM ([#1914](https://github.com/tailwindlabs/headlessui/pull/1914))
 - Fire `<Combobox.Input>`'s `onChange` handler when changing the value internally ([#1916](https://github.com/tailwindlabs/headlessui/pull/1916))
+- Add `client-only` to mark everything as client components ([#1981](https://github.com/tailwindlabs/headlessui/pull/1981))
 
 ### Added
 

--- a/packages/@headlessui-react/package.json
+++ b/packages/@headlessui-react/package.json
@@ -49,5 +49,8 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "snapshot-diff": "^0.8.1"
+  },
+  "dependencies": {
+    "client-only": "^0.0.1"
   }
 }

--- a/packages/@headlessui-react/src/index.ts
+++ b/packages/@headlessui-react/src/index.ts
@@ -1,3 +1,5 @@
+import 'client-only'
+
 export * from './components/combobox/combobox'
 export * from './components/dialog/dialog'
 export * from './components/disclosure/disclosure'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1595,6 +1595,11 @@ cli-truncate@^3.1.0:
     slice-ansi "^5.0.0"
     string-width "^5.0.0"
 
+client-only@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
+  integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
+
 cliui@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"


### PR DESCRIPTION
This should improve the error messages when using Headless UI in a Next.js 13+ repo instead of getting a cryptic error message that `createContext` doesn't exist.
