### PR TITLE
Fix `Dialog` unmounting problem due to incorrect `transitioncancel` event in the `Transition` component on Android

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix crash when using `multiple` mode without `value` prop (uncontrolled) for `Listbox` and `Combobox` components ([#2058](https://github.com/tailwindlabs/headlessui/pull/2058))
 - Apply `enter` and `enterFrom` classes in SSR for `Transition` component ([#2059](https://github.com/tailwindlabs/headlessui/pull/2059))
 - Allow passing in your own `id` prop ([#2060](https://github.com/tailwindlabs/headlessui/pull/2060))
+- Fix `Dialog` unmounting problem due to incorrect `transitioncancel` event in the `Transition` component on Android ([#2071](https://github.com/tailwindlabs/headlessui/pull/2071))
 
 ## [1.7.4] - 2022-11-03
 

--- a/packages/@headlessui-react/src/components/transitions/utils/transition.test.ts
+++ b/packages/@headlessui-react/src/components/transitions/utils/transition.test.ts
@@ -1,4 +1,4 @@
-import { Reason, transition } from './transition'
+import { transition } from './transition'
 
 import { reportChanges } from '../../../test-utils/report-dom-node-changes'
 import { disposables } from '../../../utils/disposables'
@@ -26,7 +26,7 @@ it('should be possible to transition', async () => {
     )
   )
 
-  await new Promise((resolve) => {
+  await new Promise<void>((resolve) => {
     transition(
       element,
       {
@@ -83,7 +83,7 @@ it('should wait the correct amount of time to finish a transition', async () => 
     )
   )
 
-  let reason = await new Promise((resolve) => {
+  await new Promise<void>((resolve) => {
     transition(
       element,
       {
@@ -101,7 +101,6 @@ it('should wait the correct amount of time to finish a transition', async () => 
   })
 
   await new Promise((resolve) => d.nextFrame(resolve))
-  expect(reason).toBe(Reason.Ended)
 
   // Initial render:
   expect(snapshots[0].content).toEqual(`<div style="transition-duration: ${duration}ms;"></div>`)
@@ -153,7 +152,7 @@ it('should keep the delay time into account', async () => {
     )
   )
 
-  let reason = await new Promise((resolve) => {
+  await new Promise<void>((resolve) => {
     transition(
       element,
       {
@@ -171,7 +170,6 @@ it('should keep the delay time into account', async () => {
   })
 
   await new Promise((resolve) => d.nextFrame(resolve))
-  expect(reason).toBe(Reason.Ended)
 
   let estimatedDuration = Number(
     (snapshots[snapshots.length - 1].recordedAt - snapshots[snapshots.length - 2].recordedAt) /

--- a/packages/@headlessui-react/src/hooks/use-transition.ts
+++ b/packages/@headlessui-react/src/hooks/use-transition.ts
@@ -1,8 +1,7 @@
 import { MutableRefObject } from 'react'
 
-import { Reason, transition } from '../components/transitions/utils/transition'
+import { transition } from '../components/transitions/utils/transition'
 import { disposables } from '../utils/disposables'
-import { match } from '../utils/match'
 
 import { useDisposables } from './use-disposables'
 import { useIsMounted } from './use-is-mounted'
@@ -47,15 +46,9 @@ export function useTransition({ container, direction, classes, onStart, onStop }
     onStart.current(latestDirection.current)
 
     dd.add(
-      transition(node, classes.current, latestDirection.current === 'enter', (reason) => {
+      transition(node, classes.current, latestDirection.current === 'enter', () => {
         dd.dispose()
-
-        match(reason, {
-          [Reason.Ended]() {
-            onStop.current(latestDirection.current)
-          },
-          [Reason.Cancelled]: () => {},
-        })
+        onStop.current(latestDirection.current)
       })
     )
 


### PR DESCRIPTION
This PR fixes an odd issue where the `transitioncancel` event was fired on Android devices and the `transitionend` event was never fired. Therefore the `Transition` component was never "done", which in turn means that the `Dialog` never unmounted because the internal `OpenClosed` state didn't change yet.

Removing the `transitioncancel` event handling altogether fixes this issue. This ensure that it now works on Android and still works on Safari, Chrome, iOS Safari, ...

The good part is that we didn't really do anything with the `transitioncancel` event anyway, we just removed all the active listeners.

Fixes: #2032