### PR TITLE
Fix `change` event incorrectly getting called on `blur`

### DIFF
--- a/packages/@headlessui-react/src/test-utils/interactions.ts
+++ b/packages/@headlessui-react/src/test-utils/interactions.ts
@@ -41,15 +41,13 @@ export function shift(event: Partial<KeyboardEvent>) {
 export function word(input: string): Partial<KeyboardEvent>[] {
   let result = input.split('').map((key) => ({ key }))
 
-  d.enqueue(() => {
-    let element = document.activeElement
+  let element = document.activeElement
 
-    if (element instanceof HTMLInputElement) {
-      fireEvent.change(element, {
-        target: Object.assign({}, element, { value: input }),
-      })
-    }
-  })
+  if (element instanceof HTMLInputElement) {
+    fireEvent.change(element, {
+      target: Object.assign({}, element, { value: input }),
+    })
+  }
 
   return result
 }
@@ -208,8 +206,6 @@ export async function type(events: Partial<KeyboardEvent>[], element = document.
 
     // We don't want to actually wait in our tests, so let's advance
     jest.runAllTimers()
-
-    await d.workQueue()
 
     await new Promise(nextFrame)
   } catch (err) {

--- a/packages/@headlessui-react/src/utils/disposables.ts
+++ b/packages/@headlessui-react/src/utils/disposables.ts
@@ -4,13 +4,8 @@ export type Disposables = ReturnType<typeof disposables>
 
 export function disposables() {
   let disposables: Function[] = []
-  let queue: Function[] = []
 
   let api = {
-    enqueue(fn: Function) {
-      queue.push(fn)
-    },
-
     addEventListener<TEventName extends keyof WindowEventMap>(
       element: HTMLElement | Window | Document,
       name: TEventName,
@@ -63,12 +58,6 @@ export function disposables() {
     dispose() {
       for (let dispose of disposables.splice(0)) {
         dispose()
-      }
-    },
-
-    async workQueue() {
-      for (let handle of queue.splice(0)) {
-        await handle()
       }
     },
 

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure the main tree and parent `Dialog` components are marked as `inert` ([#2290](https://github.com/tailwindlabs/headlessui/pull/2290))
 - Fix nested `Popover` components not opening ([#2293](https://github.com/tailwindlabs/headlessui/pull/2293))
+- Fix `change` event incorrectly getting called on `blur` ([#2296](https://github.com/tailwindlabs/headlessui/pull/2296))
 
 ## [1.7.10] - 2023-02-15
 

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -888,10 +888,6 @@ export let ComboboxInput = defineComponent({
       }
     }
 
-    function handleChange(event: Event & { target: HTMLInputElement }) {
-      emit('change', event)
-    }
-
     function handleInput(event: Event & { target: HTMLInputElement }) {
       api.openCombobox()
       emit('change', event)
@@ -930,7 +926,6 @@ export let ComboboxInput = defineComponent({
         onCompositionstart: handleCompositionstart,
         onCompositionend: handleCompositionend,
         onKeydown: handleKeyDown,
-        onChange: handleChange,
         onInput: handleInput,
         onBlur: handleBlur,
         role: 'combobox',

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -910,7 +910,7 @@ export let ComboboxInput = defineComponent({
 
     return () => {
       let slot = { open: api.comboboxState.value === ComboboxStates.Open }
-      let { id, displayValue, ...theirProps } = props
+      let { id, displayValue, onChange: _onChange, ...theirProps } = props
       let ourProps = {
         'aria-controls': api.optionsRef.value?.id,
         'aria-expanded': api.disabled.value

--- a/packages/@headlessui-vue/src/test-utils/interactions.ts
+++ b/packages/@headlessui-vue/src/test-utils/interactions.ts
@@ -39,15 +39,13 @@ export function shift(event: Partial<KeyboardEvent>) {
 export function word(input: string): Partial<KeyboardEvent>[] {
   let result = input.split('').map((key) => ({ key }))
 
-  d.enqueue(() => {
-    let element = document.activeElement
+  let element = document.activeElement
 
-    if (element instanceof HTMLInputElement) {
-      fireEvent.change(element, {
-        target: Object.assign({}, element, { value: input }),
-      })
-    }
-  })
+  if (element instanceof HTMLInputElement) {
+    fireEvent.change(element, {
+      target: Object.assign({}, element, { value: input }),
+    })
+  }
 
   return result
 }
@@ -206,8 +204,6 @@ export async function type(events: Partial<KeyboardEvent>[], element = document.
 
     // We don't want to actually wait in our tests, so let's advance
     jest.runAllTimers()
-
-    await d.workQueue()
 
     await new Promise(nextFrame)
   } catch (err) {

--- a/packages/@headlessui-vue/src/utils/disposables.ts
+++ b/packages/@headlessui-vue/src/utils/disposables.ts
@@ -2,13 +2,8 @@ export type Disposables = ReturnType<typeof disposables>
 
 export function disposables() {
   let disposables: Function[] = []
-  let queue: Function[] = []
 
   let api = {
-    enqueue(fn: Function) {
-      queue.push(fn)
-    },
-
     addEventListener<TEventName extends keyof WindowEventMap>(
       element: HTMLElement | Window | Document,
       name: TEventName,
@@ -50,12 +45,6 @@ export function disposables() {
     dispose() {
       for (let dispose of disposables.splice(0)) {
         dispose()
-      }
-    },
-
-    async workQueue() {
-      for (let handle of queue.splice(0)) {
-        await handle()
       }
     },
   }


### PR DESCRIPTION
This PR fixes an odd bug where blurring the input field would call the `@change` event on the `ComboboxInput`, this ins turn sets the `query.value` and therefore a list of data would be (incorrectly) filtered again because we expected `query.value === ''`.

Internally we set the `onChange` to a handler that just re-emitted the `change` event, but Vue already does that for you.

Fixes: #2171
