### PR TITLE
Ensure Popover doesn't crash when `focus` is going to `window`

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reset form-like components when the parent `<form>` resets ([#2004](https://github.com/tailwindlabs/headlessui/pull/2004))
 - Add warning when using `<Popover.Button />` multiple times ([#2007](https://github.com/tailwindlabs/headlessui/pull/2007))
+- Ensure Popover doesn't crash when `focus` is going to `window` ([#2019](https://github.com/tailwindlabs/headlessui/pull/2019))
 
 ## [1.7.4] - 2022-11-03
 

--- a/packages/@headlessui-react/src/components/popover/popover.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.tsx
@@ -281,6 +281,7 @@ let PopoverRoot = forwardRefWithAs(function Popover<
       if (isFocusWithinPopoverGroup()) return
       if (!button) return
       if (!panel) return
+      if (event.target === window) return
       if (beforePanelSentinel.current?.contains?.(event.target as HTMLElement)) return
       if (afterPanelSentinel.current?.contains?.(event.target as HTMLElement)) return
 

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Reset form-like components when the parent `<form>` resets ([#2004](https://github.com/tailwindlabs/headlessui/pull/2004))
+- Ensure Popover doesn't crash when `focus` is going to `window` ([#2019](https://github.com/tailwindlabs/headlessui/pull/2019))
 
 ## [1.7.4] - 2022-11-03
 

--- a/packages/@headlessui-vue/src/components/popover/popover.ts
+++ b/packages/@headlessui-vue/src/components/popover/popover.ts
@@ -223,6 +223,7 @@ export let Popover = defineComponent({
         if (isFocusWithinPopoverGroup()) return
         if (!button) return
         if (!panel) return
+        if (event.target === window) return
         if (dom(api.beforePanelSentinel)?.contains(event.target as HTMLElement)) return
         if (dom(api.afterPanelSentinel)?.contains(event.target as HTMLElement)) return
 


### PR DESCRIPTION
This PR fixes an issue where the `Popover` component would crash if the `window` received focus. This happened becaues we are checking based on the `event.target` if it is still within the `Popover.Panel` or not using the `node.contains(event.target)` method. However, that doesn't support `window` as a value.

Fixes: #2018

