### PR TITLE
Improve `Combobox` accessibility

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix false positive warning when using `<Popover.Button />` in React 17 ([#2163](https://github.com/tailwindlabs/headlessui/pull/2163))
 - Fix `failed to removeChild on Node` bug ([#2164](https://github.com/tailwindlabs/headlessui/pull/2164))
 - Don’t overwrite classes during SSR when rendering fragments ([#2173](https://github.com/tailwindlabs/headlessui/pull/2173))
+- Improve `Combobox` accessibility ([#2153](https://github.com/tailwindlabs/headlessui/pull/2153))
 
 ## [1.7.7] - 2022-12-16
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1092,13 +1092,7 @@ let DEFAULT_OPTIONS_TAG = 'ul' as const
 interface OptionsRenderPropArg {
   open: boolean
 }
-type OptionsPropsWeControl =
-  | 'aria-activedescendant'
-  | 'aria-labelledby'
-  | 'hold'
-  | 'onKeyDown'
-  | 'role'
-  | 'tabIndex'
+type OptionsPropsWeControl = 'aria-labelledby' | 'hold' | 'onKeyDown' | 'role' | 'tabIndex'
 
 let OptionsRenderFeatures = Features.RenderStrategy | Features.Static
 
@@ -1156,8 +1150,6 @@ let Options = forwardRefWithAs(function Options<
     [data]
   )
   let ourProps = {
-    'aria-activedescendant':
-      data.activeOptionIndex === null ? undefined : data.options[data.activeOptionIndex]?.id,
     'aria-labelledby': labelledby,
     role: 'listbox',
     id,

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -662,6 +662,7 @@ type InputPropsWeControl =
   | 'aria-labelledby'
   | 'aria-expanded'
   | 'aria-activedescendant'
+  | 'aria-autocomplete'
   | 'onKeyDown'
   | 'onChange'
   | 'displayValue'
@@ -905,6 +906,7 @@ let Input = forwardRefWithAs(function Input<
       data.activeOptionIndex === null ? undefined : data.options[data.activeOptionIndex]?.id,
     'aria-multiselectable': data.mode === ValueMode.Multi ? true : undefined,
     'aria-labelledby': labelledby,
+    'aria-autocomplete': 'list',
     defaultValue:
       props.defaultValue ??
       (data.defaultValue !== undefined

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -742,6 +742,37 @@ let Input = forwardRefWithAs(function Input<
     [currentDisplayValue, data.comboboxState]
   )
 
+  // Trick VoiceOver in behaving a little bit better. Manually "resetting" the input makes VoiceOver
+  // a bit more happy and doesn't require some changes manually first before announcing items
+  // correctly. This is a bit of a hacks, but it is a workaround for a VoiceOver bug.
+  //
+  // TODO: VoiceOver is still relatively buggy if you start VoiceOver while the Combobox is already
+  // in an open state.
+  useWatch(
+    ([newState], [oldState]) => {
+      if (newState === ComboboxState.Open && oldState === ComboboxState.Closed) {
+        let input = data.inputRef.current
+        if (!input) return
+
+        // Capture current state
+        let currentValue = input.value
+        let { selectionStart, selectionEnd, selectionDirection } = input
+
+        // Trick VoiceOver into announcing the value
+        input.value = ''
+
+        // Rollback to original state
+        input.value = currentValue
+        if (selectionDirection !== null) {
+          input.setSelectionRange(selectionStart, selectionEnd, selectionDirection)
+        } else {
+          input.setSelectionRange(selectionStart, selectionEnd)
+        }
+      }
+    },
+    [data.comboboxState]
+  )
+
   let isComposing = useRef(false)
   let handleCompositionStart = useEvent(() => {
     isComposing.current = true

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix arrow key handling in `Tab` (after DOM order changes) ([#2145](https://github.com/tailwindlabs/headlessui/pull/2145))
 - Fix `Tab` key with non focusable elements in `Popover.Panel` ([#2147](https://github.com/tailwindlabs/headlessui/pull/2147))
 - Don’t overwrite classes during SSR when rendering fragments ([#2173](https://github.com/tailwindlabs/headlessui/pull/2173))
+- Improve `Combobox` accessibility ([#2153](https://github.com/tailwindlabs/headlessui/pull/2153))
 
 ## [1.7.7] - 2022-12-16
 

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -712,6 +712,35 @@ export let ComboboxInput = defineComponent({
         },
         { immediate: true }
       )
+
+      // Trick VoiceOver in behaving a little bit better. Manually "resetting" the input makes
+      // VoiceOver a bit more happy and doesn't require some changes manually first before
+      // announcing items correctly. This is a bit of a hacks, but it is a workaround for a
+      // VoiceOver bug.
+      //
+      // TODO: VoiceOver is still relatively buggy if you start VoiceOver while the Combobox is
+      // already in an open state.
+      watch([api.comboboxState], ([newState], [oldState]) => {
+        if (newState === ComboboxStates.Open && oldState === ComboboxStates.Closed) {
+          let input = dom(api.inputRef)
+          if (!input) return
+
+          // Capture current state
+          let currentValue = input.value
+          let { selectionStart, selectionEnd, selectionDirection } = input
+
+          // Trick VoiceOver into announcing the value
+          input.value = ''
+
+          // Rollback to original state
+          input.value = currentValue
+          if (selectionDirection !== null) {
+            input.setSelectionRange(selectionStart, selectionEnd, selectionDirection)
+          } else {
+            input.setSelectionRange(selectionStart, selectionEnd)
+          }
+        }
+      })
     })
 
     let isComposing = ref(false)

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -880,6 +880,7 @@ export let ComboboxInput = defineComponent({
             : api.options.value[api.activeOptionIndex.value]?.id,
         'aria-multiselectable': api.mode.value === ValueMode.Multi ? true : undefined,
         'aria-labelledby': dom(api.labelRef)?.id ?? dom(api.buttonRef)?.id,
+        'aria-autocomplete': 'list',
         id,
         onCompositionstart: handleCompositionstart,
         onCompositionend: handleCompositionend,

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -957,10 +957,6 @@ export let ComboboxOptions = defineComponent({
     return () => {
       let slot = { open: api.comboboxState.value === ComboboxStates.Open }
       let ourProps = {
-        'aria-activedescendant':
-          api.activeOptionIndex.value === null
-            ? undefined
-            : api.options.value[api.activeOptionIndex.value]?.id,
         'aria-labelledby': dom(api.labelRef)?.id ?? dom(api.buttonRef)?.id,
         id,
         ref: api.optionsRef,


### PR DESCRIPTION
This PR improves the Combobox because there are some differences compared to the Listbox that we didn't properly account for.

Big thanks to @afercia for providing us with a wonderful issue report that talks about the differences.


Edit (24/01/2023): Going to merge this PR with partial fixes but not _everything_. This PR will fix the following items:
- Add the missing `aria-autocomplete` attributes
- Remove the unnecessary `aria-activedescendant` on the `Combobox.Options` (it is only required on the `Combobox.Input`) 
- Implement a fix to improve Safari & VoiceOver combination, where opening the Combobox doesn't always trigger VoiceOver properly. This PR will that.

For the `aria-selected` prop it is a bit confusing to apply it based on the `visual` state only which means that there is no difference between a checked active value and a non-checked active value. I also created a table below with odd findings...

We will tackle this in a different PR. But want to merge these changes/fixes already.

---

This commit fixes a few issues:

- The `aria-selected` value was always based on the `selected` value (which is correct for the `Listbox`) but it should be based on the visually selected value (in our case, this is the `active` value).
- We dropped an incorrect `aria-activedescendant` attribute from the `ComboboxOptions`, it should only exist on the `ComboboxInput`.
- We added a missing `aria-autocomplete` to the `ComboboxInput`, with a value of `list` so that assistive technology better understands what kind of Combobox we are dealing with.
- This also includes a VoiceOver bug fix where the announcements aren't properly happening unless a change to the `ComboboxInput` is made. Now we will trigger a change to the input when we open the `Combobox`, we will set the value to `''` and re-set to whatever value was present. We also make sure that the cursor position / selected range is reset so that the end user doesn't feel any differences (except for a better working VoiceOver on macOS).

---

Some additional findings:

I also think that this is impossible to get right, so we have to chose the "best" way we think. Should we start announcing these changes in state manually instead of relying on on VoiceOver? 🤔

Some fun differences between macOS Safari + VoiceOver and macOS Chrome + VoiceOver:

So while using the `active` state for `aria-selected` gives you at least consistent announcements, it also means that there is no way to differentiate between `selected` and `active`.

### Single Value Mode

| Scenario                                                  | Implementation                               | Chrome Result                                                                           | Expected? | Safari Result                                                                                                       | Expected? |
| :-------------------------------------------------------- | :------------------------------------------- | :-------------------------------------------------------------------------------------- | :-------: | :------------------------------------------------------------------------------------------------------------------ | :-------: |
| Use `aria-selected` based on the _visual_ selected value. | `aria-selected: active ? true : undefined`   | Reads out every single value as "selected".                                             |    ❌     | Reads out every single value as "selected".                                                                         |    ❌     |
| &nbsp;                                                    | `aria-selected: active`                      | Reads out every single value as "selected".                                             |    ❌     | Reads out every single value as "selected".                                                                         |    ❌     |
| Use `aria-selected` based on the _actual_ selected value. | `aria-selected: selected ? true : undefined` | Reads out every single value as "selected".                                             |    ❌     | Reads out every single value as "selected", but stops announcing values listed **after** the actual selected value. |    ❌     |
| &nbsp;                                                    | `aria-selected: selected`                    | Reads out every single value as "not selected", except for the _actual_ selected value. |    ✅     | Reads out every single value as "selected", but stops announcing values listed **after** the actual selected value. |    ❌     |
| Use `aria-checked` based on the _visual_ selected value.  | `aria-checked: active ? true : undefined`    | Reads out every single value as "selected".                                             |    ❌     | Reads out every single value as "selected".                                                                         |    ❌     |
| &nbsp;                                                    | `aria-checked: active`                       | Reads out every single value as "selected".                                             |    ❌     | Reads out every single value as "selected".                                                                         |    ❌     |
| Use `aria-checked` based on the _actual_ selected value.  | `aria-checked: selected ? true : undefined`  | Reads out every single value as "selected".                                             |    ❌     | Reads out every single value as "selected".                                                                         |    ❌     |
| &nbsp;                                                    | `aria-selected: selected`                    | Reads out every single value as "selected".                                             |    ❌     | Reads out every single value as "selected".                                                                         |    ❌     |

### Multi Value Mode

| Scenario                                                  | Implementation                               | Chrome Result                                                                            | Expected? | Safari Result                                                                                                                                                                                                       | Expected? |
| :-------------------------------------------------------- | :------------------------------------------- | :--------------------------------------------------------------------------------------- | :-------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :-------: |
| Use `aria-selected` based on the _visual_ selected value. | `aria-selected: active ? true : undefined`   | Reads out every single value as "selected".                                              |    ❌     | Initially doesn't read out anything, but if you type something and undo that, then it reads out every single value as "selected".                                                                                   |    ❌     |
| &nbsp;                                                    | `aria-selected: active`                      | Reads out every single value as "selected".                                              |    ❌     | Initially doesn't read out anything, but if you type something and undo that, then it reads out every single value as "selected".                                                                                   |    ❌     |
| Use `aria-selected` based on the _actual_ selected value. | `aria-selected: selected ? true : undefined` | Reads out every single value as "selected".                                              |    ❌     | Initially doesn't read out anything, but if you type something and undo that, then it reads out every single value as "selected", but stops announcing values listed **after** the **first** actual selected value. |    ❌     |
| &nbsp;                                                    | `aria-selected: selected`                    | Reads out every single value as "not selected", except for the _actual_ selected values. |    ✅     | Initially doesn't read out anything, but if you type something and undo that, then it reads out every single value as "selected", but stops announcing values listed **after** the **first** actual selected value. |    ❌     |
| Use `aria-checked` based on the _visual_ selected value.  | `aria-checked: active ? true : undefined`    | Reads out every single value as "selected".                                              |    ❌     | Initially doesn't read out anything, but if you type something and undo that, then it reads out every single value as "selected".                                                                                   |    ❌     |
| &nbsp;                                                    | `aria-checked: active`                       | Reads out every single value as "selected".                                              |    ❌     | Initially doesn't read out anything, but if you type something and undo that, then it reads out every single value as "selected".                                                                                   |    ❌     |
| Use `aria-checked` based on the _actual_ selected value.  | `aria-checked: selected ? true : undefined`  | Reads out every single value as "selected".                                              |    ❌     | Initially doesn't read out anything, but if you type something and undo that, then it reads out every single value as "selected".                                                                                   |    ❌     |
| &nbsp;                                                    | `aria-selected: selected`                    | Reads out every single value as "selected".                                              |    ❌     | Initially doesn't read out anything, but if you type something and undo that, then it reads out every single value as "selected".                                                                                   |    ❌     |

Fixes: #2129
Co-authored-by: Andrea Fercia <a.fercia@gmail.com>
