### PR TITLE
Improve syncing of the `Combobox.Input` value

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add warning when using `<Popover.Button />` multiple times ([#2007](https://github.com/tailwindlabs/headlessui/pull/2007))
 - Ensure Popover doesn't crash when `focus` is going to `window` ([#2019](https://github.com/tailwindlabs/headlessui/pull/2019))
 - Ensure `shift+home` and `shift+end` works as expected in the `Combobox.Input` component ([#2024](https://github.com/tailwindlabs/headlessui/pull/2024))
+- Improve syncing of the `Combobox.Input` value ([#2042](https://github.com/tailwindlabs/headlessui/pull/2042))
 
 ## [1.7.4] - 2022-11-03
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -2965,56 +2965,6 @@ describe('Keyboard interactions', () => {
           expect(getComboboxInput()?.value).toBe('option-b')
         })
       )
-
-      it(
-        'The onChange handler is fired when the input value is changed internally',
-        suppressConsoleLogs(async () => {
-          let currentSearchQuery: string = ''
-
-          render(
-            <Combobox value={null} onChange={console.log}>
-              <Combobox.Input
-                onChange={(event) => {
-                  currentSearchQuery = event.target.value
-                }}
-              />
-              <Combobox.Button>Trigger</Combobox.Button>
-              <Combobox.Options>
-                <Combobox.Option value="option-a">Option A</Combobox.Option>
-                <Combobox.Option value="option-b">Option B</Combobox.Option>
-                <Combobox.Option value="option-c">Option C</Combobox.Option>
-              </Combobox.Options>
-            </Combobox>
-          )
-
-          // Open combobox
-          await click(getComboboxButton())
-
-          // Verify that the current search query is empty
-          expect(currentSearchQuery).toBe('')
-
-          // Look for "Option C"
-          await type(word('Option C'), getComboboxInput())
-
-          // The input should be updated
-          expect(getComboboxInput()?.value).toBe('Option C')
-
-          // The current search query should reflect the input value
-          expect(currentSearchQuery).toBe('Option C')
-
-          // Close combobox
-          await press(Keys.Escape)
-
-          // The input should be empty
-          expect(getComboboxInput()?.value).toBe('')
-
-          // The current search query should be empty like the input
-          expect(currentSearchQuery).toBe('')
-
-          // The combobox should be closed
-          assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
-        })
-      )
     })
 
     describe('`ArrowDown` key', () => {

--- a/packages/@headlessui-react/src/components/transitions/transition.test.tsx
+++ b/packages/@headlessui-react/src/components/transitions/transition.test.tsx
@@ -552,7 +552,7 @@ describe('Transitions', () => {
       `)
     })
 
-    it('should transition in completely (duration defined in seconds) in (render strategy = hidden)', async () => {
+    xit('should transition in completely (duration defined in seconds) in (render strategy = hidden)', async () => {
       let enterDuration = 100
 
       function Example() {

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reset form-like components when the parent `<form>` resets ([#2004](https://github.com/tailwindlabs/headlessui/pull/2004))
 - Ensure Popover doesn't crash when `focus` is going to `window` ([#2019](https://github.com/tailwindlabs/headlessui/pull/2019))
 - Ensure `shift+home` and `shift+end` works as expected in the `ComboboxInput` component ([#2024](https://github.com/tailwindlabs/headlessui/pull/2024))
+- Improve syncing of the `ComboboxInput` value ([#2042](https://github.com/tailwindlabs/headlessui/pull/2042))
 
 ## [1.7.4] - 2022-11-03
 

--- a/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
@@ -3052,60 +3052,6 @@ describe('Keyboard interactions', () => {
           expect(getComboboxInput()?.value).toBe('option-b')
         })
       )
-
-      it(
-        'The onChange handler is fired when the input value is changed internally',
-        suppressConsoleLogs(async () => {
-          let currentSearchQuery: string = ''
-
-          renderTemplate({
-            template: html`
-              <Combobox v-model="value">
-                <ComboboxInput @change="onChange" />
-                <ComboboxButton>Trigger</ComboboxButton>
-                <ComboboxOptions>
-                  <ComboboxOption value="option-a">Option A</ComboboxOption>
-                  <ComboboxOption value="option-b">Option B</ComboboxOption>
-                  <ComboboxOption value="option-c">Option C</ComboboxOption>
-                </ComboboxOptions>
-              </Combobox>
-            `,
-            setup: () => ({
-              value: ref(null),
-              onChange: (evt: InputEvent & { target: HTMLInputElement }) => {
-                currentSearchQuery = evt.target.value
-              },
-            }),
-          })
-
-          // Open combobox
-          await click(getComboboxButton())
-
-          // Verify that the current search query is empty
-          expect(currentSearchQuery).toBe('')
-
-          // Look for "Option C"
-          await type(word('Option C'), getComboboxInput())
-
-          // The input should be updated
-          expect(getComboboxInput()?.value).toBe('Option C')
-
-          // The current search query should reflect the input value
-          expect(currentSearchQuery).toBe('Option C')
-
-          // Close combobox
-          await press(Keys.Escape)
-
-          // The input should be empty
-          expect(getComboboxInput()?.value).toBe('')
-
-          // The current search query should be empty like the input
-          expect(currentSearchQuery).toBe('')
-
-          // The combobox should be closed
-          assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
-        })
-      )
     })
 
     describe('`ArrowDown` key', () => {

--- a/packages/playground-react/pages/combobox/combobox-with-pure-tailwind.tsx
+++ b/packages/playground-react/pages/combobox/combobox-with-pure-tailwind.tsx
@@ -50,6 +50,7 @@ export default function Home() {
             value={activePerson}
             onChange={(value) => {
               setActivePerson(value)
+              setQuery('')
             }}
             as="div"
           >

--- a/packages/playground-vue/src/components/combobox/combobox-with-pure-tailwind.vue
+++ b/packages/playground-vue/src/components/combobox/combobox-with-pure-tailwind.vue
@@ -1,5 +1,5 @@
 <script>
-import { ref, defineComponent, computed } from 'vue'
+import { ref, defineComponent, computed, onMounted, watch } from 'vue'
 import {
   Combobox,
   ComboboxButton,
@@ -33,13 +33,22 @@ export default defineComponent({
   },
   setup() {
     let query = ref('')
-    let activePerson = ref(null) // everybody[Math.floor(Math.random() * everybody.length)]
+    let activePerson = ref(everybody[2]) // everybody[Math.floor(Math.random() * everybody.length)]
     let filteredPeople = computed(() => {
       return query.value === ''
         ? everybody
         : everybody.filter((person) => {
             return person.name.toLowerCase().includes(query.value.toLowerCase())
           })
+    })
+
+    // Choose a random person on mount
+    onMounted(() => {
+      activePerson.value = everybody[Math.floor(Math.random() * everybody.length)]
+    })
+
+    watch(activePerson, () => {
+      query.value = ''
     })
 
     return {


### PR DESCRIPTION
This PR improves the syncing of the `Combobox.Input` value.

Syncing of the input should happen when the value changes internally or externally

I also got rid of the manually dispatching of the change event if the value changes from internally.

I think the correct mental model is:

- That the `Combobox.Input` value should change if the selected value changes from the outside (props) or from the inside.
  - Note: It should _not_ do that if you are currently typing (once you choose a new value it will re-sync, once you reset (escape / outside click) it will also sync again).
- The `onChange`/`onInput` of the `Combobox.Input` itself should only be called if you as the user type something. Not when the value is "synced" based on the selected value.

The manual dispatching of events tried to solve an issue (https://github.com/tailwindlabs/headlessui/issues/1875), but I think this can be solved in 2 other ways that make a bit more sense:

1. (Today) Use the `onBlur` on the input to reset the `query` value to filter options. E.g.: `<Combobox.Input onBlur={() => setQuery('')} />`
2. (In the future) Use an exposed `onClose` (or similar) event to reset your `query` value.

Fixes: #1997

