### PR TITLE
Fix `Tab` key with non focusable elements in `Popover.Panel`

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix SSR tab rendering on React 17 ([#2102](https://github.com/tailwindlabs/headlessui/pull/2102))
 - Fix arrow key handling in `Tab` (after DOM order changes) ([#2145](https://github.com/tailwindlabs/headlessui/pull/2145))
 - Fix false positive warning about using multiple `<Popover.Button>` components ([#2146](https://github.com/tailwindlabs/headlessui/pull/2146))
+- Fix `Tab` key with non focusable elements in `Popover.Panel` ([#2147](https://github.com/tailwindlabs/headlessui/pull/2147))
 
 ## [1.7.7] - 2022-12-16
 

--- a/packages/@headlessui-react/src/components/popover/popover.test.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.test.tsx
@@ -1336,6 +1336,40 @@ describe('Keyboard interactions', () => {
     )
 
     it(
+      'should close the Popover menu once we Tab out of a Popover without focusable elements',
+      suppressConsoleLogs(async () => {
+        render(
+          <>
+            <a href="/">Previous</a>
+
+            <Popover>
+              <Popover.Button>Trigger 1</Popover.Button>
+              <Popover.Panel>No focusable elements here</Popover.Panel>
+            </Popover>
+
+            <a href="/">Next</a>
+          </>
+        )
+
+        // Focus the button of the Popover
+        await focus(getPopoverButton())
+
+        // Open popover
+        await click(getPopoverButton())
+
+        // Let's Tab out of the Popover
+        await press(Keys.Tab)
+
+        // Verify the next link is now focused
+        assertActiveElement(getByText('Next'))
+
+        // Verify the popover is closed
+        assertPopoverButton({ state: PopoverState.InvisibleUnmounted })
+        assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
+      })
+    )
+
+    it(
       'should close the Popover when the Popover.Panel has a focus prop',
       suppressConsoleLogs(async () => {
         render(

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure `disabled="false"` is not incorrectly passed to the underlying DOM Node ([#2138](https://github.com/tailwindlabs/headlessui/pull/2138))
 - Fix arrow key handling in `Tab` (after DOM order changes) ([#2145](https://github.com/tailwindlabs/headlessui/pull/2145))
+- Fix `Tab` key with non focusable elements in `Popover.Panel` ([#2147](https://github.com/tailwindlabs/headlessui/pull/2147))
 
 ## [1.7.7] - 2022-12-16
 

--- a/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
@@ -1475,7 +1475,7 @@ describe('Mouse interactions', () => {
     })
   )
 
-  fit(
+  it(
     'should be possible to click elements inside the dialog when they reside inside a shadow boundary',
     suppressConsoleLogs(async () => {
       let fn = jest.fn()

--- a/packages/@headlessui-vue/src/components/popover/popover.test.ts
+++ b/packages/@headlessui-vue/src/components/popover/popover.test.ts
@@ -15,7 +15,7 @@ import {
   assertContainsActiveElement,
   getPopoverOverlay,
 } from '../../test-utils/accessibility-assertions'
-import { click, press, Keys, MouseButton, shift } from '../../test-utils/interactions'
+import { click, focus, press, Keys, MouseButton, shift } from '../../test-utils/interactions'
 import { html } from '../../test-utils/html'
 import { useOpenClosedProvider, State, useOpenClosed } from '../../internal/open-closed'
 
@@ -1356,6 +1356,40 @@ describe('Keyboard interactions', () => {
         // Verify we are focused on the second link
         await press(Keys.Tab)
         assertActiveElement(getByText('Link 2'))
+
+        // Let's Tab out of the Popover
+        await press(Keys.Tab)
+
+        // Verify the next link is now focused
+        assertActiveElement(getByText('Next'))
+
+        // Verify the popover is closed
+        assertPopoverButton({ state: PopoverState.InvisibleUnmounted })
+        assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
+      })
+    )
+
+    it(
+      'should close the Popover menu once we Tab out of a Popover without focusable elements',
+      suppressConsoleLogs(async () => {
+        renderTemplate(
+          html`
+            <div>
+              <Popover>
+                <PopoverButton>Trigger 1</PopoverButton>
+                <PopoverPanel>No focusable elements here</PopoverPanel>
+              </Popover>
+
+              <a href="/">Next</a>
+            </div>
+          `
+        )
+
+        // Focus the button of the Popover
+        await focus(getPopoverButton())
+
+        // Open popover
+        await click(getPopoverButton())
 
         // Let's Tab out of the Popover
         await press(Keys.Tab)


### PR DESCRIPTION
This PR fixes an issue where using your `tab` key went to the incorrect element if your `Popover.Panel` doesn't contain any focusable elements.

We made the assumption that the `Popover.Panel` always had at least 1 focusable element, but that's not always the case. This PR makes sure that you can go to the next/previous elements correctly.

Fixes: #2112
