### PR TITLE
Fix restore focus to buttons in Safari, when `Dialog` component closes

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow root containers from the `Dialog` component in the `FocusTrap` component ([#2322](https://github.com/tailwindlabs/headlessui/pull/2322))
 - Fix `XYZPropsWeControl` and cleanup internal TypeScript types ([#2329](https://github.com/tailwindlabs/headlessui/pull/2329))
 - Fix invalid warning when using multiple `Popover.Button` components inside a `Popover.Panel` ([#2333](https://github.com/tailwindlabs/headlessui/pull/2333))
+- Fix restore focus to buttons in Safari, when `Dialog` component closes ([#2326](https://github.com/tailwindlabs/headlessui/pull/2326))
 
 ## [1.7.12] - 2023-02-24
 

--- a/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
@@ -647,9 +647,9 @@ describe('Composition', () => {
             <Popover>
               <Popover.Button>Open Popover</Popover.Button>
               <Popover.Panel>
-                <div id="openDialog" onClick={() => setIsDialogOpen(true)}>
+                <button id="openDialog" onClick={() => setIsDialogOpen(true)}>
                   Open dialog
-                </div>
+                </button>
               </Popover.Panel>
             </Popover>
 

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable native label behavior for `<Switch>` where possible ([#2265](https://github.com/tailwindlabs/headlessui/pull/2265))
 - Allow root containers from the `Dialog` component in the `FocusTrap` component ([#2322](https://github.com/tailwindlabs/headlessui/pull/2322))
 - Cleanup internal TypeScript types ([#2329](https://github.com/tailwindlabs/headlessui/pull/2329))
+- Fix restore focus to buttons in Safari, when `Dialog` component closes ([#2326](https://github.com/tailwindlabs/headlessui/pull/2326))
 
 ## [1.7.11] - 2023-02-24
 

--- a/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
@@ -863,7 +863,7 @@ describe('Composition', () => {
             <Popover>
               <PopoverButton>Open Popover</PopoverButton>
               <PopoverPanel>
-                <div id="openDialog" @click="isDialogOpen = true">Open dialog</div>
+                <button id="openDialog" @click="isDialogOpen = true">Open dialog</button>
               </PopoverPanel>
             </Popover>
 

--- a/packages/@headlessui-vue/tsconfig.json
+++ b/packages/@headlessui-vue/tsconfig.json
@@ -20,7 +20,7 @@
       "*": ["src/*", "node_modules/*"]
     },
     "esModuleInterop": true,
-    "target": "es5",
+    "target": "ESNext",
     "allowJs": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,

--- a/packages/playground-react/pages/dialog/dialog.tsx
+++ b/packages/playground-react/pages/dialog/dialog.tsx
@@ -14,6 +14,16 @@ function resolveClass({ active, disabled }) {
   )
 }
 
+function Button(props: React.ComponentProps<'button'>) {
+  return (
+    <button
+      type="button"
+      className="rounded bg-gray-200 px-2 py-1 ring-gray-500 ring-offset-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2"
+      {...props}
+    />
+  )
+}
+
 function Nested({ onClose, level = 0 }) {
   let [showChild, setShowChild] = useState(false)
 
@@ -29,15 +39,9 @@ function Nested({ onClose, level = 0 }) {
         >
           <p>Level: {level}</p>
           <div className="space-x-4">
-            <button className="rounded bg-gray-200 px-2 py-1" onClick={() => setShowChild(true)}>
-              Open (1)
-            </button>
-            <button className="rounded bg-gray-200 px-2 py-1" onClick={() => setShowChild(true)}>
-              Open (2)
-            </button>
-            <button className="rounded bg-gray-200 px-2 py-1" onClick={() => setShowChild(true)}>
-              Open (3)
-            </button>
+            <Button onClick={() => setShowChild(true)}>Open (1)</Button>
+            <Button onClick={() => setShowChild(true)}>Open (2)</Button>
+            <Button onClick={() => setShowChild(true)}>Open (3)</Button>
           </div>
         </div>
         {showChild && <Nested onClose={() => setShowChild(false)} level={level + 1} />}
@@ -60,15 +64,10 @@ export default function Home() {
 
   return (
     <>
-      <button
-        type="button"
-        onClick={() => setIsOpen((v) => !v)}
-        className="focus:shadow-outline-blue m-12 rounded-md border border-gray-300 bg-white px-4 py-2 text-base font-medium leading-6 text-gray-700 shadow-sm transition duration-150 ease-in-out hover:text-gray-500 focus:border-blue-300 focus:outline-none sm:text-sm sm:leading-5"
-      >
-        Toggle!
-      </button>
-
-      <button onClick={() => setNested(true)}>Show nested</button>
+      <div className="flex gap-4 p-12">
+        <Button onClick={() => setIsOpen((v) => !v)}>Toggle!</Button>
+        <Button onClick={() => setNested(true)}>Show nested</Button>
+      </div>
       {nested && <Nested onClose={() => setNested(false)} />}
 
       <div

--- a/packages/playground-vue/src/components/dialog/dialog.vue
+++ b/packages/playground-vue/src/components/dialog/dialog.vue
@@ -1,25 +1,8 @@
 <template>
-  <p
-    v-for="i in Array(15)
-      .fill(null)
-      .map((_, i) => i)"
-    :key="i"
-    className="m-4"
-  >
-    Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam numquam beatae, maiores sint
-    est perferendis molestiae deleniti dolorem, illum vel, quam atque facilis! Necessitatibus
-    nostrum recusandae nemo corrupti, odio eius?
-  </p>
-
-  <button
-    type="button"
-    @click="toggleIsOpen()"
-    class="focus:shadow-outline-blue m-12 rounded-md border border-gray-300 bg-white px-4 py-2 text-base font-medium leading-6 text-gray-700 shadow-sm transition duration-150 ease-in-out hover:text-gray-500 focus:border-blue-300 focus:outline-none sm:text-sm sm:leading-5"
-  >
-    Toggle!
-  </button>
-
-  <button @click="nested = true">Show nested</button>
+  <div className="flex gap-4 p-12">
+    <Button @click="toggleIsOpen()">Toggle!</Button>
+    <Button @click="nested = true">Show nested</Button>
+  </div>
   <Nested v-if="nested" @close="nested = false" />
 
   <TransitionRoot :show="isOpen" as="template">
@@ -224,6 +207,22 @@ function resolveClass({ active, disabled }) {
   )
 }
 
+let Button = defineComponent({
+  setup(props, { slots }) {
+    return () =>
+      h(
+        'button',
+        {
+          type: 'button',
+          class:
+            'rounded bg-gray-200 px-2 py-1 ring-gray-500 ring-offset-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2',
+          ...props,
+        },
+        slots.default?.()
+      )
+  },
+})
+
 let Nested = defineComponent({
   components: { Dialog, DialogOverlay },
   emits: ['close'],
@@ -247,21 +246,9 @@ let Nested = defineComponent({
           [
             h('p', `Level: ${level}`),
             h('div', { class: 'space-x-4' }, [
-              h(
-                'button',
-                { class: 'rounded bg-gray-200 px-2 py-1', onClick: () => (showChild.value = true) },
-                `Open ${level + 1} a`
-              ),
-              h(
-                'button',
-                { class: 'rounded bg-gray-200 px-2 py-1', onClick: () => (showChild.value = true) },
-                `Open ${level + 1} b`
-              ),
-              h(
-                'button',
-                { class: 'rounded bg-gray-200 px-2 py-1', onClick: () => (showChild.value = true) },
-                `Open ${level + 1} c`
-              ),
+              h(Button, { onClick: () => (showChild.value = true) }, () => `Open ${level + 1} a`),
+              h(Button, { onClick: () => (showChild.value = true) }, () => `Open ${level + 1} b`),
+              h(Button, { onClick: () => (showChild.value = true) }, () => `Open ${level + 1} c`),
             ]),
           ]
         ),
@@ -277,6 +264,7 @@ let Nested = defineComponent({
 
 export default {
   components: {
+    Button,
     Nested,
     Dialog,
     DialogTitle,


### PR DESCRIPTION
This PR fixes an issue in Safari where the focus is not properly restored to the element that originally opened the `Dialog` component.

This is because Safari doesn't "focus", the button when you click on it. We were relying on this (because we used the `document.activeElement`).

Now we will keep track of "focused" items (even when you click them), and use that as a restoreable element.

Fixes: #1643

