### PR TITLE
Ensure `disabled="false"` is not incorrectly passed to the underlying DOM Node

### DIFF
--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adjust SSR detection mechanism ([#2102](https://github.com/tailwindlabs/headlessui/pull/2102))
 
+### Fixed
+
+- Ensure `disabled="false"` is not incorrectly passed to the underlying DOM Node ([#2138](https://github.com/tailwindlabs/headlessui/pull/2138))
+
 ## [1.7.7] - 2022-12-16
 
 ### Fixed

--- a/packages/@headlessui-vue/src/components/menu/menu.ts
+++ b/packages/@headlessui-vue/src/components/menu/menu.ts
@@ -571,6 +571,7 @@ export let MenuItem = defineComponent({
         role: 'menuitem',
         tabIndex: disabled === true ? undefined : -1,
         'aria-disabled': disabled === true ? true : undefined,
+        disabled: undefined, // Never forward the `disabled` prop
         onClick: handleClick,
         onFocus: handleFocus,
         onPointerenter: handleEnter,

--- a/packages/@headlessui-vue/src/components/menu/menu.ts
+++ b/packages/@headlessui-vue/src/components/menu/menu.ts
@@ -493,6 +493,7 @@ export let MenuItems = defineComponent({
 
 export let MenuItem = defineComponent({
   name: 'MenuItem',
+  inheritAttrs: false,
   props: {
     as: { type: [Object, String], default: 'template' },
     disabled: { type: Boolean, default: false },
@@ -584,7 +585,7 @@ export let MenuItem = defineComponent({
 
       return render({
         ourProps,
-        theirProps,
+        theirProps: { ...attrs, ...theirProps },
         slot,
         attrs,
         slots,

--- a/packages/@headlessui-vue/src/hooks/use-tracked-pointer.ts
+++ b/packages/@headlessui-vue/src/hooks/use-tracked-pointer.ts
@@ -14,7 +14,7 @@ export function useTrackedPointer() {
       // FIXME: Remove this once we use browser testing in all the relevant places.
       // NOTE: This is replaced with a compile-time define during the build process
       // This hack exists to work around a few failing tests caused by our inability to "move" the virtual pointer in JSDOM pointer events.
-      if (process.env.TEST_BYPASS_TRACKED_POINTER) {
+      if (typeof process !== 'undefined' && process.env.TEST_BYPASS_TRACKED_POINTER) {
         return true
       }
 


### PR DESCRIPTION
This PR fixes an issue where `disabled="false"` was incorrectly forwarded to the underlying DOM
node, which could break some projects if some CSS sets `[disabled] { }` because this also matches
`disabled="false"`

Fixes: #2134

