### PR TITLE
Fix specificity issues when using the `@headlessui/tailwindcss` package

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure the main tree and parent `Dialog` components are marked as `inert` ([#2290](https://github.com/tailwindlabs/headlessui/pull/2290))
 - Fix nested `Popover` components not opening ([#2293](https://github.com/tailwindlabs/headlessui/pull/2293))
 - Make React types more compatible with other libraries ([#2282](https://github.com/tailwindlabs/headlessui/pull/2282))
+- Fix specificity issues when using the `@headlessui/tailwindcss` package ([#2297](https://github.com/tailwindlabs/headlessui/pull/2297))
 
 ## [1.7.11] - 2023-02-15
 

--- a/packages/@headlessui-react/src/components/radio-group/radio-group.test.tsx
+++ b/packages/@headlessui-react/src/components/radio-group/radio-group.test.tsx
@@ -342,33 +342,60 @@ describe('Rendering', () => {
       let options = getRadioGroupOptions()
 
       // Nothing is active yet
-      expect(options[0]).toHaveAttribute('data-headlessui-state', '')
-      expect(options[1]).toHaveAttribute('data-headlessui-state', '')
-      expect(options[2]).toHaveAttribute('data-headlessui-state', '')
+      expect(options[0]).toHaveAttribute(
+        'data-headlessui-state',
+        'not-checked not-disabled not-active'
+      )
+      expect(options[1]).toHaveAttribute(
+        'data-headlessui-state',
+        'not-checked not-disabled not-active'
+      )
+      expect(options[2]).toHaveAttribute(
+        'data-headlessui-state',
+        'not-checked not-disabled not-active'
+      )
 
       // Focus the RadioGroup
       await press(Keys.Tab)
 
       // The first one should be active, but not checked yet
-      expect(options[0]).toHaveAttribute('data-headlessui-state', 'active')
-      expect(options[1]).toHaveAttribute('data-headlessui-state', '')
-      expect(options[2]).toHaveAttribute('data-headlessui-state', '')
+      expect(options[0]).toHaveAttribute('data-headlessui-state', 'not-checked not-disabled active')
+      expect(options[1]).toHaveAttribute(
+        'data-headlessui-state',
+        'not-checked not-disabled not-active'
+      )
+      expect(options[2]).toHaveAttribute(
+        'data-headlessui-state',
+        'not-checked not-disabled not-active'
+      )
 
       // Select the first one
       await press(Keys.Space)
 
       // The first one should be active and checked
-      expect(options[0]).toHaveAttribute('data-headlessui-state', 'checked active')
-      expect(options[1]).toHaveAttribute('data-headlessui-state', '')
-      expect(options[2]).toHaveAttribute('data-headlessui-state', '')
+      expect(options[0]).toHaveAttribute('data-headlessui-state', 'checked not-disabled active')
+      expect(options[1]).toHaveAttribute(
+        'data-headlessui-state',
+        'not-checked not-disabled not-active'
+      )
+      expect(options[2]).toHaveAttribute(
+        'data-headlessui-state',
+        'not-checked not-disabled not-active'
+      )
 
       // Go to the next option
       await press(Keys.ArrowDown)
 
       // The second one should be active and checked
-      expect(options[0]).toHaveAttribute('data-headlessui-state', '')
-      expect(options[1]).toHaveAttribute('data-headlessui-state', 'checked active')
-      expect(options[2]).toHaveAttribute('data-headlessui-state', '')
+      expect(options[0]).toHaveAttribute(
+        'data-headlessui-state',
+        'not-checked not-disabled not-active'
+      )
+      expect(options[1]).toHaveAttribute('data-headlessui-state', 'checked not-disabled active')
+      expect(options[2]).toHaveAttribute(
+        'data-headlessui-state',
+        'not-checked not-disabled not-active'
+      )
     })
   )
 

--- a/packages/@headlessui-react/src/utils/render.ts
+++ b/packages/@headlessui-react/src/utils/render.ts
@@ -139,6 +139,8 @@ function _render<TTag extends ElementType, TSlot>(
       }
       if (v === true) {
         states.push(k)
+      } else {
+        states.push(`not-${k}`)
       }
     }
 

--- a/packages/@headlessui-tailwindcss/CHANGELOG.md
+++ b/packages/@headlessui-tailwindcss/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Fix specificity issues when using the `@headlessui/tailwindcss` package ([#2297](https://github.com/tailwindlabs/headlessui/pull/2297))
 
 ## [0.1.2] - 2022-12-06
 

--- a/packages/@headlessui-tailwindcss/src/index.test.ts
+++ b/packages/@headlessui-tailwindcss/src/index.test.ts
@@ -40,12 +40,10 @@ it('should generate the inverse "not" css for an exposed state', async () => {
 
   return run('@tailwind utilities', config).then((result) => {
     expect(result.css).toMatchFormattedCss(css`
-      .ui-not-open\:underline[data-headlessui-state]:not([data-headlessui-state~='open']) {
+      .ui-not-open\:underline[data-headlessui-state~='not-open'] {
         text-decoration-line: underline;
       }
-
-      :where([data-headlessui-state]:not([data-headlessui-state~='open']))
-        .ui-not-open\:underline:not([data-headlessui-state]) {
+      :where([data-headlessui-state~='not-open']) .ui-not-open\:underline {
         text-decoration-line: underline;
       }
     `)
@@ -79,12 +77,10 @@ describe('custom prefix', () => {
 
     return run('@tailwind utilities', config).then((result) => {
       expect(result.css).toMatchFormattedCss(css`
-        .hui-not-open\:underline[data-headlessui-state]:not([data-headlessui-state~='open']) {
+        .hui-not-open\:underline[data-headlessui-state~='not-open'] {
           text-decoration-line: underline;
         }
-
-        :where([data-headlessui-state]:not([data-headlessui-state~='open']))
-          .hui-not-open\:underline:not([data-headlessui-state]) {
+        :where([data-headlessui-state~='not-open']) .hui-not-open\:underline {
           text-decoration-line: underline;
         }
       `)

--- a/packages/@headlessui-tailwindcss/src/index.ts
+++ b/packages/@headlessui-tailwindcss/src/index.ts
@@ -28,8 +28,8 @@ export default plugin.withOptions<Options>(({ prefix = 'ui' } = {}) => {
       ])
 
       addVariant(`${prefix}-not-${state}`, [
-        `&[data-headlessui-state]:not([data-headlessui-state~="${state}"])`,
-        `:where([data-headlessui-state]:not([data-headlessui-state~="${state}"])) &:not([data-headlessui-state])`,
+        `&[data-headlessui-state~="not-${state}"]`,
+        `:where([data-headlessui-state~="not-${state}"]) &`,
       ])
     }
   }

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure the main tree and parent `Dialog` components are marked as `inert` ([#2290](https://github.com/tailwindlabs/headlessui/pull/2290))
 - Fix nested `Popover` components not opening ([#2293](https://github.com/tailwindlabs/headlessui/pull/2293))
 - Fix `change` event incorrectly getting called on `blur` ([#2296](https://github.com/tailwindlabs/headlessui/pull/2296))
+- Fix specificity issues when using the `@headlessui/tailwindcss` package ([#2297](https://github.com/tailwindlabs/headlessui/pull/2297))
 
 ## [1.7.10] - 2023-02-15
 

--- a/packages/@headlessui-vue/src/components/radio-group/radio-group.test.ts
+++ b/packages/@headlessui-vue/src/components/radio-group/radio-group.test.ts
@@ -496,6 +496,86 @@ describe('Rendering', () => {
     assertActiveElement(getByText('Option 3'))
   })
 
+  it(
+    'should expose internal data as a render prop',
+    suppressConsoleLogs(async () => {
+      renderTemplate({
+        template: html`
+          <RadioGroup v-model="value">
+            <RadioGroupOption value="a">Option 1</RadioGroupOption>
+            <RadioGroupOption value="b">Option 2</RadioGroupOption>
+            <RadioGroupOption value="c">Option 3</RadioGroupOption>
+          </RadioGroup>
+        `,
+        setup() {
+          return {
+            value: ref(null),
+          }
+        },
+      })
+
+      await nextFrame()
+
+      let options = getRadioGroupOptions()
+
+      // Nothing is active yet
+      expect(options[0]).toHaveAttribute(
+        'data-headlessui-state',
+        'not-checked not-disabled not-active'
+      )
+      expect(options[1]).toHaveAttribute(
+        'data-headlessui-state',
+        'not-checked not-disabled not-active'
+      )
+      expect(options[2]).toHaveAttribute(
+        'data-headlessui-state',
+        'not-checked not-disabled not-active'
+      )
+
+      // Focus the RadioGroup
+      await press(Keys.Tab)
+
+      // The first one should be active, but not checked yet
+      expect(options[0]).toHaveAttribute('data-headlessui-state', 'not-checked not-disabled active')
+      expect(options[1]).toHaveAttribute(
+        'data-headlessui-state',
+        'not-checked not-disabled not-active'
+      )
+      expect(options[2]).toHaveAttribute(
+        'data-headlessui-state',
+        'not-checked not-disabled not-active'
+      )
+
+      // Select the first one
+      await press(Keys.Space)
+
+      // The first one should be active and checked
+      expect(options[0]).toHaveAttribute('data-headlessui-state', 'checked not-disabled active')
+      expect(options[1]).toHaveAttribute(
+        'data-headlessui-state',
+        'not-checked not-disabled not-active'
+      )
+      expect(options[2]).toHaveAttribute(
+        'data-headlessui-state',
+        'not-checked not-disabled not-active'
+      )
+
+      // Go to the next option
+      await press(Keys.ArrowDown)
+
+      // The second one should be active and checked
+      expect(options[0]).toHaveAttribute(
+        'data-headlessui-state',
+        'not-checked not-disabled not-active'
+      )
+      expect(options[1]).toHaveAttribute('data-headlessui-state', 'checked not-disabled active')
+      expect(options[2]).toHaveAttribute(
+        'data-headlessui-state',
+        'not-checked not-disabled not-active'
+      )
+    })
+  )
+
   describe('Equality', () => {
     let options = [
       { id: 1, name: 'Alice' },

--- a/packages/@headlessui-vue/src/utils/render.ts
+++ b/packages/@headlessui-vue/src/utils/render.ts
@@ -101,6 +101,8 @@ function _render({
       }
       if (v === true) {
         states.push(k)
+      } else {
+        states.push(`not-${k}`)
       }
     }
 


### PR DESCRIPTION
This PR fixes specifity related issues when using the `@headlessui/tailwindcss` on the `Listbox` component.

```js
<Listbox value={selected} onChange={setSelected}>
  <Listbox.Button>Open Listbox</Listbox.Button>
  <Listbox.Options>
    {people.map((person, personIdx) => (
      <Listbox.Option
        key={personIdx}
        className="ui-active:bg-amber-100 ui-active:text-amber-900 ui-not-active:text-gray-900"
        value={person}
      >
        <span className="ui-selected:font-medium ui-not-selected:font-normal">
          {person.name}
        </span>

        <span className="ui-selected:flex ui-not-selected:hidden">
          <CheckIcon className="h-5 w-5" aria-hidden="true" />
        </span>
      </Listbox.Option>
    ))}
  </Listbox.Options>
</Listbox>
```

- When the `Listbox` is open, then
  - The `Listbox.Options` will have the following data attribute: `data-headlessui-state="open"`
  - The selected `Listbox.Option` will have the followin data attribute: `data-headlessui-state="active selected"`
  - The span for the icon in the `Listbox.Option` has the following classes: `class="ui-selected:flex ui-not-selected:hidden"`

You would expect that the `ui-selected` is matching because the `Listbox.Option` _is_ the selected one. However, the `ui-not-selected` is _also_ matching. The reason for this is because the selector is defined as:

```css
:where([data-headlessui-state]:not([data-headlessui-state~="selected"]))
  .ui-not-selected\:hidden:not([data-headlessui-state]) {
  display: none;
}
```

The reason for this is beacuse we wanted to style an element when a given state is present, or when a given state is _not_ present. Looking at the `Listbox.Options` it _does_ match the `[data-headlessui-state]` and it also matches the `:not([data-headlessui-state~="selected"])` because it only has the `open` state, therefore the css selector matches.

This PR tries to solve that by being very explicit. Sadly this does increase the HTML a bit, but this is the solution:

- When the `Listbox` is open, then
  - The `Listbox.Options` will have the following data attribute: `data-headlessui-state="open"`
  - The selected `Listbox.Option` will have the followin data attribute: `data-headlessui-state="active selected not-disabled"`
  - The span for the icon in the `Listbox.Option` has the following classes: `class="ui-selected:flex ui-not-selected:hidden"`

It's very similar, but instead of only having the states that apply, we also expose the states that _don't_ apply. For example by using `not-disabled`.

The `Listbox.Options` only has an open state so it doesn't contain other states right now.

This on its own is not enough, we also have to modify the css selector. We simplified it to:

```css
:where([data-headlessui-state~="not-selected"]) .ui-not-selected\:hidden {
  display: none;
}
```

In short, this is the diff we applied:

```diff
- `&[data-headlessui-state]:not([data-headlessui-state~="${state}"])`
- `:where([data-headlessui-state]:not([data-headlessui-state~="${state}"])) &:not([data-headlessui-state])`,
+ `&[data-headlessui-state~="not-${state}"]`,
+ `:where([data-headlessui-state~="not-${state}"]) &`,
```

Reproduction of the bug in CodeSandbox: https://codesandbox.io/s/agitated-fermi-8uqhf7?file=/src/App.js
There should be a `checkmark` icon for the selected person, but there is none.

Fixes: #2291
