### PR TITLE
check whether `document.body.addEventListener` exist

### DIFF
--- a/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
+++ b/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
@@ -211,7 +211,7 @@ export let FocusTrap = Object.assign(FocusTrapRoot, {
 // ---
 
 let history: HTMLElement[] = []
-if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+if (typeof window?.addEventListener !== 'undefined' && typeof document?.body?.addEventListener !== 'undefined') {
   function handle(e: Event) {
     if (!(e.target instanceof HTMLElement)) return
     if (e.target === document.body) return


### PR DESCRIPTION
if Dialog component is used in shadowDOM, browser will throw an error
```
Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
    at ../node_modules/.pnpm/@headlessui+react@1.7.13_biqbaboplfbrettd7655fr4n2y/node_modules/@headlessui/react/dist/components/focus-trap/focus-trap.js
```
which is because `document.body === null`, but we only check whether `document.body === undefined`