### PR TITLE
Improve `Tabs` wrapping around when controlling the component and overflowing the `selectedIndex`

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve `Combobox` accessibility ([#2153](https://github.com/tailwindlabs/headlessui/pull/2153))
 - Fix crash when reading `headlessuiFocusGuard` of `relatedTarget` in the `FocusTrap` component ([#2203](https://github.com/tailwindlabs/headlessui/pull/2203))
 - Fix `FocusTrap` in `Dialog` when there is only 1 focusable element ([#2172](https://github.com/tailwindlabs/headlessui/pull/2172))
+- Improve `Tabs` wrapping around when controlling the component and overflowing the `selectedIndex` ([#2213](https://github.com/tailwindlabs/headlessui/pull/2213))
 
 ## [1.7.7] - 2022-12-16
 

--- a/packages/@headlessui-react/src/components/tabs/tabs.test.tsx
+++ b/packages/@headlessui-react/src/components/tabs/tabs.test.tsx
@@ -1083,6 +1083,94 @@ describe('Rendering', () => {
         assertActiveElement(getByText('Tab 1'))
       })
     )
+
+    it(
+      'should wrap around when overflowing the index when using a controlled component',
+      suppressConsoleLogs(async () => {
+        function Example() {
+          let [selectedIndex, setSelectedIndex] = useState(0)
+
+          return (
+            <Tab.Group selectedIndex={selectedIndex} onChange={setSelectedIndex}>
+              {({ selectedIndex }) => (
+                <>
+                  <Tab.List>
+                    <Tab>Tab 1</Tab>
+                    <Tab>Tab 2</Tab>
+                    <Tab>Tab 3</Tab>
+                  </Tab.List>
+                  <Tab.Panels>
+                    <Tab.Panel>Content 1</Tab.Panel>
+                    <Tab.Panel>Content 2</Tab.Panel>
+                    <Tab.Panel>Content 3</Tab.Panel>
+                  </Tab.Panels>
+                  <button onClick={() => setSelectedIndex(selectedIndex + 1)}>Next</button>
+                </>
+              )}
+            </Tab.Group>
+          )
+        }
+        render(<Example />)
+
+        assertActiveElement(document.body)
+
+        await click(getByText('Next'))
+        assertTabs({ active: 1 })
+
+        await click(getByText('Next'))
+        assertTabs({ active: 2 })
+
+        await click(getByText('Next'))
+        assertTabs({ active: 0 })
+
+        await click(getByText('Next'))
+        assertTabs({ active: 1 })
+      })
+    )
+
+    it(
+      'should wrap around when underflowing the index when using a controlled component',
+      suppressConsoleLogs(async () => {
+        function Example() {
+          let [selectedIndex, setSelectedIndex] = useState(0)
+
+          return (
+            <Tab.Group selectedIndex={selectedIndex} onChange={setSelectedIndex}>
+              {({ selectedIndex }) => (
+                <>
+                  <Tab.List>
+                    <Tab>Tab 1</Tab>
+                    <Tab>Tab 2</Tab>
+                    <Tab>Tab 3</Tab>
+                  </Tab.List>
+                  <Tab.Panels>
+                    <Tab.Panel>Content 1</Tab.Panel>
+                    <Tab.Panel>Content 2</Tab.Panel>
+                    <Tab.Panel>Content 3</Tab.Panel>
+                  </Tab.Panels>
+                  <button onClick={() => setSelectedIndex(selectedIndex - 1)}>Previous</button>
+                </>
+              )}
+            </Tab.Group>
+          )
+        }
+        render(<Example />)
+
+        assertActiveElement(document.body)
+
+        await click(getByText('Previous'))
+        assertTabs({ active: 2 })
+
+        await click(getByText('Previous'))
+        assertTabs({ active: 1 })
+
+        await click(getByText('Previous'))
+        assertTabs({ active: 0 })
+
+        await click(getByText('Previous'))
+        assertTabs({ active: 2 })
+      })
+    )
   })
 
   describe(`'Tab'`, () => {

--- a/packages/@headlessui-react/src/components/tabs/tabs.test.tsx
+++ b/packages/@headlessui-react/src/components/tabs/tabs.test.tsx
@@ -179,7 +179,6 @@ describe('Rendering', () => {
             <button
               onClick={() => {
                 setTabs((tabs) => tabs.slice().reverse())
-                setSelectedIndex((idx) => tabs.length - 1 - idx)
               }}
             >
               reverse

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve `Combobox` accessibility ([#2153](https://github.com/tailwindlabs/headlessui/pull/2153))
 - Fix crash when reading `headlessuiFocusGuard` of `relatedTarget` in the `FocusTrap` component ([#2203](https://github.com/tailwindlabs/headlessui/pull/2203))
 - Fix `FocusTrap` in `Dialog` when there is only 1 focusable element ([#2172](https://github.com/tailwindlabs/headlessui/pull/2172))
+- Improve `Tabs` wrapping around when controlling the component and overflowing the `selectedIndex` ([#2213](https://github.com/tailwindlabs/headlessui/pull/2213))
 
 ## [1.7.7] - 2022-12-16
 

--- a/packages/@headlessui-vue/src/components/tabs/tabs.test.ts
+++ b/packages/@headlessui-vue/src/components/tabs/tabs.test.ts
@@ -999,6 +999,106 @@ describe('`selectedIndex`', () => {
     assertTabs({ active: 0 })
     assertActiveElement(getByText('Tab 1'))
   })
+
+  it(
+    'should wrap around when overflowing the index when using a controlled component',
+    suppressConsoleLogs(async () => {
+      renderTemplate({
+        template: html`
+          <TabGroup :selectedIndex="value" @change="set" v-slot="{ selectedIndex }">
+            <TabList>
+              <Tab>Tab 1</Tab>
+              <Tab>Tab 2</Tab>
+              <Tab>Tab 3</Tab>
+            </TabList>
+
+            <TabPanels>
+              <TabPanel>Content 1</TabPanel>
+              <TabPanel>Content 2</TabPanel>
+              <TabPanel>Content 3</TabPanel>
+            </TabPanels>
+
+            <button @click="set(selectedIndex + 1)">Next</button>
+          </TabGroup>
+        `,
+        setup() {
+          let value = ref(0)
+          return {
+            value,
+            set(v: number) {
+              value.value = v
+            },
+          }
+        },
+      })
+
+      await new Promise<void>(nextTick)
+
+      assertActiveElement(document.body)
+
+      await click(getByText('Next'))
+      assertTabs({ active: 1 })
+
+      await click(getByText('Next'))
+      assertTabs({ active: 2 })
+
+      await click(getByText('Next'))
+      assertTabs({ active: 0 })
+
+      await click(getByText('Next'))
+      assertTabs({ active: 1 })
+    })
+  )
+
+  it(
+    'should wrap around when underflowing the index when using a controlled component',
+    suppressConsoleLogs(async () => {
+      renderTemplate({
+        template: html`
+          <TabGroup :selectedIndex="value" @change="set" v-slot="{ selectedIndex }">
+            <TabList>
+              <Tab>Tab 1</Tab>
+              <Tab>Tab 2</Tab>
+              <Tab>Tab 3</Tab>
+            </TabList>
+
+            <TabPanels>
+              <TabPanel>Content 1</TabPanel>
+              <TabPanel>Content 2</TabPanel>
+              <TabPanel>Content 3</TabPanel>
+            </TabPanels>
+
+            <button @click="set(selectedIndex - 1)">Previous</button>
+          </TabGroup>
+        `,
+        setup() {
+          let value = ref(0)
+          return {
+            value,
+            set(v: number) {
+              value.value = v
+            },
+          }
+        },
+      })
+
+      await new Promise<void>(nextTick)
+
+      assertActiveElement(document.body)
+
+      await click(getByText('Previous'))
+      assertTabs({ active: 2 })
+
+      await click(getByText('Previous'))
+      assertTabs({ active: 1 })
+
+      await click(getByText('Previous'))
+      assertTabs({ active: 0 })
+
+      await click(getByText('Previous'))
+      assertTabs({ active: 2 })
+    })
+  )
 })
 
 describe('Keyboard interactions', () => {

--- a/packages/@headlessui-vue/src/components/tabs/tabs.test.ts
+++ b/packages/@headlessui-vue/src/components/tabs/tabs.test.ts
@@ -199,7 +199,6 @@ describe('Rendering', () => {
             selectedIndex,
             reverse() {
               tabs.value = tabs.value.slice().reverse()
-              selectedIndex.value = tabs.value.length - 1 - selectedIndex.value
             },
             handleChange(value: number) {
               selectedIndex.value = value


### PR DESCRIPTION
This PR ensures that underflowing or overflowing the `selectedIndex` always wraps around so that we
don't end up in a situation where the `selectedIndex` maps to _nothing_.

Fixes: #2211

