### PR TITLE
Optimize the as prop test within transition component

### DIFF
--- a/packages/@headlessui-react/src/components/transitions/transition.test.tsx
+++ b/packages/@headlessui-react/src/components/transitions/transition.test.tsx
@@ -127,15 +127,15 @@ describe('Setup API', () => {
 
     it('should be possible to change the underlying DOM tag', () => {
       let { container } = render(
-        <Transition show={true} as="a">
+        <Transition show={true} as="span">
           Children
         </Transition>
       )
 
       expect(container.firstChild).toMatchInlineSnapshot(`
-        <a>
+        <span>
           Children
-        </a>
+        </span>
       `)
     })
 


### PR DESCRIPTION
There is a test in transition.test.tsx in line 105 which already covers using the `as` tag to change the underlying dom tag to an anchor tag. Therefore, in this test we can test whether a span tag is correctly rendered for example.