### PR TITLE
Allow root containers from the `Dialog` component in the `FocusTrap` component

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure `Transition` component completes if nothing is transitioning ([#2318](https://github.com/tailwindlabs/headlessui/pull/2318))
 - Enable native label behavior for `<Switch>` where possible ([#2265](https://github.com/tailwindlabs/headlessui/pull/2265))
+- Allow root containers from the `Dialog` component in the `FocusTrap` component ([#2322](https://github.com/tailwindlabs/headlessui/pull/2322))
 
 ## [1.7.12] - 2023-02-24
 

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Enable native label behavior for `<Switch>` where possible ([#2265](https://github.com/tailwindlabs/headlessui/pull/2265))
+- Allow root containers from the `Dialog` component in the `FocusTrap` component ([#2322](https://github.com/tailwindlabs/headlessui/pull/2322))
 
 ## [1.7.11] - 2023-02-24
 

--- a/packages/@headlessui-vue/src/test-utils/interactions.ts
+++ b/packages/@headlessui-vue/src/test-utils/interactions.ts
@@ -282,7 +282,11 @@ export async function focus(element: Document | Element | Window | Node | null) 
   try {
     if (element === null) return expect(element).not.toBe(null)
 
-    fireEvent.focus(element)
+    if (element instanceof HTMLElement) {
+      element.focus()
+    } else {
+      fireEvent.focus(element)
+    }
 
     await new Promise(nextFrame)
   } catch (err) {


### PR DESCRIPTION
This PR fixes an issue where the `FocusTrap` is not properly handled for allowed root containers (like 3rd party containers).

When using the `FocusTrap` component inside of the `Dialog`, then only the `Dialog` was considered one of the containers. However, we should keep all the allowed containers into account just like how we handle them for outside click and escape behaviour.

Fixes: #2312
