### PR TITLE
Fix `Dialog` cleanup when the `Dialog` becomes hidden

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure the main tree and parent `Dialog` components are marked as `inert` ([#2290](https://github.com/tailwindlabs/headlessui/pull/2290))
 - Fix nested `Popover` components not opening ([#2293](https://github.com/tailwindlabs/headlessui/pull/2293))
 - Make React types more compatible with other libraries ([#2282](https://github.com/tailwindlabs/headlessui/pull/2282))
+- Fix `Dialog` cleanup when the `Dialog` becomes hidden ([#2303](https://github.com/tailwindlabs/headlessui/pull/2303))
 
 ## [1.7.11] - 2023-02-15
 

--- a/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
@@ -30,7 +30,7 @@ import { OpenClosedProvider, State } from '../../internal/open-closed'
 jest.mock('../../hooks/use-id')
 
 // @ts-expect-error
-global.IntersectionObserver = class FakeIntersectionObserver {
+global.ResizeObserver = class FakeResizeObserver {
   observe() {}
   disconnect() {}
 }

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -309,21 +309,14 @@ function DialogFn<TTag extends ElementType = typeof DEFAULT_DIALOG_TAG>(
     if (dialogState !== DialogStates.Open) return
     if (!internalDialogRef.current) return
 
-    let observer = new IntersectionObserver(
-      (entries) => {
-        for (let entry of entries) {
-          if (
-            entry.boundingClientRect.x === 0 &&
-            entry.boundingClientRect.y === 0 &&
-            entry.boundingClientRect.width === 0 &&
-            entry.boundingClientRect.height === 0
-          ) {
-            close()
-          }
+    let observer = new ResizeObserver((entries) => {
+      for (let entry of entries) {
+        let rect = entry.target.getBoundingClientRect()
+        if (rect.x === 0 && rect.y === 0 && rect.width === 0 && rect.height === 0) {
+          close()
         }
-      },
-      { root: internalDialogRef.current.parentElement }
-    )
+      }
+    })
 
     observer.observe(internalDialogRef.current)
 

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -309,18 +309,21 @@ function DialogFn<TTag extends ElementType = typeof DEFAULT_DIALOG_TAG>(
     if (dialogState !== DialogStates.Open) return
     if (!internalDialogRef.current) return
 
-    let observer = new IntersectionObserver((entries) => {
-      for (let entry of entries) {
-        if (
-          entry.boundingClientRect.x === 0 &&
-          entry.boundingClientRect.y === 0 &&
-          entry.boundingClientRect.width === 0 &&
-          entry.boundingClientRect.height === 0
-        ) {
-          close()
+    let observer = new IntersectionObserver(
+      (entries) => {
+        for (let entry of entries) {
+          if (
+            entry.boundingClientRect.x === 0 &&
+            entry.boundingClientRect.y === 0 &&
+            entry.boundingClientRect.width === 0 &&
+            entry.boundingClientRect.height === 0
+          ) {
+            close()
+          }
         }
-      }
-    })
+      },
+      { root: internalDialogRef.current.parentElement }
+    )
 
     observer.observe(internalDialogRef.current)
 

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure the main tree and parent `Dialog` components are marked as `inert` ([#2290](https://github.com/tailwindlabs/headlessui/pull/2290))
 - Fix nested `Popover` components not opening ([#2293](https://github.com/tailwindlabs/headlessui/pull/2293))
 - Fix `change` event incorrectly getting called on `blur` ([#2296](https://github.com/tailwindlabs/headlessui/pull/2296))
+- Fix `Dialog` cleanup when the `Dialog` becomes hidden ([#2303](https://github.com/tailwindlabs/headlessui/pull/2303))
 
 ## [1.7.10] - 2023-02-15
 

--- a/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
@@ -44,7 +44,7 @@ import { html } from '../../test-utils/html'
 import { useOpenClosedProvider, State } from '../../internal/open-closed'
 
 // @ts-expect-error
-global.IntersectionObserver = class FakeIntersectionObserver {
+global.ResizeObserver = class FakeResizeObserver {
   observe() {}
   disconnect() {}
 }

--- a/packages/@headlessui-vue/src/components/dialog/dialog.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.ts
@@ -280,18 +280,21 @@ export let Dialog = defineComponent({
       let container = dom(internalDialogRef)
       if (!container) return
 
-      let observer = new IntersectionObserver((entries) => {
-        for (let entry of entries) {
-          if (
-            entry.boundingClientRect.x === 0 &&
-            entry.boundingClientRect.y === 0 &&
-            entry.boundingClientRect.width === 0 &&
-            entry.boundingClientRect.height === 0
-          ) {
-            api.close()
+      let observer = new IntersectionObserver(
+        (entries) => {
+          for (let entry of entries) {
+            if (
+              entry.boundingClientRect.x === 0 &&
+              entry.boundingClientRect.y === 0 &&
+              entry.boundingClientRect.width === 0 &&
+              entry.boundingClientRect.height === 0
+            ) {
+              api.close()
+            }
           }
-        }
-      })
+        },
+        { root: container.parentElement }
+      )
 
       observer.observe(container)
 

--- a/packages/@headlessui-vue/src/components/dialog/dialog.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.ts
@@ -280,21 +280,14 @@ export let Dialog = defineComponent({
       let container = dom(internalDialogRef)
       if (!container) return
 
-      let observer = new IntersectionObserver(
-        (entries) => {
-          for (let entry of entries) {
-            if (
-              entry.boundingClientRect.x === 0 &&
-              entry.boundingClientRect.y === 0 &&
-              entry.boundingClientRect.width === 0 &&
-              entry.boundingClientRect.height === 0
-            ) {
-              api.close()
-            }
+      let observer = new ResizeObserver((entries) => {
+        for (let entry of entries) {
+          let rect = entry.target.getBoundingClientRect()
+          if (rect.x === 0 && rect.y === 0 && rect.width === 0 && rect.height === 0) {
+            api.close()
           }
-        },
-        { root: container.parentElement }
-      )
+        }
+      })
 
       observer.observe(container)
 


### PR DESCRIPTION
This PR fixes an issue with the `Dialog` component where it doesn't properly closes and therefore doesn't properly cleans up the scroll locking, focus trapping, ...

We already had the `IntersectionObserver` in place for this. But this didn't always trigger properly. For example if the `Dialog` itself didn't have a proper size, but it's content did.

We could update the `root` of the intersection observer to a different element but it becomes hard to know which element to use exactly. Just using the `parentElement` of the Dialog seemed enough, but performing some tests broke other components.

Instead, let's use a `ResizeObserver` (see browser support: https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver#browser_compatibility) which gets properly trigger when a Dialog becomes hidden and when it becomes visible again.
