### PR TITLE
Update `aria-haspopup` to use the correct role as the value instead of a boolean

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1027,7 +1027,7 @@ let Button = forwardRefWithAs(function Button<TTag extends ElementType = typeof 
     id,
     type: useResolveButtonType(props, data.buttonRef),
     tabIndex: -1,
-    'aria-haspopup': true,
+    'aria-haspopup': 'listbox',
     'aria-controls': data.optionsRef.current?.id,
     'aria-expanded': data.disabled ? undefined : data.comboboxState === ComboboxState.Open,
     'aria-labelledby': labelledby,

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -664,7 +664,7 @@ let Button = forwardRefWithAs(function Button<TTag extends ElementType = typeof 
     ref: buttonRef,
     id,
     type: useResolveButtonType(props, data.buttonRef),
-    'aria-haspopup': true,
+    'aria-haspopup': 'listbox',
     'aria-controls': data.optionsRef.current?.id,
     'aria-expanded': data.disabled ? undefined : data.listboxState === ListboxStates.Open,
     'aria-labelledby': labelledby,

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -371,7 +371,7 @@ let Button = forwardRefWithAs(function Button<TTag extends ElementType = typeof 
     ref: buttonRef,
     id,
     type: useResolveButtonType(props, state.buttonRef),
-    'aria-haspopup': true,
+    'aria-haspopup': 'menu',
     'aria-controls': state.itemsRef.current?.id,
     'aria-expanded': props.disabled ? undefined : state.menuState === MenuStates.Open,
     onKeyDown: handleKeyDown,

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -616,7 +616,7 @@ export let ComboboxButton = defineComponent({
         id,
         type: type.value,
         tabindex: '-1',
-        'aria-haspopup': true,
+        'aria-haspopup': 'listbox',
         'aria-controls': dom(api.optionsRef)?.id,
         'aria-expanded': api.disabled.value
           ? undefined

--- a/packages/@headlessui-vue/src/components/listbox/listbox.ts
+++ b/packages/@headlessui-vue/src/components/listbox/listbox.ts
@@ -527,7 +527,7 @@ export let ListboxButton = defineComponent({
         ref: api.buttonRef,
         id,
         type: type.value,
-        'aria-haspopup': true,
+        'aria-haspopup': 'listbox',
         'aria-controls': dom(api.optionsRef)?.id,
         'aria-expanded': api.disabled.value
           ? undefined

--- a/packages/@headlessui-vue/src/components/menu/menu.ts
+++ b/packages/@headlessui-vue/src/components/menu/menu.ts
@@ -317,7 +317,7 @@ export let MenuButton = defineComponent({
         ref: api.buttonRef,
         id,
         type: type.value,
-        'aria-haspopup': true,
+        'aria-haspopup': 'menu',
         'aria-controls': dom(api.itemsRef)?.id,
         'aria-expanded': props.disabled ? undefined : api.menuState.value === MenuStates.Open,
         onKeydown: handleKeyDown,


### PR DESCRIPTION
This PR improves the `aria-haspopup` attribute, which should now contain the corresponding role instead of just true or false. The `aria-haspopup="true"` is considered a `menu` now.

Context: https://w3c.github.io/aria/#aria-haspopup

Fixes: #2099
