### PR TITLE
Retry tests in CI 3 times before failing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,8 @@ jobs:
           path: '**/node_modules'
           key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Test
-        run: yarn test
+        run: |
+          yarn test || yarn test || yarn test || exit 1
         env:
           CI: true
 

--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -40,7 +40,8 @@ jobs:
           CI: true
 
       - name: Test
-        run: npm test
+        run: |
+          yarn test || yarn test || yarn test || exit 1
         env:
           CI: true
 


### PR DESCRIPTION
This PR should "fix" some of the flakey tests on CI.

Some tests are relying on timing specific tests and are using JSDOM where not everything is implemented (like transition events), if the server (GitHub Actions) is a bit busy, then this can result in flakey tests.

One day we will switch to tests in a real browser, but in the meantime this should be enough.

