### PR TITLE
fix(listbox): there should be no error with undefined value and multiple

### DIFF
--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -394,7 +394,7 @@ let ListboxRoot = forwardRefWithAs(function Listbox<
     (compareValue) =>
       match(data.mode, {
         [ValueMode.Multi]: () =>
-          (value as unknown as EnsureArray<TType>).some((option) => compare(option, compareValue)),
+          (value as unknown as EnsureArray<TType>)?.some((option) => compare(option, compareValue)),
         [ValueMode.Single]: () => compare(value as TType, compareValue),
       }),
     [value]
@@ -485,7 +485,7 @@ let ListboxRoot = forwardRefWithAs(function Listbox<
         return theirOnChange?.(value as TType)
       },
       [ValueMode.Multi]() {
-        let copy = (data.value as TActualType[]).slice()
+        let copy = (data.value as TActualType[])?.slice() ?? []
 
         let idx = copy.findIndex((item) => compare(item, value as TActualType))
         if (idx === -1) {


### PR DESCRIPTION
I think the value of `listbox` could be undefined even if the multiple prop is true. However, there would be a type error in 
the current code. This PR is to fix this issue. This PR should not affect any other feature.