### PR TITLE
Fix invalid warning when using multiple `Popover.Button` components inside a `Popover.Panel`

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable native label behavior for `<Switch>` where possible ([#2265](https://github.com/tailwindlabs/headlessui/pull/2265))
 - Allow root containers from the `Dialog` component in the `FocusTrap` component ([#2322](https://github.com/tailwindlabs/headlessui/pull/2322))
 - Fix `XYZPropsWeControl` and cleanup internal TypeScript types ([#2329](https://github.com/tailwindlabs/headlessui/pull/2329))
+- Fix invalid warning when using multiple `Popover.Button` components inside a `Popover.Panel` ([#2333](https://github.com/tailwindlabs/headlessui/pull/2333))
 
 ## [1.7.12] - 2023-02-24
 

--- a/packages/@headlessui-react/src/components/popover/popover.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.tsx
@@ -358,24 +358,26 @@ function PopoverFn<TTag extends ElementType = typeof DEFAULT_POPOVER_TAG>(
   let ourProps = { ref: popoverRef }
 
   return (
-    <PopoverContext.Provider value={reducerBag}>
-      <PopoverAPIContext.Provider value={api}>
-        <OpenClosedProvider
-          value={match(popoverState, {
-            [PopoverStates.Open]: State.Open,
-            [PopoverStates.Closed]: State.Closed,
-          })}
-        >
-          {render({
-            ourProps,
-            theirProps,
-            slot,
-            defaultTag: DEFAULT_POPOVER_TAG,
-            name: 'Popover',
-          })}
-        </OpenClosedProvider>
-      </PopoverAPIContext.Provider>
-    </PopoverContext.Provider>
+    <PopoverPanelContext.Provider value={null}>
+      <PopoverContext.Provider value={reducerBag}>
+        <PopoverAPIContext.Provider value={api}>
+          <OpenClosedProvider
+            value={match(popoverState, {
+              [PopoverStates.Open]: State.Open,
+              [PopoverStates.Closed]: State.Closed,
+            })}
+          >
+            {render({
+              ourProps,
+              theirProps,
+              slot,
+              defaultTag: DEFAULT_POPOVER_TAG,
+              name: 'Popover',
+            })}
+          </OpenClosedProvider>
+        </PopoverAPIContext.Provider>
+      </PopoverContext.Provider>
+    </PopoverPanelContext.Provider>
   )
 }
 
@@ -417,7 +419,12 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
   // if a `Popover.Button` is rendered inside a `Popover` which in turn is rendered inside a
   // `Popover.Panel` (aka nested popovers), then we need to make sure that the button is able to
   // open the nested popover.
-  let isWithinPanel = panelContext === null ? false : panelContext === state.panelId
+  //
+  // The `Popover` itself will also render a `PopoverPanelContext` but with a value of `null`. That
+  // way we don't need to keep track of _which_ `Popover.Panel` (if at all) we are in, we can just
+  // check if we are in a `Popover.Panel` or not since this will always point to the nearest one and
+  // won't pierce through `Popover` components themselves.
+  let isWithinPanel = panelContext !== null
 
   useEffect(() => {
     if (isWithinPanel) return


### PR DESCRIPTION
This PR fixes an incorrect warning that complained about using multiple `Popover.Button` components. However this is valid inside the `Popover.Panel` itself, just not the `Popover`.

Also added a few tests to make sure we don't regress on this again.

This popped up again because we were checking the `panelId` to make sure that we are in the correct `Popover.Panel`. However, the `panelId` is set when the `Popover.Panel` is rendered and it is registered in a `useEffect`. This is all fine-ish, however this causes a "delay" in the value being ready. 

Combine this with wrapping the `Panel` inside a `Transition` component and the delay causes even more issues. 

To fix this, we reset the `PopoverPanelContext` with a `null` value. That way the `Popover` itself will always reset it. This means that the moment we are in a panel, that we are always in the nearest panel. If the `Popover` components are nested, the nested `Popover` would reset the value of the parent `Popover.Panel`.