### PR TITLE
Improve `Combobox` types to improve false positives

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix "Can't perform a React state update on an unmounted component." when using the `Transition` component ([#2374](https://github.com/tailwindlabs/headlessui/pull/2374))
 - Add `FocusTrap` event listeners once document has loaded ([#2389](https://github.com/tailwindlabs/headlessui/pull/2389))
 - Fix `className` hydration for `<Transition appear>` ([#2390](https://github.com/tailwindlabs/headlessui/pull/2390))
+- Improve `Combobox` types to improve false positives ([#2411](https://github.com/tailwindlabs/headlessui/pull/2411))
 
 ### Added
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1426,10 +1426,10 @@ interface ComponentCombobox extends HasDisplayName {
     props: ComboboxProps<TValue, true, false, TTag> & RefProp<typeof ComboboxFn>
   ): JSX.Element
   <TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG>(
-    props: ComboboxProps<TValue, false, false, TTag> & RefProp<typeof ComboboxFn>
+    props: ComboboxProps<TValue, false, true, TTag> & RefProp<typeof ComboboxFn>
   ): JSX.Element
   <TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG>(
-    props: ComboboxProps<TValue, false, true, TTag> & RefProp<typeof ComboboxFn>
+    props: ComboboxProps<TValue, false, false, TTag> & RefProp<typeof ComboboxFn>
   ): JSX.Element
 }
 


### PR DESCRIPTION
If you use the default `Combobox` component then it defaults to `Fragment`. This also means that if you provide an additional prop that it would be forwarded to the `Fragment` but that won't work.

You do get a runtime error, but the types aren't 100% clear on what's going on. In fact, they make it very confusing because it will use the last "fallback" in all the `Combobox` definitions which marks the value as "multiple".

Concretely, this means:
```ts
let [value, setValue] = useState('Tom Cook')

<Combobox
  value={value}
  onChange={setValue}
  placeholder="Hello!"
/>
```

Starts complaining about the `value` and `onChange` not handling the
`multiple` case correctly. But it should complain about the `placeholder`.

Switching the order _does_ solve this, but it is not the cleanest solution.

Maybe we should be explicit about the `Fragment` case somehow.

However, there is a use case where I don't think TypeScript will be able to help and it's a bit unfortunate.
```ts
let [value, setValue] = useState('Tom Cook')

<Combobox value={value} onChange={setValue} placeholder="Hello!">
  <div>
    {/* ... */}
  </div>
</Combobox>
```

This is valid because at runtime we will forward all the props to the `div`. So not 100% sure what we should do here instead.

Visually, these changes look like:
<img width="423" alt="image" src="https://user-images.githubusercontent.com/1834413/229560139-b555961a-4c95-45bd-b6a7-1e216b729473.png">

vs
<img width="449" alt="image" src="https://user-images.githubusercontent.com/1834413/229560162-50f48a5d-7e8e-40f6-abc4-36f5230f0d5c.png">


Fixes: #2407
