### PR TITLE
Improve SSR for Tabs in Vue

### DIFF
--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix crash when using `multiple` mode without `value` prop (uncontrolled) for `Listbox` and `Combobox` components ([#2058](https://github.com/tailwindlabs/headlessui/pull/2058))
 - Allow passing in your own `id` prop ([#2060](https://github.com/tailwindlabs/headlessui/pull/2060))
 - Add `null` as a valid type for Listbox and Combobox in Vue ([#2064](https://github.com/tailwindlabs/headlessui/pull/2064), [#2067](https://github.com/tailwindlabs/headlessui/pull/2067))
+- Improve SSR for Tabs in Vue ([#2068](https://github.com/tailwindlabs/headlessui/pull/2068))
 
 ## [1.7.4] - 2022-11-03
 

--- a/packages/@headlessui-vue/src/components/tabs/tabs.test.ts
+++ b/packages/@headlessui-vue/src/components/tabs/tabs.test.ts
@@ -1,4 +1,5 @@
-import { nextTick, ref } from 'vue'
+import { createSSRApp, nextTick, ref } from 'vue'
+import { renderToString } from 'vue/server-renderer'
 import { createRenderTemplate, render } from '../../test-utils/vue-testing-library'
 import { TabGroup, TabList, Tab, TabPanels, TabPanel } from './tabs'
 import { suppressConsoleLogs } from '../../test-utils/suppress-console-logs'
@@ -552,6 +553,60 @@ describe('Rendering', () => {
 
       // Nothing should change...
       assertTabs({ active: 2 })
+    })
+  })
+
+  describe('SSR', () => {
+    it('should be possible to server side render the first Tab and Panel', async () => {
+      let app = createSSRApp({
+        components: { TabGroup, TabList, Tab, TabPanels, TabPanel },
+        template: html`
+          <TabGroup>
+            <TabList>
+              <Tab>Tab 1</Tab>
+              <Tab>Tab 2</Tab>
+              <Tab>Tab 3</Tab>
+            </TabList>
+
+            <TabPanels>
+              <TabPanel>Content 1</TabPanel>
+              <TabPanel>Content 2</TabPanel>
+              <TabPanel>Content 3</TabPanel>
+            </TabPanels>
+          </TabGroup>
+        `,
+      })
+
+      let contents = await renderToString(app)
+      expect(contents).toContain(`Content 1`)
+      expect(contents).not.toContain(`Content 2`)
+      expect(contents).not.toContain(`Content 3`)
+    })
+
+    it('should be possible to server side render the defaultIndex Tab and Panel', async () => {
+      let app = createSSRApp({
+        components: { TabGroup, TabList, Tab, TabPanels, TabPanel },
+        template: html`
+          <TabGroup :defaultIndex="1">
+            <TabList>
+              <Tab>Tab 1</Tab>
+              <Tab>Tab 2</Tab>
+              <Tab>Tab 3</Tab>
+            </TabList>
+
+            <TabPanels>
+              <TabPanel>Content 1</TabPanel>
+              <TabPanel>Content 2</TabPanel>
+              <TabPanel>Content 3</TabPanel>
+            </TabPanels>
+          </TabGroup>
+        `,
+      })
+
+      let contents = await renderToString(app)
+      expect(contents).not.toContain(`Content 1`)
+      expect(contents).toContain(`Content 2`)
+      expect(contents).not.toContain(`Content 3`)
     })
   })
 })


### PR DESCRIPTION
This PR improves the SSR for Vue so that the first `Tab` and `TabPanel` are rendered on the server. If a custom `defaultIndex` is provided, then that will be used instead.

Fixes: #1479

