### PR TITLE
Fix `failed to removeChild on Node` bug

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix false positive warning about using multiple `<Popover.Button>` components ([#2146](https://github.com/tailwindlabs/headlessui/pull/2146))
 - Fix `Tab` key with non focusable elements in `Popover.Panel` ([#2147](https://github.com/tailwindlabs/headlessui/pull/2147))
 - Fix false positive warning when using `<Popover.Button />` in React 17 ([#2163](https://github.com/tailwindlabs/headlessui/pull/2163))
+- Fix `failed to removeChild on Node` bug ([#2164](https://github.com/tailwindlabs/headlessui/pull/2164))
 
 ## [1.7.7] - 2022-12-16
 

--- a/packages/@headlessui-react/src/components/portal/portal.tsx
+++ b/packages/@headlessui-react/src/components/portal/portal.tsx
@@ -107,7 +107,9 @@ let PortalRoot = forwardRefWithAs(function Portal<
         if (!trulyUnmounted.current) return
         if (!target || !element) return
 
-        target.removeChild(element)
+        if (element instanceof Node && target.contains(element)) {
+          target.removeChild(element)
+        }
 
         if (target.childNodes.length <= 0) {
           target.parentElement?.removeChild(target)


### PR DESCRIPTION
This PR fixes a crash when calling `removeChild` with a value other than a `Node`.

Fixes: #2151
