### PR TITLE
Add CSS variable to html along with adding padding-right 

### DIFF
--- a/packages/@headlessui-react/src/hooks/document-overflow/adjust-scrollbar-padding.ts
+++ b/packages/@headlessui-react/src/hooks/document-overflow/adjust-scrollbar-padding.ts
@@ -20,6 +20,7 @@ export function adjustScrollbarPadding(): ScrollLockStep {
       let scrollbarWidth = scrollbarWidthBefore - scrollbarWidthAfter
 
       d.style(documentElement, 'paddingRight', `${scrollbarWidth}px`)
+      d.style(documentElement, '--html-padding-right', `${scrollbarWidth}px`)
     },
   }
 }

--- a/packages/@headlessui-react/src/utils/disposables.ts
+++ b/packages/@headlessui-react/src/utils/disposables.ts
@@ -46,9 +46,13 @@ export function disposables() {
 
     style(node: HTMLElement, property: string, value: string) {
       let previous = node.style.getPropertyValue(property)
-      Object.assign(node.style, { [property]: value })
+      property.startsWith('--')
+        ? node.style.setProperty(property, value)
+        : Object.assign(node.style, { [property]: value })
       return this.add(() => {
-        Object.assign(node.style, { [property]: previous })
+        property.startsWith('--')
+          ? node.style.setProperty(property, previous)
+          : Object.assign(node.style, { [property]: previous })
       })
     },
 

--- a/packages/@headlessui-vue/src/hooks/document-overflow/adjust-scrollbar-padding.ts
+++ b/packages/@headlessui-vue/src/hooks/document-overflow/adjust-scrollbar-padding.ts
@@ -20,6 +20,7 @@ export function adjustScrollbarPadding(): ScrollLockStep {
       let scrollbarWidth = scrollbarWidthBefore - scrollbarWidthAfter
 
       d.style(documentElement, 'paddingRight', `${scrollbarWidth}px`)
+      d.style(documentElement, '--html-padding-right', `${scrollbarWidth}px`)
     },
   }
 }

