### PR TITLE
Fix false positive warning when using `<Popover.Button />` in React 17

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix arrow key handling in `Tab` (after DOM order changes) ([#2145](https://github.com/tailwindlabs/headlessui/pull/2145))
 - Fix false positive warning about using multiple `<Popover.Button>` components ([#2146](https://github.com/tailwindlabs/headlessui/pull/2146))
 - Fix `Tab` key with non focusable elements in `Popover.Panel` ([#2147](https://github.com/tailwindlabs/headlessui/pull/2147))
+- Fix false positive warning when using `<Popover.Button />` in React 17 ([#2163](https://github.com/tailwindlabs/headlessui/pull/2163))
 
 ## [1.7.7] - 2022-12-16
 


### PR DESCRIPTION
This PR fixes a false positive in the `Popover.Button` warning in React 17 due to the suboptimal `useId` hook implementation we have as a fallback for the real `useId` hook.

It replaces the `useId` result with a symbol just for tracking the `Popover.Button`. This value doesn't change over time (whereas the `useId` value is patched after the first render, resulting in incorrect values).

Fixes: #2154

