### PR TITLE
Combobox open on focus

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -427,7 +427,7 @@ describe('Rendering', () => {
     )
 
     it(
-      'focusing the input opens the list when openOnChange',
+      'focusing the input opens the list when openOnFocus',
       suppressConsoleLogs(async () => {
         function Example() {
           let [value, setValue] = useState(undefined)

--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -427,6 +427,40 @@ describe('Rendering', () => {
     )
 
     it(
+      'focusing the input opens the list when openOnChange',
+      suppressConsoleLogs(async () => {
+        function Example() {
+          let [value, setValue] = useState(undefined)
+
+          return (
+            <Combobox value={value} onChange={setValue}>
+              <Combobox.Input
+                onChange={NOOP}
+                displayValue={(str?: string) => str?.toUpperCase() ?? ''}
+                openOnChange
+              />
+              <Combobox.Button>Trigger</Combobox.Button>
+              <Combobox.Options>
+                <Combobox.Option value="a">Option A</Combobox.Option>
+                <Combobox.Option value="b">Option B</Combobox.Option>
+                <Combobox.Option value="c">Option C</Combobox.Option>
+              </Combobox.Options>
+            </Combobox>
+          )
+        }
+
+        render(<Example />)
+
+        assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
+
+        // Focus the input
+        await focus(getComboboxInput())
+
+        assertComboboxList({ state: ComboboxState.Visible })
+      })
+    )
+
+    it(
       'selecting an option puts the display value into Combobox.Input when displayValue is provided',
       suppressConsoleLogs(async () => {
         function Example() {

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -664,7 +664,9 @@ type InputPropsWeControl =
   | 'aria-activedescendant'
   | 'onKeyDown'
   | 'onChange'
+  | 'onFocus'
   | 'displayValue'
+  | ''
 
 let Input = forwardRefWithAs(function Input<
   TTag extends ElementType = typeof DEFAULT_INPUT_TAG,
@@ -673,12 +675,13 @@ let Input = forwardRefWithAs(function Input<
   TType = Parameters<typeof ComboboxRoot>[0]['value']
 >(
   props: Props<TTag, InputRenderPropArg, InputPropsWeControl> & {
+    openOnChange?: boolean
     displayValue?(item: TType): string
     onChange(event: React.ChangeEvent<HTMLInputElement>): void
   },
   ref: Ref<HTMLInputElement>
 ) {
-  let { value, onChange, displayValue, type = 'text', ...theirProps } = props
+  let { value, onChange, displayValue, openOnChange = false, type = 'text', ...theirProps } = props
   let data = useData('Combobox.Input')
   let actions = useActions('Combobox.Input')
 
@@ -867,6 +870,12 @@ let Input = forwardRefWithAs(function Input<
     onChange?.(event)
   })
 
+  let handleFocus = useEvent(() => {
+    if (openOnChange) {
+      actions.openCombobox()
+    }
+  })
+
   // TODO: Verify this. The spec says that, for the input/combobox, the label is the labelling element when present
   // Otherwise it's the ID of the non-label element
   let labelledby = useComputed(() => {
@@ -899,6 +908,7 @@ let Input = forwardRefWithAs(function Input<
     onCompositionEnd: handleCompositionEnd,
     onKeyDown: handleKeyDown,
     onChange: handleChange,
+    onFocus: handleFocus,
   }
 
   return render({

--- a/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
@@ -493,6 +493,32 @@ describe('Rendering', () => {
       })
     )
 
+    it(
+      'should open list when focused',
+      suppressConsoleLogs(async () => {
+        renderTemplate({
+          template: html`
+            <Combobox v-model="value">
+              <ComboboxInput :displayValue="(str) => str?.toUpperCase() ?? ''" openOnFocus />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `,
+          setup: () => ({ value: ref(null) }),
+        })
+
+        assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
+
+        await focus(getComboboxInput())
+
+        assertComboboxList({ state: ComboboxState.Visible })
+      })
+    )
+
     // This really is a bug in Vue but we have a workaround for it
     it(
       'selecting an option puts the display value into Combobox.Input when displayValue is provided (when v-model is undefined)',

--- a/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
@@ -494,7 +494,7 @@ describe('Rendering', () => {
     )
 
     it(
-      'should open list when focused',
+      'focusing the input opens the list when openOnFocus',
       suppressConsoleLogs(async () => {
         renderTemplate({
           template: html`

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -35,6 +35,7 @@ import { useOutsideClick } from '../../hooks/use-outside-click'
 import { Hidden, Features as HiddenFeatures } from '../../internal/hidden'
 import { objectToFormEntries } from '../../utils/form'
 import { useControllable } from '../../hooks/use-controllable'
+import { findAllByTestId } from '@testing-library/dom'
 
 function defaultComparator<T>(a: T, z: T): boolean {
   return a === z
@@ -629,6 +630,7 @@ export let ComboboxInput = defineComponent({
     unmount: { type: Boolean, default: true },
     displayValue: { type: Function as PropType<(item: unknown) => string> },
     defaultValue: { type: String, default: undefined },
+    openOnFocus: { type: Boolean, default: false },
   },
   emits: {
     change: (_value: Event & { target: HTMLInputElement }) => true,
@@ -830,6 +832,12 @@ export let ComboboxInput = defineComponent({
       emit('change', event)
     }
 
+    function handleFocus() {
+      if (props.openOnFocus) {
+        api.openCombobox()
+      }
+    }
+
     let defaultValue = computed(() => {
       return (
         props.defaultValue ??
@@ -858,6 +866,7 @@ export let ComboboxInput = defineComponent({
         onKeydown: handleKeyDown,
         onChange: handleChange,
         onInput: handleInput,
+        onFocus: handleFocus,
         role: 'combobox',
         type: attrs.type ?? 'text',
         tabIndex: 0,

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -35,7 +35,6 @@ import { useOutsideClick } from '../../hooks/use-outside-click'
 import { Hidden, Features as HiddenFeatures } from '../../internal/hidden'
 import { objectToFormEntries } from '../../utils/form'
 import { useControllable } from '../../hooks/use-controllable'
-import { findAllByTestId } from '@testing-library/dom'
 
 function defaultComparator<T>(a: T, z: T): boolean {
   return a === z


### PR DESCRIPTION
This is a solution to the problems described in [#1236 ](https://github.com/tailwindlabs/headlessui/discussions/1236).

It adds a prop on the ComboboxInput component. When set, the ComboboxList is opened on focus of the ComboboxInput.

I think there probably should be a discussion about exposing the openCombobox and closeCombobox functions in the future, to allow even more control. While exposing these internal functions has a certain "smell" to it, the current workarounds that need to be used might justify such a step. However, most people seem to want mostly the behaviour this change provides, so it should do for now.