### PR TITLE
Allow custom `id` attribute to `<Listbox.Button />`

### DIFF
--- a/packages/@headlessui-react/src/components/listbox/listbox.test.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.test.tsx
@@ -658,6 +658,16 @@ describe('Rendering', () => {
 
         expect(getListboxButton()).not.toHaveAttribute('type')
       })
+
+      it('should support a custom `id` attribute', async () => {
+        render(
+          <Listbox value={null} onChange={console.log}>
+            <Listbox.Button id="my-custom-id">Trigger</Listbox.Button>
+          </Listbox>
+        )
+
+        expect(getListboxButton()).toHaveAttribute('id', 'my-custom-id')
+      })
     })
   })
 

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -592,7 +592,7 @@ let Button = forwardRefWithAs(function Button<TTag extends ElementType = typeof 
   let actions = useActions('Listbox.Button')
   let buttonRef = useSyncRefs(data.buttonRef, ref)
 
-  let id = `headlessui-listbox-button-${useId()}`
+  let id = props.id ?? `headlessui-listbox-button-${useId()}`
   let d = useDisposables()
 
   let handleKeyDown = useEvent((event: ReactKeyboardEvent<HTMLButtonElement>) => {


### PR DESCRIPTION
Needed to use an external label for my `<Select />`-like component (In my case the label is part of a generic `<FormItem />` that manages validation for form items). And unfortunately you currently can't override the `<Listbox.Button />` id attribute. This PR fixes that.