### PR TITLE
Fix SSR tab hydration when using Strict Mode in development

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Fix SSR tab hydration when using Strict Mode in development ([#2231](https://github.com/tailwindlabs/headlessui/pull/2231))
 
 ## [1.7.8] - 2023-01-27
 

--- a/packages/@headlessui-react/src/components/tabs/tabs.ssr.test.tsx
+++ b/packages/@headlessui-react/src/components/tabs/tabs.ssr.test.tsx
@@ -7,9 +7,13 @@ beforeAll(() => {
   jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(clearImmediate as any)
 })
 
-function Example({ defaultIndex = 0 }) {
+let spy: jest.SpyInstance<void, Parameters<typeof console.error>>
+beforeEach(() => (spy = jest.spyOn(console, 'error').mockImplementation(() => {})))
+afterEach(() => spy.mockRestore())
+
+function Example(props: { defaultIndex?: number; selectedIndex?: number }) {
   return (
-    <Tab.Group defaultIndex={defaultIndex}>
+    <Tab.Group {...props}>
       <Tab.List>
         <Tab>Tab 1</Tab>
         <Tab>Tab 2</Tab>
@@ -42,25 +46,70 @@ describe('Rendering', () => {
       expect(contents).toContain(`Content 2`)
       expect(contents).not.toContain(`Content 3`)
     })
-  })
 
-  // The hydration tests don't work in React 18 due to some bug in Testing Library maybe?
-  // Skipping for now
-  xdescribe('Hydration', () => {
-    it('should be possible to server side render the first Tab and Panel', async () => {
-      const { contents } = await renderHydrate(<Example />)
+    it('should be possible to server side render the selectedIndex=0 Tab and Panel', async () => {
+      let { contents } = await renderSSR(<Example selectedIndex={0} />)
 
       expect(contents).toContain(`Content 1`)
       expect(contents).not.toContain(`Content 2`)
       expect(contents).not.toContain(`Content 3`)
     })
 
-    it('should be possible to server side render the defaultIndex Tab and Panel', async () => {
-      const { contents } = await renderHydrate(<Example defaultIndex={1} />)
+    it('should be possible to server side render the selectedIndex=1 Tab and Panel', async () => {
+      let { contents } = await renderSSR(<Example selectedIndex={1} />)
 
       expect(contents).not.toContain(`Content 1`)
       expect(contents).toContain(`Content 2`)
       expect(contents).not.toContain(`Content 3`)
+    })
+  })
+
+  // The hydration tests don't work in React 18 due to some bug in Testing Library maybe?
+  // Skipping for now
+  describe.each([{ strict: true }, { strict: false }])('Hydration: %p', (opts) => {
+    it('should be possible to server side render the first Tab and Panel by default', async () => {
+      const { contents } = await renderHydrate(<Example />, opts)
+
+      expect(contents).toContain(`Content 1`)
+      expect(contents).not.toContain(`Content 2`)
+      expect(contents).not.toContain(`Content 3`)
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('should be possible to server side render the first Tab and Panel', async () => {
+      const { contents } = await renderHydrate(<Example defaultIndex={0} />, opts)
+
+      expect(contents).toContain(`Content 1`)
+      expect(contents).not.toContain(`Content 2`)
+      expect(contents).not.toContain(`Content 3`)
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('should be possible to server side render the defaultIndex Tab and Panel', async () => {
+      const { contents } = await renderHydrate(<Example defaultIndex={1} />, opts)
+
+      expect(contents).not.toContain(`Content 1`)
+      expect(contents).toContain(`Content 2`)
+      expect(contents).not.toContain(`Content 3`)
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('should be possible to server side render the selectedIndex=0 Tab and Panel', async () => {
+      let { contents } = await renderHydrate(<Example selectedIndex={0} />, opts)
+
+      expect(contents).toContain(`Content 1`)
+      expect(contents).not.toContain(`Content 2`)
+      expect(contents).not.toContain(`Content 3`)
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('should be possible to server side render the selectedIndex=1 Tab and Panel', async () => {
+      let { contents } = await renderHydrate(<Example selectedIndex={1} />, opts)
+
+      expect(contents).not.toContain(`Content 1`)
+      expect(contents).toContain(`Content 2`)
+      expect(contents).not.toContain(`Content 3`)
+      expect(spy).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/@headlessui-react/src/utils/stable-collection.tsx
+++ b/packages/@headlessui-react/src/utils/stable-collection.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react'
+
+type CollectionKey = string | symbol
+type CollectionItem = [number, () => void]
+type CollectionRef = React.MutableRefObject<ReturnType<typeof createCollection>>
+const StableCollectionContext = React.createContext<CollectionRef | null>(null)
+
+function createCollection() {
+  return {
+    /** @type {Map<string, Map<string, number>>} */
+    groups: new Map(),
+
+    get(group: string, key: CollectionKey): CollectionItem {
+      let list = this.groups.get(group)
+      if (!list) {
+        list = new Map()
+        this.groups.set(group, list)
+      }
+
+      let renders = list.get(key) ?? 0
+      list.set(key, renders + 1)
+
+      let index = Array.from(list.keys()).indexOf(key)
+      function release() {
+        let renders = list.get(key)
+        if (renders > 1) {
+          list.set(key, renders - 1)
+        } else {
+          list.delete(key)
+        }
+      }
+
+      return [index, release]
+    },
+  }
+}
+
+export function StableCollection({ children }: { children: React.ReactNode | React.ReactNode[] }) {
+  let collection = React.useRef(createCollection())
+
+  return (
+    <StableCollectionContext.Provider value={collection}>
+      {children}
+    </StableCollectionContext.Provider>
+  )
+}
+
+export function useStableCollectionIndex(group: string) {
+  let collection = React.useContext(StableCollectionContext)
+  if (!collection) throw new Error('You must wrap your component in a <StableCollection>')
+
+  let key = useStableCollectionKey()
+  let [idx, cleanupIdx] = collection.current.get(group, key)
+  React.useEffect(() => cleanupIdx, [])
+  return idx
+}
+
+/**
+ * Return a stable key based on the position of this node.
+ *
+ * @returns {symbol | string}
+ */
+function useStableCollectionKey() {
+  let owner =
+    // @ts-ignore
+    React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED?.ReactCurrentOwner?.current ?? null
+
+  // ssr: dev/prod
+  // client: prod
+  if (!owner) return Symbol()
+
+  // client: dev
+  let indexes = []
+  let fiber = owner
+  while (fiber) {
+    indexes.push(fiber.index)
+    fiber = fiber.return
+  }
+
+  return '$.' + indexes.join('.')
+}


### PR DESCRIPTION
Here I've reworked the tab and panel counting mechanism to:

1. Use `Symbol()` when internals aren't available (only in SSR and prod builds where double rendering does not happen)
2. Use a generated key based on the position of the Tab in the React Virtual DOM tree when internals are available. (In dev builds whether or not Strict Mode is enabled)

The reason for this is that React’s double rendering in strict mode in development makes SSR + hydration **impossible** without reaching into internals. We reference the current fiber, walk up the tree of fibers, use the position of each fiber in its list of siblings to generate the key, and then use that as a "stable" reference. It is unfortunate that we have to do this at all but React doesn't give us the ability to do this using public API. The choices you have are basically: 1. No SSR at all; 2. SSR + hydration mismatches; 3. Use internals

Fixes #2220