### PR TITLE
[vue] Fix Combobox input disabled state

### DIFF
--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -935,6 +935,7 @@ export let ComboboxInput = defineComponent({
         tabIndex: 0,
         ref: api.inputRef,
         defaultValue: defaultValue.value,
+        disabled: api.disabled.value === true ? true : undefined,
       }
 
       return render({


### PR DESCRIPTION
Hi,
Thanks for your great work!

When disabling a Combobox in vue, the input didn't have the disabled attribute passed to true, resulting in a weird behavior.

![2023-03-16 20 07 01](https://user-images.githubusercontent.com/11351322/225727765-a841f6f8-253f-407b-92c1-6ebed14b0592.gif)

This PR fixes it.

Thanks
Mathieu.