### PR TITLE
Add ESM and `types` paths to `package.json` for TailwindCSS plugin

### DIFF
--- a/packages/@headlessui-tailwindcss/package.json
+++ b/packages/@headlessui-tailwindcss/package.json
@@ -11,9 +11,9 @@
     "dist"
   ],
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/headlessui.esm.js",
-    "require": "./dist/index.cjs",
-    "types": "./dist/index.d.ts"
+    "require": "./dist/index.cjs"
   },
   "sideEffects": false,
   "engines": {

--- a/packages/@headlessui-tailwindcss/package.json
+++ b/packages/@headlessui-tailwindcss/package.json
@@ -4,13 +4,16 @@
   "description": "A complementary Tailwind CSS plugin",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",
+  "module": "dist/headlessui.esm.js",
   "license": "MIT",
   "files": [
     "README.md",
     "dist"
   ],
   "exports": {
-    "require": "./dist/index.cjs"
+    "import": "./dist/headlessui.esm.js",
+    "require": "./dist/index.cjs",
+    "types": "./dist/index.d.ts"
   },
   "sideEffects": false,
   "engines": {


### PR DESCRIPTION
Fixes #2381. Also added ESM import paths since I noticed they were also missing.