### PR TITLE
Drop unnecessary `readOnly` prop on hidden input fields

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Reset form-like components when the parent `<form>` resets ([#2004](https://github.com/tailwindlabs/headlessui/pull/2004))
+- Drop unnecessary `readOnly` prop on hidden input fields ([#2005](https://github.com/tailwindlabs/headlessui/pull/2005))
 
 ## [1.7.4] - 2022-11-03
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -629,7 +629,6 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
                   as: 'input',
                   type: 'hidden',
                   hidden: true,
-                  readOnly: true,
                   name,
                   value,
                 })}

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -552,7 +552,6 @@ let ListboxRoot = forwardRefWithAs(function Listbox<
                   as: 'input',
                   type: 'hidden',
                   hidden: true,
-                  readOnly: true,
                   name,
                   value,
                 })}

--- a/packages/@headlessui-react/src/components/radio-group/radio-group.tsx
+++ b/packages/@headlessui-react/src/components/radio-group/radio-group.tsx
@@ -337,7 +337,6 @@ let RadioGroupRoot = forwardRefWithAs(function RadioGroup<
                     type: 'radio',
                     checked: value != null,
                     hidden: true,
-                    readOnly: true,
                     name,
                     value,
                   })}

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Reset form-like components when the parent `<form>` resets ([#2004](https://github.com/tailwindlabs/headlessui/pull/2004))
+- Drop unnecessary `readOnly` prop on hidden input fields ([#2005](https://github.com/tailwindlabs/headlessui/pull/2005))
 
 ## [1.7.4] - 2022-11-03
 

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -451,7 +451,6 @@ export let Combobox = defineComponent({
                   as: 'input',
                   type: 'hidden',
                   hidden: true,
-                  readOnly: true,
                   name,
                   value,
                 })

--- a/packages/@headlessui-vue/src/components/listbox/listbox.ts
+++ b/packages/@headlessui-vue/src/components/listbox/listbox.ts
@@ -365,7 +365,6 @@ export let Listbox = defineComponent({
                   as: 'input',
                   type: 'hidden',
                   hidden: true,
-                  readOnly: true,
                   name,
                   value,
                 })

--- a/packages/@headlessui-vue/src/components/radio-group/radio-group.ts
+++ b/packages/@headlessui-vue/src/components/radio-group/radio-group.ts
@@ -262,7 +262,6 @@ export let RadioGroup = defineComponent({
                   as: 'input',
                   type: 'hidden',
                   hidden: true,
-                  readOnly: true,
                   name,
                   value,
                 })


### PR DESCRIPTION
This PR fixes an issue where some tools complain about the "invalid" input elements (even though in real-world testing these are all just working fine). But after more testing it turns out that the `readonly` property is not required (and also doesn't do what I originally expected since it only prevents human input. `myHiddenReadOnlyInput.value = 'new value'` just works).

Therefore I think it is fine to just get rid of it, and make loud tools happy as well.

Note: this _is_ necessary for the hidden `input[type="checkbox"]` otherwise you will retrieve warnings from react:

> Warning: You provided a `checked` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultChecked`. Otherwise, set either `onChange` or `readOnly`.

- We won't be able to use `defaultChecked` because then it will only set initially
- We don't want to use `onChange` because we already know the value and don't want to change it from within the checkbox (aka, it is not the source of truth)

Fixes: #1990

