### PR TITLE
Fix `shadow-root` bug closing `Dialog` containers

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix crash when reading `headlessuiFocusGuard` of `relatedTarget` in the `FocusTrap` component ([#2203](https://github.com/tailwindlabs/headlessui/pull/2203))
 - Fix `FocusTrap` in `Dialog` when there is only 1 focusable element ([#2172](https://github.com/tailwindlabs/headlessui/pull/2172))
 - Improve `Tabs` wrapping around when controlling the component and overflowing the `selectedIndex` ([#2213](https://github.com/tailwindlabs/headlessui/pull/2213))
+- Fix `shadow-root` bug closing `Dialog` containers ([#2217](https://github.com/tailwindlabs/headlessui/pull/2217))
 
 ### Added
 

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -317,8 +317,10 @@ let DialogRoot = forwardRefWithAs(function Dialog<
   let resolveContainers = useEvent(() => {
     // Third party roots
     let rootContainers = Array.from(
-      ownerDocument?.querySelectorAll('body > *, [data-headlessui-portal]') ?? []
+      ownerDocument?.querySelectorAll('html > *, body > *, [data-headlessui-portal]') ?? []
     ).filter((container) => {
+      if (container === document.body) return false // Skip `<body>`
+      if (container === document.head) return false // Skip `<head>`
       if (!(container instanceof HTMLElement)) return false // Skip non-HTMLElements
       if (container.contains(mainTreeNode.current)) return false // Skip if it is the main app
       if (state.panelRef.current && container.contains(state.panelRef.current)) return false

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix crash when reading `headlessuiFocusGuard` of `relatedTarget` in the `FocusTrap` component ([#2203](https://github.com/tailwindlabs/headlessui/pull/2203))
 - Fix `FocusTrap` in `Dialog` when there is only 1 focusable element ([#2172](https://github.com/tailwindlabs/headlessui/pull/2172))
 - Improve `Tabs` wrapping around when controlling the component and overflowing the `selectedIndex` ([#2213](https://github.com/tailwindlabs/headlessui/pull/2213))
+- Fix `shadow-root` bug closing `Dialog` containers ([#2217](https://github.com/tailwindlabs/headlessui/pull/2217))
 
 ### Added
 

--- a/packages/@headlessui-vue/src/components/dialog/dialog.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.ts
@@ -186,8 +186,10 @@ export let Dialog = defineComponent({
     function resolveAllowedContainers() {
       // Third party roots
       let rootContainers = Array.from(
-        ownerDocument.value?.querySelectorAll('body > *, [data-headlessui-portal]') ?? []
+        ownerDocument.value?.querySelectorAll('html > *, body > *, [data-headlessui-portal]') ?? []
       ).filter((container) => {
+        if (container === document.body) return false // Skip `<body>`
+        if (container === document.head) return false // Skip `<head>`
         if (!(container instanceof HTMLElement)) return false // Skip non-HTMLElements
         if (container.contains(dom(mainTreeNode))) return false // Skip if it is the main app
         if (api.panelRef.value && container.contains(api.panelRef.value)) return false


### PR DESCRIPTION
We added better support for shadow roots being valid containers for the `Dialog` component in #2079. This means that if you have a 3rd party (or 1st party) tool that uses the shadow DOM, then the `Dialog` used to close when interacting with those items.

This was solved by @thecrypticace in the #2079 PR.

But I found that there is a bug here with one of these:

- Clicks from shadow roots inside the panel (keeps dialog open)
- Clicks from shadow roots outside the panel (closes the dialog)

There is an issue with the Grammarly extension that injects a shadow root component inside the `Dialog.Panel`. Yet, clicking on it closes the `Dialog`. This issue occurs on Campsite for example (by @brianlovin).

I can make it work by _always_ allowing shadow roots with (before checking all the allowed containers):
```js
// Ignore if the target is in a shadow root
if (target.getRootNode() !== document) return
```

The tree looks like this: 
<img width="771" alt="image" src="https://user-images.githubusercontent.com/1834413/215076887-b592f1f5-d887-473f-b74a-7437015746c8.png">

Looking at the `<grammarly-extensions>` if I log `$0.shadowRoot` I get the `Shadow Content (open)` log.

Looking at our check:
```js
console.log(event.composed, event.composedPath().includes(domNode as EventTarget))
```

It results in `true` and `false`. The last value being `false` is what breaks things and is the confusing part. It looks like the parent of the `<grammarly-extension>` is the `<grammarly-mirror>` and then immediately the `html` 
<img width="1224" alt="image" src="https://user-images.githubusercontent.com/1834413/215078046-6c0a5c8b-7568-4e2c-8de5-7768b4f3c0a2.png">

So we never saw the `Dialog.Panel` element and therefore closing the `Dialog`... 

Time to dig deeper!

Well it turns out that the bug is very stupid actually and the solution is luckily very simple. Grammarly doesn't inject its container in the `<body>` but as a sibling of `<body>` so we don't have any valid containers that contain this...
<img width="256" alt="image" src="https://user-images.githubusercontent.com/1834413/215078377-1c00babd-8997-49ee-b556-dcf73dad6df5.png">


So.. let's include `html > *` except for the `body` and `head` itself as valid containers and lo and behold: 
<img width="659" alt="image" src="https://user-images.githubusercontent.com/1834413/215079105-b328c1a3-1fdd-4c20-ad8f-20543e615325.png">

Fixes: https://github.com/tailwindlabs/headlessui/discussions/1832
