### PR TITLE
Fix false positive warning about using multiple `<Popover.Button>` components

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix SSR tab rendering on React 17 ([#2102](https://github.com/tailwindlabs/headlessui/pull/2102))
 - Fix arrow key handling in `Tab` (after DOM order changes) ([#2145](https://github.com/tailwindlabs/headlessui/pull/2145))
+- Fix false positive warning about using multiple `<Popover.Button>` components ([#2146](https://github.com/tailwindlabs/headlessui/pull/2146))
 
 ## [1.7.7] - 2022-12-16
 


### PR DESCRIPTION
This PR fixes a false positive warning when using multiple `<Popover.Button>` components. This warning should only happen when you use multipel `<Popover.Button>` components **outside** of the `<Popover.Panel>`, but it also got logged when you used multiple `<Popover.Button>` components **inside** the `<Popover.Panel>` component.

This last bit is allowed, and it is a quick short hand to make closing the `<Popover>` a bit easier: https://headlessui.com/react/popover#closing-popovers-manually

Fixes: #2143
