### PR TITLE
Add `FocusTrap` event listeners once document has loaded

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix focus styles showing up when using the mouse ([#2347](https://github.com/tailwindlabs/headlessui/pull/2347))
 - Fix "Can't perform a React state update on an unmounted component." when using the `Transition` component ([#2374](https://github.com/tailwindlabs/headlessui/pull/2374))
+- Add `FocusTrap` event listeners once document has loaded ([#2389](https://github.com/tailwindlabs/headlessui/pull/2389))
 
 ### Added
 

--- a/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
+++ b/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
@@ -212,28 +212,26 @@ export let FocusTrap = Object.assign(FocusTrapRoot, {
 // ---
 
 let history: HTMLElement[] = []
-onDocumentReady().then(() => {
-  if (typeof window !== 'undefined' && typeof document !== 'undefined') {
-    function handle(e: Event) {
-      if (!(e.target instanceof HTMLElement)) return
-      if (e.target === document.body) return
-      if (history[0] === e.target) return
+onDocumentReady(() => {
+  function handle(e: Event) {
+    if (!(e.target instanceof HTMLElement)) return
+    if (e.target === document.body) return
+    if (history[0] === e.target) return
 
-      history.unshift(e.target)
+    history.unshift(e.target)
 
-      // Filter out DOM Nodes that don't exist anymore
-      history = history.filter((x) => x != null && x.isConnected)
-      history.splice(10) // Only keep the 10 most recent items
-    }
-
-    window.addEventListener('click', handle, { capture: true })
-    window.addEventListener('mousedown', handle, { capture: true })
-    window.addEventListener('focus', handle, { capture: true })
-
-    document.body.addEventListener('click', handle, { capture: true })
-    document.body.addEventListener('mousedown', handle, { capture: true })
-    document.body.addEventListener('focus', handle, { capture: true })
+    // Filter out DOM Nodes that don't exist anymore
+    history = history.filter((x) => x != null && x.isConnected)
+    history.splice(10) // Only keep the 10 most recent items
   }
+
+  window.addEventListener('click', handle, { capture: true })
+  window.addEventListener('mousedown', handle, { capture: true })
+  window.addEventListener('focus', handle, { capture: true })
+
+  document.body.addEventListener('click', handle, { capture: true })
+  document.body.addEventListener('mousedown', handle, { capture: true })
+  document.body.addEventListener('focus', handle, { capture: true })
 })
 
 function useRestoreElement(enabled: boolean = true) {

--- a/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
+++ b/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
@@ -24,6 +24,7 @@ import { useEventListener } from '../../hooks/use-event-listener'
 import { microTask } from '../../utils/micro-task'
 import { useWatch } from '../../hooks/use-watch'
 import { useDisposables } from '../../hooks/use-disposables'
+import { onDocumentReady } from '../../utils/document-ready'
 
 type Containers =
   // Lazy resolved containers
@@ -211,27 +212,29 @@ export let FocusTrap = Object.assign(FocusTrapRoot, {
 // ---
 
 let history: HTMLElement[] = []
-if (typeof window !== 'undefined' && typeof document !== 'undefined') {
-  function handle(e: Event) {
-    if (!(e.target instanceof HTMLElement)) return
-    if (e.target === document.body) return
-    if (history[0] === e.target) return
+onDocumentReady().then(() => {
+  if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+    function handle(e: Event) {
+      if (!(e.target instanceof HTMLElement)) return
+      if (e.target === document.body) return
+      if (history[0] === e.target) return
 
-    history.unshift(e.target)
+      history.unshift(e.target)
 
-    // Filter out DOM Nodes that don't exist anymore
-    history = history.filter((x) => x != null && x.isConnected)
-    history.splice(10) // Only keep the 10 most recent items
+      // Filter out DOM Nodes that don't exist anymore
+      history = history.filter((x) => x != null && x.isConnected)
+      history.splice(10) // Only keep the 10 most recent items
+    }
+
+    window.addEventListener('click', handle, { capture: true })
+    window.addEventListener('mousedown', handle, { capture: true })
+    window.addEventListener('focus', handle, { capture: true })
+
+    document.body.addEventListener('click', handle, { capture: true })
+    document.body.addEventListener('mousedown', handle, { capture: true })
+    document.body.addEventListener('focus', handle, { capture: true })
   }
-
-  window.addEventListener('click', handle, { capture: true })
-  window.addEventListener('mousedown', handle, { capture: true })
-  window.addEventListener('focus', handle, { capture: true })
-
-  document.body.addEventListener('click', handle, { capture: true })
-  document.body.addEventListener('mousedown', handle, { capture: true })
-  document.body.addEventListener('focus', handle, { capture: true })
-}
+})
 
 function useRestoreElement(enabled: boolean = true) {
   let localHistory = useRef<HTMLElement[]>(history.slice())

--- a/packages/@headlessui-react/src/utils/document-ready.ts
+++ b/packages/@headlessui-react/src/utils/document-ready.ts
@@ -1,7 +1,7 @@
-export function onDocumentReady(cb?: () => void) {
+export function onDocumentReady(cb: () => void) {
   function check() {
     if (document.readyState === 'loading') return
-    cb?.()
+    cb()
     document.removeEventListener('DOMContentLoaded', check)
   }
 

--- a/packages/@headlessui-react/src/utils/document-ready.ts
+++ b/packages/@headlessui-react/src/utils/document-ready.ts
@@ -1,25 +1,12 @@
-function defer<T = unknown>() {
-  let resolve!: (value: T | PromiseLike<T>) => void
-  let reject!: (reason?: unknown) => void
-  const promise = new Promise<T>((_resolve, _reject) => {
-    resolve = _resolve
-    reject = _reject
-  })
-  return { promise, resolve, reject }
-}
-
-export function onDocumentReady() {
-  const ready = defer<void>()
-  const check = () => {
-    if (document.readyState === 'complete' || document.readyState === 'interactive') {
-      ready.resolve()
-      document.removeEventListener('readystatechange', check)
-    }
+export function onDocumentReady(cb?: () => void) {
+  let check = () => {
+    if (document.readyState === 'loading') return
+    cb?.()
+    document.removeEventListener('DOMContentLoaded', check)
   }
 
-  document.addEventListener('readystatechange', check)
-
-  check()
-
-  return ready.promise
+  if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', check)
+    check()
+  }
 }

--- a/packages/@headlessui-react/src/utils/document-ready.ts
+++ b/packages/@headlessui-react/src/utils/document-ready.ts
@@ -1,0 +1,25 @@
+function defer<T = unknown>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve
+    reject = _reject
+  })
+  return { promise, resolve, reject }
+}
+
+export function onDocumentReady() {
+  const ready = defer<void>()
+  const check = () => {
+    if (document.readyState === 'complete' || document.readyState === 'interactive') {
+      ready.resolve()
+      document.removeEventListener('readystatechange', check)
+    }
+  }
+
+  document.addEventListener('readystatechange', check)
+
+  check()
+
+  return ready.promise
+}

--- a/packages/@headlessui-react/src/utils/document-ready.ts
+++ b/packages/@headlessui-react/src/utils/document-ready.ts
@@ -1,5 +1,5 @@
 export function onDocumentReady(cb?: () => void) {
-  let check = () => {
+  function check() {
     if (document.readyState === 'loading') return
     cb?.()
     document.removeEventListener('DOMContentLoaded', check)

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix focus styles showing up when using the mouse ([#2347](https://github.com/tailwindlabs/headlessui/pull/2347))
 - Disable `ComboboxInput` when its `Combobox` is disabled ([#2375](https://github.com/tailwindlabs/headlessui/pull/2375))
+- Add `FocusTrap` event listeners once document has loaded ([#2389](https://github.com/tailwindlabs/headlessui/pull/2389))
 
 ### Added
 

--- a/packages/@headlessui-vue/src/components/focus-trap/focus-trap.ts
+++ b/packages/@headlessui-vue/src/components/focus-trap/focus-trap.ts
@@ -210,28 +210,26 @@ export let FocusTrap = Object.assign(
 )
 
 let history: HTMLElement[] = []
-onDocumentReady().then(() => {
-  if (typeof window !== 'undefined' && typeof document !== 'undefined') {
-    function handle(e: Event) {
-      if (!(e.target instanceof HTMLElement)) return
-      if (e.target === document.body) return
-      if (history[0] === e.target) return
+onDocumentReady(() => {
+  function handle(e: Event) {
+    if (!(e.target instanceof HTMLElement)) return
+    if (e.target === document.body) return
+    if (history[0] === e.target) return
 
-      history.unshift(e.target)
+    history.unshift(e.target)
 
-      // Filter out DOM Nodes that don't exist anymore
-      history = history.filter((x) => x != null && x.isConnected)
-      history.splice(10) // Only keep the 10 most recent items
-    }
-
-    window.addEventListener('click', handle, { capture: true })
-    window.addEventListener('mousedown', handle, { capture: true })
-    window.addEventListener('focus', handle, { capture: true })
-
-    document.body.addEventListener('click', handle, { capture: true })
-    document.body.addEventListener('mousedown', handle, { capture: true })
-    document.body.addEventListener('focus', handle, { capture: true })
+    // Filter out DOM Nodes that don't exist anymore
+    history = history.filter((x) => x != null && x.isConnected)
+    history.splice(10) // Only keep the 10 most recent items
   }
+
+  window.addEventListener('click', handle, { capture: true })
+  window.addEventListener('mousedown', handle, { capture: true })
+  window.addEventListener('focus', handle, { capture: true })
+
+  document.body.addEventListener('click', handle, { capture: true })
+  document.body.addEventListener('mousedown', handle, { capture: true })
+  document.body.addEventListener('focus', handle, { capture: true })
 })
 
 function useRestoreElement(enabled: Ref<boolean>) {

--- a/packages/@headlessui-vue/src/components/focus-trap/focus-trap.ts
+++ b/packages/@headlessui-vue/src/components/focus-trap/focus-trap.ts
@@ -22,7 +22,7 @@ import { useTabDirection, Direction as TabDirection } from '../../hooks/use-tab-
 import { getOwnerDocument } from '../../utils/owner'
 import { useEventListener } from '../../hooks/use-event-listener'
 import { microTask } from '../../utils/micro-task'
-import { onDocumentReady } from 'utils/document-ready'
+import { onDocumentReady } from '../../utils/document-ready'
 
 type Containers =
   // Lazy resolved containers

--- a/packages/@headlessui-vue/src/components/focus-trap/focus-trap.ts
+++ b/packages/@headlessui-vue/src/components/focus-trap/focus-trap.ts
@@ -22,6 +22,7 @@ import { useTabDirection, Direction as TabDirection } from '../../hooks/use-tab-
 import { getOwnerDocument } from '../../utils/owner'
 import { useEventListener } from '../../hooks/use-event-listener'
 import { microTask } from '../../utils/micro-task'
+import { onDocumentReady } from 'utils/document-ready'
 
 type Containers =
   // Lazy resolved containers
@@ -209,27 +210,29 @@ export let FocusTrap = Object.assign(
 )
 
 let history: HTMLElement[] = []
-if (typeof window !== 'undefined' && typeof document !== 'undefined') {
-  function handle(e: Event) {
-    if (!(e.target instanceof HTMLElement)) return
-    if (e.target === document.body) return
-    if (history[0] === e.target) return
+onDocumentReady().then(() => {
+  if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+    function handle(e: Event) {
+      if (!(e.target instanceof HTMLElement)) return
+      if (e.target === document.body) return
+      if (history[0] === e.target) return
 
-    history.unshift(e.target)
+      history.unshift(e.target)
 
-    // Filter out DOM Nodes that don't exist anymore
-    history = history.filter((x) => x != null && x.isConnected)
-    history.splice(10) // Only keep the 10 most recent items
+      // Filter out DOM Nodes that don't exist anymore
+      history = history.filter((x) => x != null && x.isConnected)
+      history.splice(10) // Only keep the 10 most recent items
+    }
+
+    window.addEventListener('click', handle, { capture: true })
+    window.addEventListener('mousedown', handle, { capture: true })
+    window.addEventListener('focus', handle, { capture: true })
+
+    document.body.addEventListener('click', handle, { capture: true })
+    document.body.addEventListener('mousedown', handle, { capture: true })
+    document.body.addEventListener('focus', handle, { capture: true })
   }
-
-  window.addEventListener('click', handle, { capture: true })
-  window.addEventListener('mousedown', handle, { capture: true })
-  window.addEventListener('focus', handle, { capture: true })
-
-  document.body.addEventListener('click', handle, { capture: true })
-  document.body.addEventListener('mousedown', handle, { capture: true })
-  document.body.addEventListener('focus', handle, { capture: true })
-}
+})
 
 function useRestoreElement(enabled: Ref<boolean>) {
   let localHistory = ref<HTMLElement[]>(history.slice())

--- a/packages/@headlessui-vue/src/utils/document-ready.ts
+++ b/packages/@headlessui-vue/src/utils/document-ready.ts
@@ -1,7 +1,7 @@
-export function onDocumentReady(cb?: () => void) {
+export function onDocumentReady(cb: () => void) {
   function check() {
     if (document.readyState === 'loading') return
-    cb?.()
+    cb()
     document.removeEventListener('DOMContentLoaded', check)
   }
 

--- a/packages/@headlessui-vue/src/utils/document-ready.ts
+++ b/packages/@headlessui-vue/src/utils/document-ready.ts
@@ -1,25 +1,12 @@
-function defer<T = unknown>() {
-  let resolve!: (value: T | PromiseLike<T>) => void
-  let reject!: (reason?: unknown) => void
-  const promise = new Promise<T>((_resolve, _reject) => {
-    resolve = _resolve
-    reject = _reject
-  })
-  return { promise, resolve, reject }
-}
-
-export function onDocumentReady() {
-  const ready = defer<void>()
-  const check = () => {
-    if (document.readyState === 'complete' || document.readyState === 'interactive') {
-      ready.resolve()
-      document.removeEventListener('readystatechange', check)
-    }
+export function onDocumentReady(cb?: () => void) {
+  let check = () => {
+    if (document.readyState === 'loading') return
+    cb?.()
+    document.removeEventListener('DOMContentLoaded', check)
   }
 
-  document.addEventListener('readystatechange', check)
-
-  check()
-
-  return ready.promise
+  if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', check)
+    check()
+  }
 }

--- a/packages/@headlessui-vue/src/utils/document-ready.ts
+++ b/packages/@headlessui-vue/src/utils/document-ready.ts
@@ -1,0 +1,25 @@
+function defer<T = unknown>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve
+    reject = _reject
+  })
+  return { promise, resolve, reject }
+}
+
+export function onDocumentReady() {
+  const ready = defer<void>()
+  const check = () => {
+    if (document.readyState === 'complete' || document.readyState === 'interactive') {
+      ready.resolve()
+      document.removeEventListener('readystatechange', check)
+    }
+  }
+
+  document.addEventListener('readystatechange', check)
+
+  check()
+
+  return ready.promise
+}

--- a/packages/@headlessui-vue/src/utils/document-ready.ts
+++ b/packages/@headlessui-vue/src/utils/document-ready.ts
@@ -1,5 +1,5 @@
 export function onDocumentReady(cb?: () => void) {
-  let check = () => {
+  function check() {
     if (document.readyState === 'loading') return
     cb?.()
     document.removeEventListener('DOMContentLoaded', check)


### PR DESCRIPTION
This PR fixes an issue where some event listeners in the `FocusTrap` component were added prematurely and could crash. This PR ensures that the document itself is ready before trying to attach these events.

If the events are added a little bit later it's not a super big deal.

---

Lazy loading event listeners. See: https://github.com/tailwindlabs/headlessui/pull/2387#issuecomment-1478293818