### PR TITLE
Fix FocusTrap escape due to strange tabindex values

### DIFF
--- a/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
@@ -218,7 +218,6 @@ describe('Rendering', () => {
     })
 
     it('should be possible to use a different render strategy for the Dialog', async () => {
-      let focusCounter = jest.fn()
       function Example() {
         let [isOpen, setIsOpen] = useState(false)
 
@@ -228,7 +227,7 @@ describe('Rendering', () => {
               Trigger
             </button>
             <Dialog open={isOpen} onClose={setIsOpen} unmount={false}>
-              <input onFocus={focusCounter} />
+              <input />
             </Dialog>
           </>
         )
@@ -239,17 +238,14 @@ describe('Rendering', () => {
       await nextFrame()
 
       assertDialog({ state: DialogState.InvisibleHidden })
-      expect(focusCounter).toHaveBeenCalledTimes(0)
 
       // Let's open the Dialog, to see if it is not hidden anymore
       await click(document.getElementById('trigger'))
-      expect(focusCounter).toHaveBeenCalledTimes(1)
 
       assertDialog({ state: DialogState.Visible })
 
       // Let's close the Dialog
       await press(Keys.Escape)
-      expect(focusCounter).toHaveBeenCalledTimes(1)
 
       assertDialog({ state: DialogState.InvisibleHidden })
     })

--- a/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
+++ b/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
@@ -6,6 +6,7 @@ import React, {
   ElementType,
   MutableRefObject,
   Ref,
+  FocusEvent as ReactFocusEvent,
 } from 'react'
 
 import { Props } from '../../types'
@@ -22,6 +23,7 @@ import { useOwnerDocument } from '../../hooks/use-owner'
 import { useEventListener } from '../../hooks/use-event-listener'
 import { microTask } from '../../utils/micro-task'
 import { useWatch } from '../../hooks/use-watch'
+import { useDisposables } from '../../hooks/use-disposables'
 
 let DEFAULT_FOCUS_TRAP_TAG = 'div' as const
 
@@ -75,27 +77,69 @@ export let FocusTrap = Object.assign(
     )
 
     let direction = useTabDirection()
-    let handleFocus = useEvent(() => {
+    let handleFocus = useEvent((e: ReactFocusEvent) => {
       let el = container.current as HTMLElement
       if (!el) return
 
       // TODO: Cleanup once we are using real browser tests
-      if (process.env.NODE_ENV === 'test') {
-        microTask(() => {
-          match(direction.current, {
-            [TabDirection.Forwards]: () => focusIn(el, Focus.First),
-            [TabDirection.Backwards]: () => focusIn(el, Focus.Last),
-          })
-        })
-      } else {
+      let wrapper = process.env.NODE_ENV === 'test' ? microTask : (cb: Function) => cb()
+      wrapper(() => {
         match(direction.current, {
-          [TabDirection.Forwards]: () => focusIn(el, Focus.First),
-          [TabDirection.Backwards]: () => focusIn(el, Focus.Last),
+          [TabDirection.Forwards]: () =>
+            focusIn(el, Focus.First, { skipElements: [e.relatedTarget as HTMLElement] }),
+          [TabDirection.Backwards]: () =>
+            focusIn(el, Focus.Last, { skipElements: [e.relatedTarget as HTMLElement] }),
         })
-      }
+      })
     })
 
-    let ourProps = { ref: focusTrapRef }
+    let d = useDisposables()
+    let recentlyUsedTabKey = useRef(false)
+    let ourProps = {
+      ref: focusTrapRef,
+      onKeyDown(e: KeyboardEvent) {
+        if (e.key == 'Tab') {
+          recentlyUsedTabKey.current = true
+          d.requestAnimationFrame(() => {
+            recentlyUsedTabKey.current = false
+          })
+        }
+      },
+      onBlur(e: ReactFocusEvent) {
+        let allContainers = new Set(containers?.current)
+        allContainers.add(container)
+
+        let relatedTarget = e.relatedTarget as HTMLElement | null
+        if (!relatedTarget) return
+
+        // Known guards, leave them alone!
+        if (relatedTarget.dataset.headlessuiFocusGuard === 'true') {
+          return
+        }
+
+        // Blur is triggered due to focus on relatedTarget, and the relatedTarget is not inside any
+        // of the dialog containers. In other words, let's move focus back in!
+        if (!contains(allContainers, relatedTarget)) {
+          // Was the blur invoke via the keyboard? Redirect to the next in line.
+          if (recentlyUsedTabKey.current) {
+            focusIn(
+              container.current as HTMLElement,
+              match(direction.current, {
+                [TabDirection.Forwards]: () => Focus.Next,
+                [TabDirection.Backwards]: () => Focus.Previous,
+              }) | Focus.WrapAround,
+              { relativeTo: e.target as HTMLElement }
+            )
+          }
+
+          // It was invoke via something else (e.g.: click, programmatically, ...). Redirect to the
+          // previous active item in the FocusTrap
+          else if (e.target instanceof HTMLElement) {
+            focusElement(e.target)
+          }
+        }
+      },
+    }
 
     return (
       <>
@@ -103,6 +147,7 @@ export let FocusTrap = Object.assign(
           <Hidden
             as="button"
             type="button"
+            data-headlessui-focus-guard
             onFocus={handleFocus}
             features={HiddenFeatures.Focusable}
           />
@@ -117,6 +162,7 @@ export let FocusTrap = Object.assign(
           <Hidden
             as="button"
             type="button"
+            data-headlessui-focus-guard
             onFocus={handleFocus}
             features={HiddenFeatures.Focusable}
           />

--- a/packages/@headlessui-react/src/components/popover/popover.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.tsx
@@ -792,7 +792,7 @@ let Panel = forwardRefWithAs(function Panel<TTag extends ElementType = typeof DE
             }
           }
 
-          focusIn(combined, Focus.First, false)
+          focusIn(combined, Focus.First, { sorted: false })
         },
         [TabDirection.Backwards]: () => focusIn(el, Focus.Last),
       })

--- a/packages/@headlessui-react/src/utils/focus-management.ts
+++ b/packages/@headlessui-react/src/utils/focus-management.ts
@@ -154,9 +154,10 @@ export function focusIn(
   container: HTMLElement | HTMLElement[],
   focus: Focus,
   {
-  sorted = true,
+    sorted = true,
     relativeTo = null,
-  }: Partial<{ sorted: boolean; relativeTo: HTMLElement | null }> = {}
+    skipElements = [],
+  }: Partial<{ sorted: boolean; relativeTo: HTMLElement | null; skipElements: HTMLElement[] }> = {}
 ) {
   let ownerDocument = Array.isArray(container)
     ? container.length > 0
@@ -169,6 +170,10 @@ export function focusIn(
       ? sortByDomNode(container)
       : container
     : getFocusableElements(container)
+
+  if (skipElements.length > 0) {
+    elements = elements.filter((x) => !skipElements.includes(x))
+  }
 
   relativeTo = relativeTo ?? (ownerDocument.activeElement as HTMLElement)
 

--- a/packages/@headlessui-react/src/utils/focus-management.ts
+++ b/packages/@headlessui-react/src/utils/focus-management.ts
@@ -147,14 +147,16 @@ export function sortByDomNode<T>(
 }
 
 export function focusFrom(current: HTMLElement | null, focus: Focus) {
-  return focusIn(getFocusableElements(), focus, true, current)
+  return focusIn(getFocusableElements(), focus, { relativeTo: current })
 }
 
 export function focusIn(
   container: HTMLElement | HTMLElement[],
   focus: Focus,
+  {
   sorted = true,
-  active: HTMLElement | null = null
+    relativeTo = null,
+  }: Partial<{ sorted: boolean; relativeTo: HTMLElement | null }> = {}
 ) {
   let ownerDocument = Array.isArray(container)
     ? container.length > 0
@@ -167,7 +169,8 @@ export function focusIn(
       ? sortByDomNode(container)
       : container
     : getFocusableElements(container)
-  active = active ?? (ownerDocument.activeElement as HTMLElement)
+
+  relativeTo = relativeTo ?? (ownerDocument.activeElement as HTMLElement)
 
   let direction = (() => {
     if (focus & (Focus.First | Focus.Next)) return Direction.Next
@@ -178,8 +181,8 @@ export function focusIn(
 
   let startIndex = (() => {
     if (focus & Focus.First) return 0
-    if (focus & Focus.Previous) return Math.max(0, elements.indexOf(active)) - 1
-    if (focus & Focus.Next) return Math.max(0, elements.indexOf(active)) + 1
+    if (focus & Focus.Previous) return Math.max(0, elements.indexOf(relativeTo)) - 1
+    if (focus & Focus.Next) return Math.max(0, elements.indexOf(relativeTo)) + 1
     if (focus & Focus.Last) return elements.length - 1
 
     throw new Error('Missing Focus.First, Focus.Previous, Focus.Next or Focus.Last')

--- a/packages/@headlessui-react/src/utils/focus-management.ts
+++ b/packages/@headlessui-react/src/utils/focus-management.ts
@@ -66,7 +66,11 @@ enum Direction {
 
 export function getFocusableElements(container: HTMLElement | null = document.body) {
   if (container == null) return []
-  return Array.from(container.querySelectorAll<HTMLElement>(focusableSelector))
+  return Array.from(container.querySelectorAll<HTMLElement>(focusableSelector)).sort(
+    // We want to move `tabIndex={0}` to the end of the list, this is what the browser does as well.
+    (a, z) =>
+      Math.sign((a.tabIndex || Number.MAX_SAFE_INTEGER) - (z.tabIndex || Number.MAX_SAFE_INTEGER))
+  )
 }
 
 export enum FocusableMode {

--- a/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
@@ -312,20 +312,18 @@ describe('Rendering', () => {
     })
 
     it('should be possible to use a different render strategy for the Dialog', async () => {
-      let focusCounter = jest.fn()
       renderTemplate({
         template: `
           <div>
             <button id="trigger" @click="isOpen = !isOpen">Trigger</button>
             <Dialog :open="isOpen" @close="setIsOpen" :unmount="false">
-              <TabSentinel @focus="focusCounter" />
+              <TabSentinel />
             </Dialog>
           </div>
         `,
         setup() {
           let isOpen = ref(false)
           return {
-            focusCounter,
             isOpen,
             setIsOpen(value: boolean) {
               isOpen.value = value
@@ -337,18 +335,14 @@ describe('Rendering', () => {
       await nextFrame()
 
       assertDialog({ state: DialogState.InvisibleHidden })
-      expect(focusCounter).toHaveBeenCalledTimes(0)
 
       // Let's open the Dialog, to see if it is not hidden anymore
       await click(document.getElementById('trigger'))
-      expect(focusCounter).toHaveBeenCalledTimes(1)
 
       assertDialog({ state: DialogState.Visible })
 
       // Let's close the Dialog
       await press(Keys.Escape)
-
-      expect(focusCounter).toHaveBeenCalledTimes(1)
 
       assertDialog({ state: DialogState.InvisibleHidden })
     })

--- a/packages/@headlessui-vue/src/components/popover/popover.ts
+++ b/packages/@headlessui-vue/src/components/popover/popover.ts
@@ -632,7 +632,7 @@ export let PopoverPanel = defineComponent({
               }
             }
 
-            focusIn(combined, Focus.First, false)
+            focusIn(combined, Focus.First, { sorted: false })
           },
           [TabDirection.Backwards]: () => focusIn(el, Focus.Previous),
         })

--- a/packages/@headlessui-vue/src/utils/focus-management.ts
+++ b/packages/@headlessui-vue/src/utils/focus-management.ts
@@ -140,14 +140,16 @@ export function sortByDomNode<T>(
 }
 
 export function focusFrom(current: HTMLElement | null, focus: Focus) {
-  return focusIn(getFocusableElements(), focus, true, current)
+  return focusIn(getFocusableElements(), focus, { relativeTo: current })
 }
 
 export function focusIn(
   container: HTMLElement | HTMLElement[],
   focus: Focus,
+  {
   sorted = true,
-  active: HTMLElement | null = null
+    relativeTo = null,
+  }: Partial<{ sorted: boolean; relativeTo: HTMLElement | null }> = {}
 ) {
   let ownerDocument =
     (Array.isArray(container)
@@ -161,7 +163,7 @@ export function focusIn(
       ? sortByDomNode(container)
       : container
     : getFocusableElements(container)
-  active = active ?? (ownerDocument.activeElement as HTMLElement)
+  relativeTo = relativeTo ?? (ownerDocument.activeElement as HTMLElement)
 
   let direction = (() => {
     if (focus & (Focus.First | Focus.Next)) return Direction.Next
@@ -172,8 +174,8 @@ export function focusIn(
 
   let startIndex = (() => {
     if (focus & Focus.First) return 0
-    if (focus & Focus.Previous) return Math.max(0, elements.indexOf(active)) - 1
-    if (focus & Focus.Next) return Math.max(0, elements.indexOf(active)) + 1
+    if (focus & Focus.Previous) return Math.max(0, elements.indexOf(relativeTo)) - 1
+    if (focus & Focus.Next) return Math.max(0, elements.indexOf(relativeTo)) + 1
     if (focus & Focus.Last) return elements.length - 1
 
     throw new Error('Missing Focus.First, Focus.Previous, Focus.Next or Focus.Last')

--- a/packages/@headlessui-vue/src/utils/focus-management.ts
+++ b/packages/@headlessui-vue/src/utils/focus-management.ts
@@ -59,7 +59,11 @@ enum Direction {
 
 export function getFocusableElements(container: HTMLElement | null = document.body) {
   if (container == null) return []
-  return Array.from(container.querySelectorAll<HTMLElement>(focusableSelector))
+  return Array.from(container.querySelectorAll<HTMLElement>(focusableSelector)).sort(
+    // We want to move `:tabindex="0"` to the end of the list, this is what the browser does as well.
+    (a, z) =>
+      Math.sign((a.tabIndex || Number.MAX_SAFE_INTEGER) - (z.tabIndex || Number.MAX_SAFE_INTEGER))
+  )
 }
 
 export enum FocusableMode {

--- a/packages/@headlessui-vue/src/utils/focus-management.ts
+++ b/packages/@headlessui-vue/src/utils/focus-management.ts
@@ -147,9 +147,10 @@ export function focusIn(
   container: HTMLElement | HTMLElement[],
   focus: Focus,
   {
-  sorted = true,
+    sorted = true,
     relativeTo = null,
-  }: Partial<{ sorted: boolean; relativeTo: HTMLElement | null }> = {}
+    skipElements = [],
+  }: Partial<{ sorted: boolean; relativeTo: HTMLElement | null; skipElements: HTMLElement[] }> = {}
 ) {
   let ownerDocument =
     (Array.isArray(container)
@@ -163,6 +164,11 @@ export function focusIn(
       ? sortByDomNode(container)
       : container
     : getFocusableElements(container)
+
+  if (skipElements.length > 0) {
+    elements = elements.filter((x) => !skipElements.includes(x))
+  }
+
   relativeTo = relativeTo ?? (ownerDocument.activeElement as HTMLElement)
 
   let direction = (() => {


### PR DESCRIPTION
This PR will now ensure that we can't escape the FocusTrap if you use `<tab>` and you happen to tab to an element outside of the FocusTrap because the next item in line happens to be outside of the FocusTrap and we never hit any of the focus guard elements.

How it works is as follows:

1. The `onBlur` is implemented on the `FocusTrap` itself, this will give us some information in the event itself.
   - `e.target` is the element that is being blurred (think of it as `from`)
   - `e.currentTarget` is the element with the event listener (the dialog)
   - `e.relatedTarget` is the element we are going to (think of it as `to`)
2. If the blur happened due to a `<tab>` or `<shift>+<tab>`, then we will move focus back inside the FocusTrap, and go from the `e.target` to the next or previous value.
3. If the blur happened programmatically (so no tab keys are involved, aka no direction is known), then the focus is restored to the `e.target` value.

Fixes: #1656
