### PR TITLE
Fix arrow key handling in `Tab` (after DOM order changes)

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix SSR tab rendering on React 17 ([#2102](https://github.com/tailwindlabs/headlessui/pull/2102))
+- Fix arrow key handling in `Tab` (after DOM order changes) ([#2145](https://github.com/tailwindlabs/headlessui/pull/2145))
 
 ## [1.7.7] - 2022-12-16
 

--- a/packages/@headlessui-react/src/components/tabs/tabs.test.tsx
+++ b/packages/@headlessui-react/src/components/tabs/tabs.test.tsx
@@ -167,6 +167,177 @@ describe('Rendering', () => {
     })
   )
 
+  it(
+    'should guarantee the order of DOM nodes when reversing the tabs and panels themselves, then performing actions (controlled component)',
+    suppressConsoleLogs(async () => {
+      function Example() {
+        let [selectedIndex, setSelectedIndex] = useState(1)
+        let [tabs, setTabs] = useState([0, 1, 2])
+
+        return (
+          <>
+            <button
+              onClick={() => {
+                setTabs((tabs) => tabs.slice().reverse())
+                setSelectedIndex((idx) => tabs.length - 1 - idx)
+              }}
+            >
+              reverse
+            </button>
+            <Tab.Group selectedIndex={selectedIndex} onChange={setSelectedIndex}>
+              <Tab.List>
+                {tabs.map((tab) => (
+                  <Tab key={tab}>Tab {tab}</Tab>
+                ))}
+              </Tab.List>
+
+              <Tab.Panels>
+                {tabs.map((tab) => (
+                  <Tab.Panel key={tab}>Content {tab}</Tab.Panel>
+                ))}
+              </Tab.Panels>
+            </Tab.Group>
+            <p id="selectedIndex">{selectedIndex}</p>
+          </>
+        )
+      }
+
+      render(<Example />)
+
+      let selectedIndexElement = document.getElementById('selectedIndex')
+
+      assertTabs({ active: 1 })
+
+      await click(getByText('Tab 0'))
+      assertTabs({ active: 0 })
+      expect(selectedIndexElement).toHaveTextContent('0')
+
+      await click(getByText('Tab 1'))
+      assertTabs({ active: 1 })
+      expect(selectedIndexElement).toHaveTextContent('1')
+
+      await click(getByText('Tab 2'))
+      assertTabs({ active: 2 })
+      expect(selectedIndexElement).toHaveTextContent('2')
+
+      await click(getByText('reverse'))
+
+      // Note: the indices are reversed now
+      await click(getByText('Tab 0'))
+      assertTabs({ active: 2 })
+      expect(selectedIndexElement).toHaveTextContent('2')
+
+      await click(getByText('Tab 1'))
+      assertTabs({ active: 1 })
+      expect(selectedIndexElement).toHaveTextContent('1')
+
+      await click(getByText('Tab 2'))
+      assertTabs({ active: 0 })
+      expect(selectedIndexElement).toHaveTextContent('0')
+
+      await click(getByText('reverse'))
+
+      // Note: the indices are reversed again now (back to normal)
+      await click(getByText('Tab 0'))
+      assertTabs({ active: 0 })
+      expect(selectedIndexElement).toHaveTextContent('0')
+
+      await click(getByText('Tab 1'))
+      assertTabs({ active: 1 })
+      expect(selectedIndexElement).toHaveTextContent('1')
+
+      await click(getByText('Tab 2'))
+      assertTabs({ active: 2 })
+      expect(selectedIndexElement).toHaveTextContent('2')
+    })
+  )
+
+  it(
+    'should guarantee the order of DOM nodes when reversing the tabs and panels themselves, then performing actions (uncontrolled component)',
+    suppressConsoleLogs(async () => {
+      function Example() {
+        let [tabs, setTabs] = useState([0, 1, 2])
+
+        return (
+          <>
+            <button
+              onClick={() => {
+                setTabs((tabs) => tabs.slice().reverse())
+              }}
+            >
+              reverse
+            </button>
+            <Tab.Group>
+              {({ selectedIndex }) => (
+                <>
+                  <Tab.List>
+                    {tabs.map((tab) => (
+                      <Tab key={tab}>Tab {tab}</Tab>
+                    ))}
+                  </Tab.List>
+
+                  <Tab.Panels>
+                    {tabs.map((tab) => (
+                      <Tab.Panel key={tab}>Content {tab}</Tab.Panel>
+                    ))}
+                  </Tab.Panels>
+
+                  <p id="selectedIndex">{selectedIndex}</p>
+                </>
+              )}
+            </Tab.Group>
+          </>
+        )
+      }
+
+      render(<Example />)
+
+      let selectedIndexElement = document.getElementById('selectedIndex')
+
+      await click(getByText('Tab 0'))
+      assertTabs({ active: 0 })
+      expect(selectedIndexElement).toHaveTextContent('0')
+
+      await click(getByText('Tab 1'))
+      assertTabs({ active: 1 })
+      expect(selectedIndexElement).toHaveTextContent('1')
+
+      await click(getByText('Tab 2'))
+      assertTabs({ active: 2 })
+      expect(selectedIndexElement).toHaveTextContent('2')
+
+      await click(getByText('reverse'))
+
+      // Note: the indices are reversed now
+      await click(getByText('Tab 0'))
+      assertTabs({ active: 2 })
+      expect(selectedIndexElement).toHaveTextContent('2')
+
+      await click(getByText('Tab 1'))
+      assertTabs({ active: 1 })
+      expect(selectedIndexElement).toHaveTextContent('1')
+
+      await click(getByText('Tab 2'))
+      assertTabs({ active: 0 })
+      expect(selectedIndexElement).toHaveTextContent('0')
+
+      await click(getByText('reverse'))
+
+      // Note: the indices are reversed again now (back to normal)
+      await click(getByText('Tab 0'))
+      assertTabs({ active: 0 })
+      expect(selectedIndexElement).toHaveTextContent('0')
+
+      await click(getByText('Tab 1'))
+      assertTabs({ active: 1 })
+      expect(selectedIndexElement).toHaveTextContent('1')
+
+      await click(getByText('Tab 2'))
+      assertTabs({ active: 2 })
+      expect(selectedIndexElement).toHaveTextContent('2')
+    })
+  )
+
   describe('`renderProps`', () => {
     it(
       'should be possible to render using as={Fragment}',

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ensure `disabled="false"` is not incorrectly passed to the underlying DOM Node ([#2138](https://github.com/tailwindlabs/headlessui/pull/2138))
+- Fix arrow key handling in `Tab` (after DOM order changes) ([#2145](https://github.com/tailwindlabs/headlessui/pull/2145))
 
 ## [1.7.7] - 2022-12-16
 

--- a/packages/@headlessui-vue/src/components/tabs/tabs.test.ts
+++ b/packages/@headlessui-vue/src/components/tabs/tabs.test.ts
@@ -174,6 +174,175 @@ describe('Rendering', () => {
     })
   )
 
+  it(
+    'should guarantee the order of DOM nodes when reversing the tabs and panels themselves, then performing actions (controlled component)',
+    suppressConsoleLogs(async () => {
+      renderTemplate({
+        template: html`
+          <button @click="reverse">reverse</button>
+          <TabGroup :selectedIndex="selectedIndex" @change="handleChange">
+            <TabList>
+              <Tab v-for="tab in tabs" :key="tab">Tab {{ tab }}</Tab>
+            </TabList>
+            <TabPanels>
+              <TabPanel v-for="tab in tabs" :key="tab">Content {{ tab }}</TabPanel>
+            </TabPanels>
+          </TabGroup>
+          <p id="selectedIndex">{{ selectedIndex }}</p>
+        `,
+        setup() {
+          let selectedIndex = ref(1)
+          let tabs = ref([0, 1, 2])
+
+          return {
+            tabs,
+            selectedIndex,
+            reverse() {
+              tabs.value = tabs.value.slice().reverse()
+              selectedIndex.value = tabs.value.length - 1 - selectedIndex.value
+            },
+            handleChange(value: number) {
+              selectedIndex.value = value
+            },
+          }
+        },
+      })
+
+      await new Promise<void>(nextTick)
+
+      let selectedIndexElement = document.getElementById('selectedIndex')
+
+      assertTabs({ active: 1 })
+
+      await click(getByText('Tab 0'))
+      assertTabs({ active: 0 })
+      expect(selectedIndexElement).toHaveTextContent('0')
+
+      await click(getByText('Tab 1'))
+      assertTabs({ active: 1 })
+      expect(selectedIndexElement).toHaveTextContent('1')
+
+      await click(getByText('Tab 2'))
+      assertTabs({ active: 2 })
+      expect(selectedIndexElement).toHaveTextContent('2')
+
+      await click(getByText('reverse'))
+
+      // Note: the indices are reversed now
+      await click(getByText('Tab 0'))
+      assertTabs({ active: 2 })
+      expect(selectedIndexElement).toHaveTextContent('2')
+
+      await click(getByText('Tab 1'))
+      assertTabs({ active: 1 })
+      expect(selectedIndexElement).toHaveTextContent('1')
+
+      await click(getByText('Tab 2'))
+      assertTabs({ active: 0 })
+      expect(selectedIndexElement).toHaveTextContent('0')
+
+      await click(getByText('reverse'))
+
+      // Note: the indices are reversed again now (back to normal)
+      await click(getByText('Tab 0'))
+      assertTabs({ active: 0 })
+      expect(selectedIndexElement).toHaveTextContent('0')
+
+      await click(getByText('Tab 1'))
+      assertTabs({ active: 1 })
+      expect(selectedIndexElement).toHaveTextContent('1')
+
+      await click(getByText('Tab 2'))
+      assertTabs({ active: 2 })
+      expect(selectedIndexElement).toHaveTextContent('2')
+    })
+  )
+
+  it(
+    'should guarantee the order of DOM nodes when reversing the tabs and panels themselves, then performing actions (uncontrolled component)',
+    suppressConsoleLogs(async () => {
+      renderTemplate({
+        template: html`
+          <button @click="reverse">reverse</button>
+          <TabGroup
+            :selectedIndex="selectedIndex"
+            @change="handleChange"
+            v-slot="{ selectedIndex }"
+          >
+            <TabList>
+              <Tab v-for="tab in tabs" :key="tab">Tab {{ tab }}</Tab>
+            </TabList>
+            <TabPanels>
+              <TabPanel v-for="tab in tabs" :key="tab">Content {{ tab }}</TabPanel>
+            </TabPanels>
+            <p id="selectedIndex">{{ selectedIndex }}</p>
+          </TabGroup>
+        `,
+        setup() {
+          let selectedIndex = ref(1)
+          let tabs = ref([0, 1, 2])
+
+          return {
+            tabs,
+            selectedIndex,
+            reverse() {
+              tabs.value = tabs.value.slice().reverse()
+            },
+            handleChange(value: number) {
+              selectedIndex.value = value
+            },
+          }
+        },
+      })
+
+      await new Promise<void>(nextTick)
+
+      let selectedIndexElement = document.getElementById('selectedIndex')
+
+      await click(getByText('Tab 0'))
+      assertTabs({ active: 0 })
+      expect(selectedIndexElement).toHaveTextContent('0')
+
+      await click(getByText('Tab 1'))
+      assertTabs({ active: 1 })
+      expect(selectedIndexElement).toHaveTextContent('1')
+
+      await click(getByText('Tab 2'))
+      assertTabs({ active: 2 })
+      expect(selectedIndexElement).toHaveTextContent('2')
+
+      await click(getByText('reverse'))
+
+      // Note: the indices are reversed now
+      await click(getByText('Tab 0'))
+      assertTabs({ active: 2 })
+      expect(selectedIndexElement).toHaveTextContent('2')
+
+      await click(getByText('Tab 1'))
+      assertTabs({ active: 1 })
+      expect(selectedIndexElement).toHaveTextContent('1')
+
+      await click(getByText('Tab 2'))
+      assertTabs({ active: 0 })
+      expect(selectedIndexElement).toHaveTextContent('0')
+
+      await click(getByText('reverse'))
+
+      // Note: the indices are reversed again now (back to normal)
+      await click(getByText('Tab 0'))
+      assertTabs({ active: 0 })
+      expect(selectedIndexElement).toHaveTextContent('0')
+
+      await click(getByText('Tab 1'))
+      assertTabs({ active: 1 })
+      expect(selectedIndexElement).toHaveTextContent('1')
+
+      await click(getByText('Tab 2'))
+      assertTabs({ active: 2 })
+      expect(selectedIndexElement).toHaveTextContent('2')
+    })
+  )
+
   describe('`renderProps`', () => {
     it('should expose the `selectedIndex` on the `Tabs` component', async () => {
       renderTemplate(


### PR DESCRIPTION
This PR fixes a bug where if you are using your arrow keys after you re-ordered the tabs that the next/previous tab is the incorrect one. This PR ensures that the previous / next values are the correct ones instead of the "old" values before the order change happened.

Fixes: #2131
