### PR TITLE
Allow setting `tabIndex` on the `Tab.Panel`

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix crash when reading `headlessuiFocusGuard` of `relatedTarget` in the `FocusTrap` component ([#2203](https://github.com/tailwindlabs/headlessui/pull/2203))
 - Fix `FocusTrap` in `Dialog` when there is only 1 focusable element ([#2172](https://github.com/tailwindlabs/headlessui/pull/2172))
 
+### Added
+
+- Allow setting `tabIndex` on the `Tab.Panel` ([#2214](https://github.com/tailwindlabs/headlessui/pull/2214))
+
 ## [1.7.7] - 2022-12-16
 
 ### Fixed

--- a/packages/@headlessui-react/src/components/tabs/tabs.tsx
+++ b/packages/@headlessui-react/src/components/tabs/tabs.tsx
@@ -495,7 +495,7 @@ let DEFAULT_PANEL_TAG = 'div' as const
 interface PanelRenderPropArg {
   selected: boolean
 }
-type PanelPropsWeControl = 'role' | 'aria-labelledby' | 'tabIndex'
+type PanelPropsWeControl = 'role' | 'aria-labelledby'
 let PanelRenderFeatures = Features.RenderStrategy | Features.Static
 
 let Panel = forwardRefWithAs(function Panel<TTag extends ElementType = typeof DEFAULT_PANEL_TAG>(
@@ -504,7 +504,7 @@ let Panel = forwardRefWithAs(function Panel<TTag extends ElementType = typeof DE
   ref: Ref<HTMLElement>
 ) {
   let internalId = useId()
-  let { id = `headlessui-tabs-panel-${internalId}`, ...theirProps } = props
+  let { id = `headlessui-tabs-panel-${internalId}`, tabIndex = 0, ...theirProps } = props
   let { selectedIndex, tabs, panels } = useData('Tab.Panel')
   let actions = useActions('Tab.Panel')
   let SSRContext = useSSRTabsCounter('Tab.Panel')
@@ -531,7 +531,7 @@ let Panel = forwardRefWithAs(function Panel<TTag extends ElementType = typeof DE
     id,
     role: 'tabpanel',
     'aria-labelledby': tabs[myIndex]?.current?.id,
-    tabIndex: selected ? 0 : -1,
+    tabIndex: selected ? tabIndex : -1,
   }
 
   if (!selected && (theirProps.unmount ?? true) && !(theirProps.static ?? false)) {

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix crash when reading `headlessuiFocusGuard` of `relatedTarget` in the `FocusTrap` component ([#2203](https://github.com/tailwindlabs/headlessui/pull/2203))
 - Fix `FocusTrap` in `Dialog` when there is only 1 focusable element ([#2172](https://github.com/tailwindlabs/headlessui/pull/2172))
 
+### Added
+
+- Allow setting `tabIndex` on the `Tab.Panel` ([#2214](https://github.com/tailwindlabs/headlessui/pull/2214))
+
 ## [1.7.7] - 2022-12-16
 
 ### Fixed

--- a/packages/@headlessui-vue/src/components/tabs/tabs.ts
+++ b/packages/@headlessui-vue/src/components/tabs/tabs.ts
@@ -431,6 +431,7 @@ export let TabPanel = defineComponent({
     static: { type: Boolean, default: false },
     unmount: { type: Boolean, default: true },
     id: { type: String, default: () => `headlessui-tabs-panel-${useId()}` },
+    tabIndex: { type: Number, default: 0 },
   },
   setup(props, { attrs, slots, expose }) {
     let api = useTabsContext('TabPanel')
@@ -462,13 +463,13 @@ export let TabPanel = defineComponent({
 
     return () => {
       let slot = { selected: selected.value }
-      let { id, ...theirProps } = props
+      let { id, tabIndex, ...theirProps } = props
       let ourProps = {
         ref: internalPanelRef,
         id,
         role: 'tabpanel',
         'aria-labelledby': dom(api.tabs.value[myIndex.value])?.id,
-        tabIndex: selected.value ? 0 : -1,
+        tabIndex: selected.value ? tabIndex : -1,
       }
 
       if (!selected.value && props.unmount && !props.static) {


### PR DESCRIPTION
This PR adds the ability to override the `tabIndex` of the `Tab.Panel`.

### The problem:

Right now the `Tab.Panel` will always be focusable this allows assistive technology to know that the moment you press <kbd>tab</kbd> that you are in a `tabpanel` container.

However, it can be that your `Tab.Panel` only consists of focusable elements (like links, buttons, ...), which means that you have to <kbd>tab</kbd> twice to get to the first focusable element. Sometimes you don't want this behaviour and just want to go straight to the first item, even if this means that we potentially skip elements (like paragraphs, images, ...).

### Potential solutions:

- Keep the current implementation, this will require you to <kbd>tab</kbd> twice. But assistive technology will still know the proper boundaries.
- Automatically focus the first focusable element if the `Tab.Panel` includes focusable elements and make the `Tab.Panel` itself have a `tabIndex=-1`. The downside here is that you potentially skip a lot of information (like paragraphs). This is what React Aria does (https://react-spectrum.adobe.com/react-aria/useTabList.html#focusable-content), but for us that will technically result in a breaking change.
- Allow to set the `tabIndex` and opt-in this behaviour and skip the focus of the `Tab.Panel` itself.

We currently implemented the 3rd option where it is opt-in using the `tabIndex` prop. This way you can technically break accessibility if you have important paragraphs before the first focusable element.

Resolves: #2110

