### PR TITLE
Ensure DOM `ref` is properly handled in the `RadioGroup` component

### DIFF
--- a/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
@@ -1523,6 +1523,33 @@ describe('Rendering', () => {
       expect(handleChange).toHaveBeenNthCalledWith(2, 'bob')
     })
   })
+
+  it(
+    'should be possible to use a custom component using the `as` prop without crashing',
+    suppressConsoleLogs(async () => {
+      let CustomComponent = defineComponent({
+        template: html`<button><slot /></button>`,
+      })
+
+      renderTemplate({
+        template: html`
+          <Combobox name="assignee">
+            <ComboboxInput />
+            <ComboboxButton />
+            <ComboboxOptions>
+              <ComboboxOption :as="CustomComponent" value="alice">Alice</RadioGroupOption>
+              <ComboboxOption :as="CustomComponent" value="bob">Bob</RadioGroupOption>
+              <ComboboxOption :as="CustomComponent" value="charlie">Charlie</RadioGroupOption>
+            </ComboboxOptions>
+          </Combobox>
+        `,
+        setup: () => ({ CustomComponent }),
+      })
+
+      // Open combobox
+      await click(getComboboxButton())
+    })
+  )
 })
 
 describe('Rendering composition', () => {

--- a/packages/@headlessui-vue/src/components/listbox/listbox.test.tsx
+++ b/packages/@headlessui-vue/src/components/listbox/listbox.test.tsx
@@ -1270,6 +1270,32 @@ describe('Rendering', () => {
       expect(handleChange).toHaveBeenNthCalledWith(2, 'bob')
     })
   })
+
+  it(
+    'should be possible to use a custom component using the `as` prop without crashing',
+    suppressConsoleLogs(async () => {
+      let CustomComponent = defineComponent({
+        template: html`<button><slot /></button>`,
+      })
+
+      renderTemplate({
+        template: html`
+          <Listbox name="assignee">
+            <ListboxButton />
+            <ListboxOptions>
+              <ListboxOption :as="CustomComponent" value="alice">Alice</RadioGroupOption>
+              <ListboxOption :as="CustomComponent" value="bob">Bob</RadioGroupOption>
+              <ListboxOption :as="CustomComponent" value="charlie">Charlie</RadioGroupOption>
+            </ListboxOptions>
+          </Listbox>
+        `,
+        setup: () => ({ CustomComponent }),
+      })
+
+      // Open listbox
+      await click(getListboxButton())
+    })
+  )
 })
 
 describe('Rendering composition', () => {

--- a/packages/@headlessui-vue/src/components/menu/menu.test.tsx
+++ b/packages/@headlessui-vue/src/components/menu/menu.test.tsx
@@ -818,6 +818,32 @@ describe('Rendering', () => {
     // Verify that the third menu item is active
     assertMenuLinkedWithMenuItem(items[2])
   })
+
+  it(
+    'should be possible to use a custom component using the `as` prop without crashing',
+    suppressConsoleLogs(async () => {
+      let CustomComponent = defineComponent({
+        template: `<button><slot /></button>`,
+      })
+
+      renderTemplate({
+        template: `
+          <Menu>
+            <MenuButton />
+            <MenuOptions>
+              <MenuOption :as="CustomComponent">Alice</RadioGroupOption>
+              <MenuOption :as="CustomComponent">Bob</RadioGroupOption>
+              <MenuOption :as="CustomComponent">Charlie</RadioGroupOption>
+            </MenuOptions>
+          </Menu>
+        `,
+        setup: () => ({ CustomComponent }),
+      })
+
+      // Open menu
+      await click(getMenuButton())
+    })
+  )
 })
 
 describe('Rendering composition', () => {

--- a/packages/@headlessui-vue/src/components/radio-group/radio-group.test.ts
+++ b/packages/@headlessui-vue/src/components/radio-group/radio-group.test.ts
@@ -1,4 +1,4 @@
-import { nextTick, ref, watch, reactive } from 'vue'
+import { nextTick, ref, watch, reactive, defineComponent, defineExpose } from 'vue'
 import { createRenderTemplate, render } from '../../test-utils/vue-testing-library'
 
 import { RadioGroup, RadioGroupOption, RadioGroupLabel, RadioGroupDescription } from './radio-group'
@@ -495,6 +495,26 @@ describe('Rendering', () => {
     // Verify that the third radio group option is active
     assertActiveElement(getByText('Option 3'))
   })
+
+  it(
+    'should be possible to use a custom component using the `as` prop without crashing',
+    suppressConsoleLogs(async () => {
+      let CustomComponent = defineComponent({
+        template: html`<button><slot /></button>`,
+      })
+
+      renderTemplate({
+        template: html`
+          <RadioGroup name="assignee">
+            <RadioGroupOption :as="CustomComponent" value="alice">Alice</RadioGroupOption>
+            <RadioGroupOption :as="CustomComponent" value="bob">Bob</RadioGroupOption>
+            <RadioGroupOption :as="CustomComponent" value="charlie">Charlie</RadioGroupOption>
+          </RadioGroup>
+        `,
+        setup: () => ({ CustomComponent }),
+      })
+    })
+  )
 
   describe('Equality', () => {
     let options = [

--- a/packages/@headlessui-vue/src/components/radio-group/radio-group.ts
+++ b/packages/@headlessui-vue/src/components/radio-group/radio-group.ts
@@ -272,7 +272,7 @@ export let RadioGroup = defineComponent({
           : []),
         render({
           ourProps,
-          theirProps: { ...attrs, ...omit(theirProps, ['modelValue', 'defaultValue']) },
+          theirProps: { ...attrs, ...omit(theirProps, ['modelValue', 'defaultValue', 'by']) },
           slot: {},
           attrs,
           slots,

--- a/packages/@headlessui-vue/src/components/radio-group/radio-group.ts
+++ b/packages/@headlessui-vue/src/components/radio-group/radio-group.ts
@@ -309,7 +309,8 @@ export let RadioGroupOption = defineComponent({
 
     expose({ el: optionRef, $el: optionRef })
 
-    onMounted(() => api.registerOption({ id: props.id, element: optionRef, propsRef }))
+    let element = computed(() => dom(optionRef))
+    onMounted(() => api.registerOption({ id: props.id, element, propsRef }))
     onUnmounted(() => api.unregisterOption(props.id))
 
     let isFirstOption = computed(() => api.firstOption.value?.id === props.id)
@@ -326,7 +327,7 @@ export let RadioGroupOption = defineComponent({
       if (!api.change(props.value)) return
 
       state.value |= OptionState.Active
-      optionRef.value?.focus()
+      dom(optionRef)?.focus()
     }
 
     function handleFocus() {


### PR DESCRIPTION
This PR fixes an issue where the `RadioGroup` component didn't handle the `ref` correctly if you
were using a custom component using the `as` prop.

Small aside: dropped the `by` prop that leaked into the DOM.

Fixes: #2423
