### PR TITLE
Start cleanup phase of the `Dialog` component when going into the `Closing` state

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Re-focus `Combobox.Input` when a `Combobox.Option` is selected ([#2272](https://github.com/tailwindlabs/headlessui/pull/2272))
 - Ensure we reset the `activeOptionIndex` if the active option is unmounted ([#2274](https://github.com/tailwindlabs/headlessui/pull/2274))
 - Improve Ref type for forwarded `Switch`'s ref ([#2277](https://github.com/tailwindlabs/headlessui/pull/2277))
+- Start cleanup phase of the Dialog component when going into the Closing state ([#2264](https://github.com/tailwindlabs/headlessui/pull/2264))
 
 ## [1.7.10] - 2023-02-06
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1174,7 +1174,7 @@ let Options = forwardRefWithAs(function Options<
   let usesOpenClosedState = useOpenClosed()
   let visible = (() => {
     if (usesOpenClosedState !== null) {
-      return usesOpenClosedState === State.Open
+      return (usesOpenClosedState & State.Open) === State.Open
     }
 
     return data.comboboxState === ComboboxState.Open

--- a/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from 'react-dom'
 import React, { createElement, useRef, useState, Fragment, useEffect, useCallback } from 'react'
 import { render } from '@testing-library/react'
 
@@ -24,7 +25,7 @@ import {
 import { click, mouseDrag, press, Keys, shift } from '../../test-utils/interactions'
 import { PropsOf } from '../../types'
 import { Transition } from '../transitions/transition'
-import { createPortal } from 'react-dom'
+import { OpenClosedProvider, State } from '../../internal/open-closed'
 
 jest.mock('../../hooks/use-id')
 
@@ -408,6 +409,34 @@ describe('Rendering', () => {
         // Close the dialog & dont expect overflow
         await click(close3())
         await frames(2)
+        expect(document.documentElement.style.overflow).toBe('')
+      })
+    )
+
+    it(
+      'should remove the scroll lock when the open closed state is `Closing`',
+      suppressConsoleLogs(async () => {
+        function Example({ value = State.Open }) {
+          return (
+            <OpenClosedProvider value={value}>
+              <Dialog open={true} onClose={() => {}}>
+                <input id="a" type="text" />
+                <input id="b" type="text" />
+                <input id="c" type="text" />
+              </Dialog>
+            </OpenClosedProvider>
+          )
+        }
+
+        let { rerender } = render(<Example value={State.Open} />)
+
+        // The overflow should be there
+        expect(document.documentElement.style.overflow).toBe('hidden')
+
+        // Re-render but with the `Closing` state
+        rerender(<Example value={State.Open | State.Closing} />)
+
+        // The moment the dialog is closing, the overflow should be gone
         expect(document.documentElement.style.overflow).toBe('')
       })
     )

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -140,10 +140,7 @@ let DialogRoot = forwardRefWithAs(function Dialog<
   let usesOpenClosedState = useOpenClosed()
   if (open === undefined && usesOpenClosedState !== null) {
     // Update the `open` prop based on the open closed state
-    open = match(usesOpenClosedState, {
-      [State.Open]: true,
-      [State.Closed]: false,
-    })
+    open = (usesOpenClosedState & State.Open) === State.Open
   }
 
   let containers = useRef<Set<MutableRefObject<HTMLElement | null>>>(new Set())

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -206,9 +206,18 @@ let DialogRoot = forwardRefWithAs(function Dialog<
   // in between. We only care abou whether you are the top most one or not.
   let position = !hasNestedDialogs ? 'leaf' : 'parent'
 
+  // When the `Dialog` is wrapped in a `Transition` (or another Headless UI component that exposes
+  // the OpenClosed state) then we get some information via context about its state. When the
+  // `Transition` is about to close, then the `State.Closing` state will be exposed. This allows us
+  // to enable/disable certain functionality in the `Dialog` upfront instead of waiting until the
+  // `Transition` is done transitioning.
+  let isClosing =
+    usesOpenClosedState !== null ? (usesOpenClosedState & State.Closing) === State.Closing : false
+
   // Ensure other elements can't be interacted with
   let inertOthersEnabled = (() => {
     if (!hasNestedDialogs) return false
+    if (isClosing) return false
     return enabled
   })()
   useInertOthers(internalDialogRef, inertOthersEnabled)
@@ -254,6 +263,7 @@ let DialogRoot = forwardRefWithAs(function Dialog<
 
   // Scroll lock
   let scrollLockEnabled = (() => {
+    if (isClosing) return false
     if (dialogState !== DialogStates.Open) return false
     if (hasParentDialog) return false
     return true

--- a/packages/@headlessui-react/src/components/disclosure/disclosure.tsx
+++ b/packages/@headlessui-react/src/components/disclosure/disclosure.tsx
@@ -375,7 +375,7 @@ let Panel = forwardRefWithAs(function Panel<TTag extends ElementType = typeof DE
   let usesOpenClosedState = useOpenClosed()
   let visible = (() => {
     if (usesOpenClosedState !== null) {
-      return usesOpenClosedState === State.Open
+      return (usesOpenClosedState & State.Open) === State.Open
     }
 
     return state.disclosureState === DisclosureStates.Open

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -756,7 +756,7 @@ let Options = forwardRefWithAs(function Options<
   let usesOpenClosedState = useOpenClosed()
   let visible = (() => {
     if (usesOpenClosedState !== null) {
-      return usesOpenClosedState === State.Open
+      return (usesOpenClosedState & State.Open) === State.Open
     }
 
     return data.listboxState === ListboxStates.Open

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -419,7 +419,7 @@ let Items = forwardRefWithAs(function Items<TTag extends ElementType = typeof DE
   let usesOpenClosedState = useOpenClosed()
   let visible = (() => {
     if (usesOpenClosedState !== null) {
-      return usesOpenClosedState === State.Open
+      return (usesOpenClosedState & State.Open) === State.Open
     }
 
     return state.menuState === MenuStates.Open

--- a/packages/@headlessui-react/src/components/popover/popover.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.tsx
@@ -616,7 +616,7 @@ let Overlay = forwardRefWithAs(function Overlay<
   let usesOpenClosedState = useOpenClosed()
   let visible = (() => {
     if (usesOpenClosedState !== null) {
-      return usesOpenClosedState === State.Open
+      return (usesOpenClosedState & State.Open) === State.Open
     }
 
     return popoverState === PopoverStates.Open
@@ -693,7 +693,7 @@ let Panel = forwardRefWithAs(function Panel<TTag extends ElementType = typeof DE
   let usesOpenClosedState = useOpenClosed()
   let visible = (() => {
     if (usesOpenClosedState !== null) {
-      return usesOpenClosedState === State.Open
+      return (usesOpenClosedState & State.Open) === State.Open
     }
 
     return state.popoverState === PopoverStates.Open

--- a/packages/@headlessui-react/src/components/transitions/transition.tsx
+++ b/packages/@headlessui-react/src/components/transitions/transition.tsx
@@ -457,10 +457,7 @@ let TransitionRoot = forwardRefWithAs(function Transition<
   let usesOpenClosedState = useOpenClosed()
 
   if (show === undefined && usesOpenClosedState !== null) {
-    show = match(usesOpenClosedState, {
-      [State.Open]: true,
-      [State.Closed]: false,
-    })
+    show = (usesOpenClosedState & State.Open) === State.Open
   }
 
   if (![true, false].includes(show as unknown as boolean)) {

--- a/packages/@headlessui-react/src/components/transitions/transition.tsx
+++ b/packages/@headlessui-react/src/components/transitions/transition.tsx
@@ -32,6 +32,7 @@ import { useEvent } from '../../hooks/use-event'
 import { useDisposables } from '../../hooks/use-disposables'
 import { classNames } from '../../utils/class-names'
 import { env } from '../../utils/env'
+import { useFlags } from '../../hooks/use-flags'
 
 type ContainerElement = MutableRefObject<HTMLElement | null>
 
@@ -359,18 +360,32 @@ let TransitionChild = forwardRefWithAs(function TransitionChild<
     return show ? 'enter' : 'leave'
   })() as TransitionDirection
 
+  let transitionStateFlags = useFlags(0)
+
   let beforeEvent = useEvent((direction: TransitionDirection) => {
     return match(direction, {
-      enter: () => events.current.beforeEnter(),
-      leave: () => events.current.beforeLeave(),
+      enter: () => {
+        transitionStateFlags.addFlag(State.Opening)
+        events.current.beforeEnter()
+      },
+      leave: () => {
+        transitionStateFlags.addFlag(State.Closing)
+        events.current.beforeLeave()
+      },
       idle: () => {},
     })
   })
 
   let afterEvent = useEvent((direction: TransitionDirection) => {
     return match(direction, {
-      enter: () => events.current.afterEnter(),
-      leave: () => events.current.afterLeave(),
+      enter: () => {
+        transitionStateFlags.removeFlag(State.Opening)
+        events.current.afterEnter()
+      },
+      leave: () => {
+        transitionStateFlags.removeFlag(State.Closing)
+        events.current.afterLeave()
+      },
       idle: () => {},
     })
   })
@@ -425,10 +440,12 @@ let TransitionChild = forwardRefWithAs(function TransitionChild<
   return (
     <NestingContext.Provider value={nesting}>
       <OpenClosedProvider
-        value={match(state, {
-          [TreeStates.Visible]: State.Open,
-          [TreeStates.Hidden]: State.Closed,
-        })}
+        value={
+          match(state, {
+            [TreeStates.Visible]: State.Open,
+            [TreeStates.Hidden]: State.Closed,
+          }) | transitionStateFlags.flags
+        }
       >
         {render({
           ourProps,

--- a/packages/@headlessui-react/src/hooks/use-flags.ts
+++ b/packages/@headlessui-react/src/hooks/use-flags.ts
@@ -8,5 +8,5 @@ export function useFlags(initialFlags = 0) {
   let removeFlag = useCallback((flag: number) => setFlags((flags) => flags & ~flag), [setFlags])
   let toggleFlag = useCallback((flag: number) => setFlags((flags) => flags ^ flag), [setFlags])
 
-  return { addFlag, hasFlag, removeFlag, toggleFlag }
+  return { flags, addFlag, hasFlag, removeFlag, toggleFlag }
 }

--- a/packages/@headlessui-react/src/internal/open-closed.tsx
+++ b/packages/@headlessui-react/src/internal/open-closed.tsx
@@ -11,8 +11,10 @@ let Context = createContext<State | null>(null)
 Context.displayName = 'OpenClosedContext'
 
 export enum State {
-  Open,
-  Closed,
+  Open = 1 << 0,
+  Closed = 1 << 1,
+  Closing = 1 << 2,
+  Opening = 1 << 3,
 }
 
 export function useOpenClosed() {

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move `aria-multiselectable` to `[role=listbox]` in the `Combobox` component ([#2271](https://github.com/tailwindlabs/headlessui/pull/2271))
 - Re-focus `Combobox.Input` when a `Combobox.Option` is selected ([#2272](https://github.com/tailwindlabs/headlessui/pull/2272))
 - Ensure we reset the `activeOptionIndex` if the active option is unmounted ([#2274](https://github.com/tailwindlabs/headlessui/pull/2274))
+- Start cleanup phase of the Dialog component when going into the Closing state ([#2264](https://github.com/tailwindlabs/headlessui/pull/2264))
 
 ## [1.7.9] - 2023-02-03
 

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -980,7 +980,7 @@ export let ComboboxOptions = defineComponent({
     let usesOpenClosedState = useOpenClosed()
     let visible = computed(() => {
       if (usesOpenClosedState !== null) {
-        return usesOpenClosedState.value === State.Open
+        return (usesOpenClosedState.value & State.Open) === State.Open
       }
 
       return api.comboboxState.value === ComboboxStates.Open

--- a/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
@@ -8,7 +8,7 @@ import {
   PropType,
   computed,
 } from 'vue'
-import { createRenderTemplate, render, screen } from '../../test-utils/vue-testing-library'
+import { createRenderTemplate, render } from '../../test-utils/vue-testing-library'
 
 import {
   Dialog,

--- a/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
@@ -41,6 +41,7 @@ import {
 } from '../../test-utils/accessibility-assertions'
 import { click, mouseDrag, press, Keys, shift } from '../../test-utils/interactions'
 import { html } from '../../test-utils/html'
+import { useOpenClosedProvider, State } from '../../internal/open-closed'
 
 // @ts-expect-error
 global.IntersectionObserver = class FakeIntersectionObserver {
@@ -542,6 +543,75 @@ describe('Rendering', () => {
         await click(close3())
         await frames(2)
 
+        expect(document.documentElement.style.overflow).toBe('')
+      })
+    )
+
+    it(
+      'should remove the scroll lock when the open closed state is `Closing`',
+      suppressConsoleLogs(async () => {
+        let Wrapper = defineComponent({
+          props: {
+            state: {
+              type: Number as PropType<State>,
+              default: State.Open,
+            },
+          },
+          setup(props, { slots }) {
+            useOpenClosedProvider(ref(props.state))
+            return () => h('div', {}, slots.default?.())
+          },
+        })
+
+        let x = renderTemplate({
+          components: {
+            Dialog,
+            Wrapper,
+          },
+          template: `
+            <Wrapper :state="state">
+              <Dialog :open="true" @close="() => {}">
+                <input id="a" type="text" />
+                <input id="b" type="text" />
+                <input id="c" type="text" />
+              </Dialog>
+            </Wrapper>
+          `,
+
+          setup: () => ({ state: State.Open }),
+        })
+
+        await nextFrame()
+
+        // The overflow should be there
+        expect(document.documentElement.style.overflow).toBe('hidden')
+
+        // Reset the document
+        x.unmount()
+        await nextFrame()
+
+        // Re-render but with the `Closing` state
+        renderTemplate({
+          components: {
+            Dialog,
+            Wrapper,
+          },
+          template: `
+            <Wrapper :state="state">
+              <Dialog :open="true" @close="() => {}">
+                <input id="a" type="text" />
+                <input id="b" type="text" />
+                <input id="c" type="text" />
+              </Dialog>
+            </Wrapper>
+          `,
+
+          setup: () => ({ state: State.Open | State.Closing }),
+        })
+
+        await nextFrame()
+
+        // The moment the dialog is closing, the overflow should be gone
         expect(document.documentElement.style.overflow).toBe('')
       })
     )

--- a/packages/@headlessui-vue/src/components/dialog/dialog.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.ts
@@ -91,11 +91,7 @@ export let Dialog = defineComponent({
     let usesOpenClosedState = useOpenClosed()
     let open = computed(() => {
       if (props.open === Missing && usesOpenClosedState !== null) {
-        // Update the `open` prop based on the open closed state
-        return match(usesOpenClosedState.value, {
-          [State.Open]: true,
-          [State.Closed]: false,
-        })
+        return (usesOpenClosedState.value & State.Open) === State.Open
       }
       return props.open
     })

--- a/packages/@headlessui-vue/src/components/dialog/dialog.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.ts
@@ -34,7 +34,6 @@ import { getOwnerDocument } from '../../utils/owner'
 import { useEventListener } from '../../hooks/use-event-listener'
 import { Hidden, Features as HiddenFeatures } from '../../internal/hidden'
 import { useDocumentOverflowLockedEffect } from '../../hooks/document-overflow/use-document-overflow'
-import { handleIOSLocking } from '../../hooks/document-overflow/handle-ios-locking'
 
 enum DialogStates {
   Open,

--- a/packages/@headlessui-vue/src/components/disclosure/disclosure.ts
+++ b/packages/@headlessui-vue/src/components/disclosure/disclosure.ts
@@ -278,7 +278,7 @@ export let DisclosurePanel = defineComponent({
     let usesOpenClosedState = useOpenClosed()
     let visible = computed(() => {
       if (usesOpenClosedState !== null) {
-        return usesOpenClosedState.value === State.Open
+        return (usesOpenClosedState.value & State.Open) === State.Open
       }
 
       return api.disclosureState.value === DisclosureStates.Open

--- a/packages/@headlessui-vue/src/components/listbox/listbox.ts
+++ b/packages/@headlessui-vue/src/components/listbox/listbox.ts
@@ -643,7 +643,7 @@ export let ListboxOptions = defineComponent({
     let usesOpenClosedState = useOpenClosed()
     let visible = computed(() => {
       if (usesOpenClosedState !== null) {
-        return usesOpenClosedState.value === State.Open
+        return (usesOpenClosedState.value & State.Open) === State.Open
       }
 
       return api.listboxState.value === ListboxStates.Open

--- a/packages/@headlessui-vue/src/components/menu/menu.ts
+++ b/packages/@headlessui-vue/src/components/menu/menu.ts
@@ -454,7 +454,7 @@ export let MenuItems = defineComponent({
     let usesOpenClosedState = useOpenClosed()
     let visible = computed(() => {
       if (usesOpenClosedState !== null) {
-        return usesOpenClosedState.value === State.Open
+        return (usesOpenClosedState.value & State.Open) === State.Open
       }
 
       return api.menuState.value === MenuStates.Open

--- a/packages/@headlessui-vue/src/components/popover/popover.ts
+++ b/packages/@headlessui-vue/src/components/popover/popover.ts
@@ -473,7 +473,7 @@ export let PopoverOverlay = defineComponent({
     let usesOpenClosedState = useOpenClosed()
     let visible = computed(() => {
       if (usesOpenClosedState !== null) {
-        return usesOpenClosedState.value === State.Open
+        return (usesOpenClosedState.value & State.Open) === State.Open
       }
 
       return api.popoverState.value === PopoverStates.Open
@@ -551,7 +551,7 @@ export let PopoverPanel = defineComponent({
     let usesOpenClosedState = useOpenClosed()
     let visible = computed(() => {
       if (usesOpenClosedState !== null) {
-        return usesOpenClosedState.value === State.Open
+        return (usesOpenClosedState.value & State.Open) === State.Open
       }
 
       return api.popoverState.value === PopoverStates.Open

--- a/packages/@headlessui-vue/src/components/transitions/transition.ts
+++ b/packages/@headlessui-vue/src/components/transitions/transition.ts
@@ -155,16 +155,38 @@ export let TransitionChild = defineComponent({
     afterLeave: () => true,
   },
   setup(props, { emit, attrs, slots, expose }) {
+    let transitionStateFlags = ref(0)
+
+    function beforeEnter() {
+      transitionStateFlags.value |= State.Opening
+      emit('beforeEnter')
+    }
+
+    function afterEnter() {
+      transitionStateFlags.value &= ~State.Opening
+      emit('afterEnter')
+    }
+
+    function beforeLeave() {
+      transitionStateFlags.value |= State.Closing
+      emit('beforeLeave')
+    }
+
+    function afterLeave() {
+      transitionStateFlags.value &= ~State.Closing
+      emit('afterLeave')
+    }
+
     if (!hasTransitionContext() && hasOpenClosed()) {
       return () =>
         h(
           TransitionRoot,
           {
             ...props,
-            onBeforeEnter: () => emit('beforeEnter'),
-            onAfterEnter: () => emit('afterEnter'),
-            onBeforeLeave: () => emit('beforeLeave'),
-            onAfterLeave: () => emit('afterLeave'),
+            onBeforeEnter: beforeEnter,
+            onAfterEnter: afterEnter,
+            onBeforeLeave: beforeLeave,
+            onAfterLeave: afterLeave,
           },
           slots
         )
@@ -191,7 +213,7 @@ export let TransitionChild = defineComponent({
       if (!isTransitioning.value && state.value !== TreeStates.Hidden) {
         state.value = TreeStates.Hidden
         unregister(id)
-        emit('afterLeave')
+        afterLeave()
       }
     })
 
@@ -252,8 +274,8 @@ export let TransitionChild = defineComponent({
 
       isTransitioning.value = true
 
-      if (show.value) emit('beforeEnter')
-      if (!show.value) emit('beforeLeave')
+      if (show.value) beforeEnter()
+      if (!show.value) beforeLeave()
 
       onInvalidate(
         show.value
@@ -265,7 +287,7 @@ export let TransitionChild = defineComponent({
               enteredClasses,
               (reason) => {
                 isTransitioning.value = false
-                if (reason === Reason.Finished) emit('afterEnter')
+                if (reason === Reason.Finished) afterEnter()
               }
             )
           : transition(
@@ -284,7 +306,7 @@ export let TransitionChild = defineComponent({
                 if (!hasChildren(nesting)) {
                   state.value = TreeStates.Hidden
                   unregister(id)
-                  emit('afterLeave')
+                  afterLeave()
                 }
               }
             )
@@ -304,11 +326,12 @@ export let TransitionChild = defineComponent({
 
     provide(NestingContext, nesting)
     useOpenClosedProvider(
-      computed(() =>
-        match(state.value, {
-          [TreeStates.Visible]: State.Open,
-          [TreeStates.Hidden]: State.Closed,
-        })
+      computed(
+        () =>
+          match(state.value, {
+            [TreeStates.Visible]: State.Open,
+            [TreeStates.Hidden]: State.Closed,
+          }) | transitionStateFlags.value
       )
     )
 

--- a/packages/@headlessui-vue/src/components/transitions/transition.ts
+++ b/packages/@headlessui-vue/src/components/transitions/transition.ts
@@ -384,10 +384,7 @@ export let TransitionRoot = defineComponent({
 
     let show = computed(() => {
       if (props.show === null && usesOpenClosedState !== null) {
-        return match(usesOpenClosedState.value, {
-          [State.Open]: true,
-          [State.Closed]: false,
-        })
+        return (usesOpenClosedState.value & State.Open) === State.Open
       }
 
       return props.show

--- a/packages/@headlessui-vue/src/internal/open-closed.ts
+++ b/packages/@headlessui-vue/src/internal/open-closed.ts
@@ -10,8 +10,10 @@ import {
 let Context = Symbol('Context') as InjectionKey<Ref<State>>
 
 export enum State {
-  Open,
-  Closed,
+  Open = 1 << 0,
+  Closed = 1 << 1,
+  Closing = 1 << 2,
+  Opening = 1 << 3,
 }
 
 export function hasOpenClosed() {

--- a/packages/@headlessui-vue/src/test-utils/vue-testing-library.ts
+++ b/packages/@headlessui-vue/src/test-utils/vue-testing-library.ts
@@ -41,6 +41,9 @@ export function render(TestComponent: any, options?: Parameters<typeof mount>[1]
   mountedWrappers.add(wrapper)
 
   return {
+    unmount() {
+      wrapper.unmount()
+    },
     get container() {
       return wrapper.element.parentElement!
     },


### PR DESCRIPTION
This PR improves when certain cleanup parts of the `Dialog` component happen.

The Dialog is a complex component. Once the Dialog is active it does a number of things:

- Ensure all other elements on the page are marked as inert
- Setup outside click behaviour
- Setup <kbd>Escape</kbd> to close
- Focuses the first focusable element in the Dialog
- Traps focus in the Dialog
- Ensures you can't scroll the background / interact with it
- …

When you wrap the Dialog in a Transition, then the `open` state is controlled by the Transition component. This means that all of the steps above will only be "reverted" the moment the Transition component is fully done transitioning out.

This can cause some problems in SPA environments where clicking on a link goes to a new page, but the Transition/Dialog is persistent (For example when it is used as a sidebar). A lot of routers in those environments will do scroll restoration. But this means that the following will happen:

1. Click link
2. Application goes to new page
3. In the meantime the sidebar Dialog wrapped in a Transition starts transitioning out
4. Application arrives on the new page and does scroll restoration
5. Transition is done transitioning out
6. Dialog receives the information from the Transition component that it is done transitioning
7. Dialog does scroll restoration

The last step is an important step for the Dialog itself because we have to apply (admittedly a bunch of hacks, especially on iOS) to make it work properly.

The big problem here is that the scroll restoration doesn't make any sense anymore because we are on a new page (potentially) already. This could now result in the fact that you are scrolled down on the new page, because you happened to be scrolled down on the previous page.

Headless UI itself is generic in the sense that we don't know anything about the applications / frameworks we are used in. So we can't listen to router events from Next.js if our components are used in a Remix application.

Instead what we can do is split up the functionality and cleanup parts in "stages". The moment our Transition component starts transitioning out, it will add the `Closing` state to the OpenClosed state. (Internally we have an OpenClosed context provider that allows us to have a thin layer for communication between components. This way you don't have to manually link the state from a Transition component with the state from a Menu, Listbox, Dialog, ... components).

Using this new state we can immediately start cleanup for some of the functionality in the Dialog component. For example, we can immediately do the scroll restoration while the Transition component is still transitioning.