### PR TITLE
Expose openCombobox and closeCombobox from Combobox

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -427,6 +427,44 @@ describe('Rendering', () => {
     )
 
     it(
+      'should be possible to open the combobox with scoped slot',
+      suppressConsoleLogs(async () => {
+        function Example() {
+          let [value, setValue] = useState(undefined)
+
+          return (
+            <Combobox value={value} onChange={setValue}>
+              {({ openCombobox }) => (
+                <>
+                  <Combobox.Input
+                    onChange={NOOP}
+                    onFocus={openCombobox}
+                    displayValue={(str?: string) => str?.toUpperCase() ?? ''}
+                  />
+                  <Combobox.Button>Trigger</Combobox.Button>
+                  <Combobox.Options>
+                    <Combobox.Option value="a">Option A</Combobox.Option>
+                    <Combobox.Option value="b">Option B</Combobox.Option>
+                    <Combobox.Option value="c">Option C</Combobox.Option>
+                  </Combobox.Options>
+                </>
+              )}
+            </Combobox>
+          )
+        }
+
+        render(<Example />)
+
+        assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
+
+        // Focus the input
+        await focus(getComboboxInput())
+
+        assertComboboxList({ state: ComboboxState.Visible })
+      })
+    )
+
+    it(
       'selecting an option puts the display value into Combobox.Input when displayValue is provided',
       suppressConsoleLogs(async () => {
         function Example() {

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -314,6 +314,8 @@ interface ComboboxRenderPropArg<T> {
   activeIndex: number | null
   activeOption: T | null
   value: T
+  openCombobox: () => void
+  closeCombobox: () => void
 }
 
 type O = 'value' | 'defaultValue' | 'nullable' | 'multiple' | 'onChange' | 'by'
@@ -494,6 +496,16 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
     data.comboboxState === ComboboxState.Open
   )
 
+  let openCombobox = useEvent(() => {
+    dispatch({ type: ActionTypes.OpenCombobox })
+    defaultToFirstOption.current = true
+  })
+
+  let closeCombobox = useEvent(() => {
+    dispatch({ type: ActionTypes.CloseCombobox })
+    defaultToFirstOption.current = false
+  })
+
   let slot = useMemo<ComboboxRenderPropArg<unknown>>(
     () => ({
       open: data.comboboxState === ComboboxState.Open,
@@ -504,8 +516,10 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
           ? null
           : (data.options[data.activeOptionIndex].dataRef.current.value as TValue),
       value,
+      openCombobox,
+      closeCombobox,
     }),
-    [data, disabled, value]
+    [data, disabled, value, openCombobox, closeCombobox]
   )
 
   let selectOption = useEvent((id: string) => {
@@ -524,16 +538,6 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
       // but we are getting the fallback active option back instead.
       dispatch({ type: ActionTypes.GoToOption, focus: Focus.Specific, id })
     }
-  })
-
-  let openCombobox = useEvent(() => {
-    dispatch({ type: ActionTypes.OpenCombobox })
-    defaultToFirstOption.current = true
-  })
-
-  let closeCombobox = useEvent(() => {
-    dispatch({ type: ActionTypes.CloseCombobox })
-    defaultToFirstOption.current = false
   })
 
   let goToOption = useEvent((focus, id, trigger) => {

--- a/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
@@ -493,6 +493,35 @@ describe('Rendering', () => {
       })
     )
 
+    it(
+      'should be possible to open the combobox with scoped slot',
+      suppressConsoleLogs(async () => {
+        renderTemplate({
+          template: html`
+            <Combobox v-model="value" v-slot="{ openCombobox }">
+              <ComboboxInput
+                :displayValue="(str) => str?.toUpperCase() ?? ''"
+                @focus="openCombobox"
+              />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `,
+          setup: () => ({ value: ref(null) }),
+        })
+
+        assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
+
+        await focus(getComboboxInput())
+
+        assertComboboxList({ state: ComboboxState.Visible })
+      })
+    )
+
     // This really is a bug in Vue but we have a workaround for it
     it(
       'selecting an option puts the display value into Combobox.Input when displayValue is provided (when v-model is undefined)',

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -438,6 +438,8 @@ export let Combobox = defineComponent({
         activeIndex: api.activeOptionIndex.value,
         activeOption: activeOption.value,
         value: value.value,
+        openCombobox: api.openCombobox,
+        closeCombobox: api.closeCombobox,
       }
 
       return h(Fragment, [


### PR DESCRIPTION
This is a solution to the problems described in https://github.com/tailwindlabs/headlessui/discussions/1236.

It exposes both closeCombobox and openCombobox. This allows more control over the behaviour of the combobox component, for example opening the combobox on focusing the combobox input.