### PR TITLE
Adds form prop to Switch component

### DIFF
--- a/packages/@headlessui-react/src/components/switch/switch.tsx
+++ b/packages/@headlessui-react/src/components/switch/switch.tsx
@@ -112,6 +112,7 @@ export type SwitchProps<TTag extends ElementType> = Props<
     onChange?(checked: boolean): void
     name?: string
     value?: string
+    form?: string
   }
 >
 
@@ -127,6 +128,7 @@ function SwitchFn<TTag extends ElementType = typeof DEFAULT_SWITCH_TAG>(
     onChange: controlledOnChange,
     name,
     value,
+    form,
     ...theirProps
   } = props
   let groupContext = useContext(GroupContext)
@@ -193,6 +195,7 @@ function SwitchFn<TTag extends ElementType = typeof DEFAULT_SWITCH_TAG>(
             type: 'checkbox',
             hidden: true,
             readOnly: true,
+            form,
             checked,
             name,
             value,


### PR DESCRIPTION
There are cases where you need to submit a form with elements that are not children of said form, with native inputs you can do this by adding the form name to the input, however when adding the hidden input field there is no way to add the form name thus this component cannot be used outside of a form.

This PR adds the possibility to add the form name to the hidden input field so that it can be submitted with the said form even if it's rendered outside of it.

This is particularly needed if you have inputs in different table cells within one row and only want to keep the submit button within the form so you don't have to wrap the entire  row on a form element (invalid markup)