### PR TITLE
Ensure `Transition` component completes if nothing is transitioning

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Ensure `Transition` component completes if nothing is transitioning ([#2318](https://github.com/tailwindlabs/headlessui/pull/2318))
 
 ## [1.7.12] - 2023-02-24
 

--- a/packages/@headlessui-react/src/components/transitions/utils/transition.ts
+++ b/packages/@headlessui-react/src/components/transitions/utils/transition.ts
@@ -39,6 +39,23 @@ function waitForTransition(node: HTMLElement, done: () => void) {
         dispose()
       }, totalDuration)
     } else {
+      d.group((d) => {
+        // Mark the transition as done when the timeout is reached. This is a fallback in case the
+        // transitionrun event is not fired.
+        d.setTimeout(() => {
+          done()
+          d.dispose()
+        }, totalDuration)
+
+        // The moment the transitionrun event fires, we should cleanup the timeout fallback, because
+        // then we know that we can use the native transition events because something is
+        // transitioning.
+        d.addEventListener(node, 'transitionrun', (event) => {
+          if (event.target !== event.currentTarget) return
+          d.dispose()
+        })
+      })
+
       let dispose = d.addEventListener(node, 'transitionend', (event) => {
         if (event.target !== event.currentTarget) return
         done()


### PR DESCRIPTION
This PR fixes an issue where the `Transition` component causes sub-components (like a `Dialog`) to get "stuck" because it nevers finishes transitioning. 

This can happen if there is nothing to transition at all (e.g.: `display: block;` -> `display: none;`). 

If this happens then the `transitionend` event is never fired and therefore it's waiting for nothing and gets stuck.

Fixes: #2114