--- a/packages/@headlessui-vue/src/utils/disposables.ts
+++ b/packages/@headlessui-vue/src/utils/disposables.ts
@@ -32,9 +32,13 @@ export function disposables() {
 
     style(node: HTMLElement, property: string, value: string) {
       let previous = node.style.getPropertyValue(property)
-      Object.assign(node.style, { [property]: value })
+      property.startsWith('--')
+        ? node.style.setProperty(property, value)
+        : Object.assign(node.style, { [property]: value })
       return this.add(() => {
-        Object.assign(node.style, { [property]: previous })
+        property.startsWith('--')
+          ? node.style.setProperty(property, previous)
+          : Object.assign(node.style, { [property]: previous })
       })
     },
 

--- a/packages/playground-react/pages/_app.tsx
+++ b/packages/playground-react/pages/_app.tsx
@@ -146,8 +146,8 @@ function MyApp({ Component, pageProps }) {
 
   return (
     <>
-      <div className="flex h-screen flex-col overflow-hidden bg-gray-700 font-sans text-gray-900 antialiased">
-        <header className="relative z-10 flex flex-shrink-0 items-center justify-between border-b border-gray-200 bg-gray-700 px-4 py-4 sm:px-6 lg:px-8">
+      <div className="flex h-screen flex-col bg-gray-700 font-sans text-gray-900 antialiased">
+        <header className="sticky top-0 z-10 flex flex-shrink-0 items-center justify-between border-b border-gray-200 bg-gray-700 px-4 py-4 sm:px-6 lg:px-8">
           <NextLink href="/">
             <Logo className="h-6" />
           </NextLink>
@@ -155,7 +155,7 @@ function MyApp({ Component, pageProps }) {
 
         <KeyCaster />
 
-        <main className="flex-1 overflow-auto bg-gray-50">
+        <main className="flex-1 bg-gray-50">
           <Component {...pageProps} />
         </main>
       </div>

--- a/packages/playground-react/pages/dialog/scrollable-page-with-dialog.tsx
+++ b/packages/playground-react/pages/dialog/scrollable-page-with-dialog.tsx
@@ -49,7 +49,7 @@ export default function Home() {
             setIsOpen(false)
           }}
         >
-          <div className="fixed inset-0 z-10 overflow-y-auto">
+          <div className="fixed inset-y-0 left-0 z-10 w-screen overflow-y-auto">
             <div className="flex min-h-screen items-end justify-center px-4 pt-4 pb-20 text-center sm:block sm:p-0">
               <Transition.Child
                 as={Fragment}

--- a/packages/playground-react/pages/dialog/scrollable-page-with-fixed-bar.tsx
+++ b/packages/playground-react/pages/dialog/scrollable-page-with-fixed-bar.tsx
@@ -1,0 +1,158 @@
+import React, { useState, Fragment } from 'react'
+import { Dialog, Transition } from '@headlessui/react'
+
+export default function Home() {
+  let [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <>
+      <div className="fixed inset-x-0 top-0 z-20 bg-black py-4 px-4 text-right text-sm text-white">
+        this will jump
+      </div>
+      <div className="fixed top-16 left-0 right-[var(--html-padding-right,0)] z-20 bg-black py-4 px-4 text-right text-sm text-white">
+        this one won't
+      </div>
+      {Array(5)
+        .fill(null)
+        .map((_, i) => (
+          <p key={i} className="m-4">
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam numquam beatae,
+            maiores sint est perferendis molestiae deleniti dolorem, illum vel, quam atque facilis!
+            Necessitatibus nostrum recusandae nemo corrupti, odio eius?
+          </p>
+        ))}
+
+      <button
+        type="button"
+        onClick={() => setIsOpen((v) => !v)}
+        className="focus:shadow-outline-blue m-12 rounded-md border border-gray-300 bg-white px-4 py-2 text-base font-medium leading-6 text-gray-700 shadow-sm transition duration-150 ease-in-out hover:text-gray-500 focus:border-blue-300 focus:outline-none sm:text-sm sm:leading-5"
+      >
+        Toggle!
+      </button>
+
+      {Array(20)
+        .fill(null)
+        .map((_, i) => (
+          <p key={i} className="m-4">
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam numquam beatae,
+            maiores sint est perferendis molestiae deleniti dolorem, illum vel, quam atque facilis!
+            Necessitatibus nostrum recusandae nemo corrupti, odio eius?
+          </p>
+        ))}
+
+      <Transition
+        data-debug="Dialog"
+        show={isOpen}
+        as={Fragment}
+        beforeEnter={() => console.log('[Transition] Before enter')}
+        afterEnter={() => console.log('[Transition] After enter')}
+        beforeLeave={() => console.log('[Transition] Before leave')}
+        afterLeave={() => console.log('[Transition] After leave')}
+      >
+        <Dialog
+          onClose={() => {
+            console.log('close')
+            setIsOpen(false)
+          }}
+        >
+          <div className="fixed inset-y-0 left-0 z-10 w-screen overflow-y-auto">
+            <div className="flex min-h-screen items-end justify-center px-4 pt-4 pb-20 text-center sm:block sm:p-0">
+              <Transition.Child
+                as={Fragment}
+                enter="ease-out duration-300"
+                enterFrom="opacity-0"
+                enterTo="opacity-75"
+                leave="ease-in duration-200"
+                leaveFrom="opacity-75"
+                leaveTo="opacity-0"
+                entered="opacity-75"
+                beforeEnter={() => console.log('[Transition.Child] [Overlay] Before enter')}
+                afterEnter={() => console.log('[Transition.Child] [Overlay] After enter')}
+                beforeLeave={() => console.log('[Transition.Child] [Overlay] Before leave')}
+                afterLeave={() => console.log('[Transition.Child] [Overlay] After leave')}
+              >
+                <div className="fixed inset-0 bg-gray-500 transition-opacity" />
+              </Transition.Child>
+
+              <Transition.Child
+                enter="ease-out transform duration-300"
+                enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+                enterTo="opacity-100 translate-y-0 sm:scale-100"
+                leave="ease-in transform duration-200"
+                leaveFrom="opacity-100 translate-y-0 sm:scale-100"
+                leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+                beforeEnter={() => console.log('[Transition.Child] [Panel] Before enter')}
+                afterEnter={() => console.log('[Transition.Child] [Panel] After enter')}
+                beforeLeave={() => console.log('[Transition.Child] [Panel] Before leave')}
+                afterLeave={() => console.log('[Transition.Child] [Panel] After leave')}
+              >
+                {/* This element is to trick the browser into centering the modal contents. */}
+                <span
+                  className="hidden sm:inline-block sm:h-screen sm:align-middle"
+                  aria-hidden="true"
+                >
+                  &#8203;
+                </span>
+                <Dialog.Panel className="inline-block transform overflow-hidden rounded-lg bg-white text-left align-bottom shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:align-middle">
+                  <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                    <div className="sm:flex sm:items-start">
+                      <div className="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
+                        {/* Heroicon name: exclamation */}
+                        <svg
+                          className="h-6 w-6 text-red-600"
+                          xmlns="http://www.w3.org/2000/svg"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          aria-hidden="true"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                          />
+                        </svg>
+                      </div>
+                      <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+                        <Dialog.Title
+                          as="h3"
+                          className="text-lg font-medium leading-6 text-gray-900"
+                        >
+                          Deactivate account
+                        </Dialog.Title>
+                        <div className="mt-2">
+                          <p className="text-sm text-gray-500">
+                            Are you sure you want to deactivate your account? All of your data will
+                            be permanently removed. This action cannot be undone.
+                          </p>
+                        </div>
+                        <input type="text" />
+                      </div>
+                    </div>
+                  </div>
+                  <div className="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
+                    <button
+                      type="button"
+                      onClick={() => setIsOpen(false)}
+                      className="focus:shadow-outline-red inline-flex w-full justify-center rounded-md border border-transparent bg-red-600 px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-red-700 focus:outline-none sm:ml-3 sm:w-auto sm:text-sm"
+                    >
+                      Deactivate
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setIsOpen(false)}
+                      className="focus:shadow-outline-indigo mt-3 inline-flex w-full justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-base font-medium text-gray-700 shadow-sm hover:text-gray-500 focus:outline-none sm:mt-0 sm:w-auto sm:text-sm"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </Dialog.Panel>
+              </Transition.Child>
+            </div>
+          </div>
+        </Dialog>
+      </Transition>
+    </>
+  )
+}

--- a/packages/playground-vue/src/App.vue
+++ b/packages/playground-vue/src/App.vue
@@ -1,9 +1,7 @@
 <template>
-  <div
-    class="flex h-screen flex-col overflow-hidden bg-gray-700 font-sans text-gray-900 antialiased"
-  >
+  <div class="flex h-screen flex-col bg-gray-700 font-sans text-gray-900 antialiased">
     <header
-      class="relative z-10 flex flex-shrink-0 items-center justify-between border-b border-gray-200 bg-gray-700 px-4 py-4 sm:px-6 lg:px-8"
+      class="sticky top-0 z-10 flex flex-shrink-0 items-center justify-between border-b border-gray-200 bg-gray-700 px-4 py-4 sm:px-6 lg:px-8"
     >
       <router-link to="/">
         <svg class="h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 243 42">
@@ -60,7 +58,7 @@
         </svg>
       </router-link>
     </header>
-    <main class="flex-1 overflow-auto bg-gray-50">
+    <main class="flex-1 bg-gray-50">
       <router-view />
       <KeyCaster />
     </main>
@@ -68,8 +66,6 @@
 </template>
 
 <script>
-import { computed, watchEffect } from 'vue'
-import { useRoute } from 'vue-router'
 import KeyCaster from './KeyCaster.vue'
 
 export default {


### PR DESCRIPTION
This PR includes improvements to the management of the scroll lock state (especially for Dialog component).

- Enable page scrolling instead of limiting scrolling to inner containers. (891990819cf726b2bafbd95d4cb0148b73658756) Because the other one is a very rare use case and hides some of the issues that are being faced (fixed here 36ac5cfbb3ad06b3c93266f01f536df327f2fd7a).
- The `padding-right` added to `html` doesn't work for full-width fixed elements and causes a jump on them. If we know the padding applied to `html`, we can use something like this to prevent the jumping `right-[var(--html-padding-right,0)]`

```html
<div className="fixed top-0 left-0 right-[var(--html-padding-right,0)] ...">
```

Here is the comparison of `inset-x-0` and `left-0 right-[var(--html-padding-right,0)]`

`inset-x-0`            |  `left-0 right-[var(--html-padding-right,0)]`
:-------------------------:|:-------------------------:
<img width="1312" alt="Screen Shot 2023-03-02 at 17 57 48" src="https://user-images.githubusercontent.com/38227845/222468838-d3960e4c-1881-4e57-a86f-000932efa9ff.png">  |  <img width="1310" alt="Screen Shot 2023-03-02 at 17 58 02" src="https://user-images.githubusercontent.com/38227845/222468860-757b67f2-f307-45c8-aef8-d9bb5f9becba.png">

I think this addition will come in very handy for people who don't want this jump. I couldn't find any other solutions other than using MutationObserver or running an additional function on every modal opening and closing and adding the `padding-right` applied to `html` as a CSS variable.








