### PR TITLE
Ensure `FocusTrap` is only active when the given `enabled` value is `true`

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [internal] add demo mode to `Menu` and `Popover` components ([#2448](https://github.com/tailwindlabs/headlessui/pull/2448))
 
+### Fixed
+
+- Ensure `FocusTrap` is only active when the given `enabled` value is `true` ([#2456](https://github.com/tailwindlabs/headlessui/pull/2456))
+
 ## [1.7.14] - 2023-04-12
 
 ### Fixed

--- a/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
+++ b/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
@@ -93,6 +93,7 @@ function FocusTrapFn<TTag extends ElementType = typeof DEFAULT_FOCUS_TRAP_TAG>(
     { ownerDocument, container, initialFocus },
     Boolean(features & Features.InitialFocus)
   )
+
   useFocusLock(
     { ownerDocument, container, containers, previousActiveElement },
     Boolean(features & Features.FocusLock)
@@ -236,6 +237,7 @@ onDocumentReady(() => {
 
 function useRestoreElement(enabled: boolean = true) {
   let localHistory = useRef<HTMLElement[]>(history.slice())
+  let oldActive = useRef<boolean>(enabled)
 
   useWatch(
     ([newEnabled], [oldEnabled]) => {
@@ -246,11 +248,13 @@ function useRestoreElement(enabled: boolean = true) {
         microTask(() => {
           localHistory.current.splice(0)
         })
+        oldActive.current = true
       }
 
       // We are enabling the restore element, so we need to set it to the last "focused" element.
       if (oldEnabled === false && newEnabled === true) {
         localHistory.current = history.slice()
+        oldActive.current = false
       }
     },
     [enabled, history, localHistory]
@@ -259,7 +263,7 @@ function useRestoreElement(enabled: boolean = true) {
   // We want to return the last element that is still connected to the DOM, so we can restore the
   // focus to it.
   return useEvent(() => {
-    return localHistory.current.find((x) => x != null && x.isConnected) ?? null
+    return localHistory.current.find((x) => x != null && x.isConnected && oldActive.current) ?? null
   })
 }
 

--- a/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
+++ b/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
@@ -279,11 +279,10 @@ function useRestoreFocus({ ownerDocument }: { ownerDocument: Document | null }, 
   // Restore the focus to the previous element when the component is unmounted
   let trulyUnmounted = useRef(false)
   useEffect(() => {
-    if (!enabled) return
-
     trulyUnmounted.current = false
 
     return () => {
+      if (!enabled) return
       trulyUnmounted.current = true
       microTask(() => {
         if (!trulyUnmounted.current) return

--- a/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
+++ b/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
@@ -237,7 +237,7 @@ onDocumentReady(() => {
 
 function useRestoreElement(enabled: boolean = true) {
   let localHistory = useRef<HTMLElement[]>(history.slice())
-  let oldActive = useRef<boolean>(enabled)
+  let isPreviouslyActive = useRef<boolean>(enabled)
 
   useWatch(
     ([newEnabled], [oldEnabled]) => {
@@ -248,13 +248,15 @@ function useRestoreElement(enabled: boolean = true) {
         microTask(() => {
           localHistory.current.splice(0)
         })
-        oldActive.current = true
       }
 
       // We are enabling the restore element, so we need to set it to the last "focused" element.
       if (oldEnabled === false && newEnabled === true) {
         localHistory.current = history.slice()
-        oldActive.current = false
+      }
+
+      if (oldEnabled !== undefined) {
+        isPreviouslyActive.current = oldEnabled
       }
     },
     [enabled, history, localHistory]
@@ -263,7 +265,10 @@ function useRestoreElement(enabled: boolean = true) {
   // We want to return the last element that is still connected to the DOM, so we can restore the
   // focus to it.
   return useEvent(() => {
-    return localHistory.current.find((x) => x != null && x.isConnected && oldActive.current) ?? null
+    return (
+      localHistory.current.find((x) => x != null && x.isConnected && isPreviouslyActive.current) ??
+      null
+    )
   })
 }
 

--- a/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
+++ b/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
@@ -237,7 +237,6 @@ onDocumentReady(() => {
 
 function useRestoreElement(enabled: boolean = true) {
   let localHistory = useRef<HTMLElement[]>(history.slice())
-  let isPreviouslyActive = useRef<boolean>(enabled)
 
   useWatch(
     ([newEnabled], [oldEnabled]) => {
@@ -254,10 +253,6 @@ function useRestoreElement(enabled: boolean = true) {
       if (oldEnabled === false && newEnabled === true) {
         localHistory.current = history.slice()
       }
-
-      if (oldEnabled !== undefined) {
-        isPreviouslyActive.current = oldEnabled
-      }
     },
     [enabled, history, localHistory]
   )
@@ -265,10 +260,7 @@ function useRestoreElement(enabled: boolean = true) {
   // We want to return the last element that is still connected to the DOM, so we can restore the
   // focus to it.
   return useEvent(() => {
-    return (
-      localHistory.current.find((x) => x != null && x.isConnected && isPreviouslyActive.current) ??
-      null
-    )
+    return localHistory.current.find((x) => x != null && x.isConnected) ?? null
   })
 }
 
@@ -287,6 +279,8 @@ function useRestoreFocus({ ownerDocument }: { ownerDocument: Document | null }, 
   // Restore the focus to the previous element when the component is unmounted
   let trulyUnmounted = useRef(false)
   useEffect(() => {
+    if (!enabled) return
+
     trulyUnmounted.current = false
 
     return () => {
@@ -297,7 +291,7 @@ function useRestoreFocus({ ownerDocument }: { ownerDocument: Document | null }, 
         focusElement(getRestoreElement())
       })
     }
-  }, [])
+  }, [enabled])
 }
 
 function useInitialFocus(

--- a/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
+++ b/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
@@ -1,5 +1,4 @@
 import React, {
-  useEffect,
   useRef,
 
   // Types
@@ -25,6 +24,7 @@ import { microTask } from '../../utils/micro-task'
 import { useWatch } from '../../hooks/use-watch'
 import { useDisposables } from '../../hooks/use-disposables'
 import { onDocumentReady } from '../../utils/document-ready'
+import { useOnUnmount } from '../../hooks/use-on-unmount'
 
 type Containers =
   // Lazy resolved containers
@@ -277,20 +277,11 @@ function useRestoreFocus({ ownerDocument }: { ownerDocument: Document | null }, 
   }, [enabled])
 
   // Restore the focus to the previous element when the component is unmounted
-  let trulyUnmounted = useRef(false)
-  useEffect(() => {
-    trulyUnmounted.current = false
+  useOnUnmount(() => {
+    if (!enabled) return
 
-    return () => {
-      if (!enabled) return
-      trulyUnmounted.current = true
-      microTask(() => {
-        if (!trulyUnmounted.current) return
-
-        focusElement(getRestoreElement())
-      })
-    }
-  }, [enabled])
+    focusElement(getRestoreElement())
+  })
 }
 
 function useInitialFocus(

--- a/packages/@headlessui-react/src/components/tabs/tabs.test.tsx
+++ b/packages/@headlessui-react/src/components/tabs/tabs.test.tsx
@@ -1,8 +1,8 @@
 import React, { createElement, useState } from 'react'
 import { render } from '@testing-library/react'
 
-import { Dialog } from '../dialog/dialog'
 import { Tab } from './tabs'
+import { Dialog } from '../dialog/dialog'
 import { suppressConsoleLogs } from '../../test-utils/suppress-console-logs'
 import {
   assertTabs,
@@ -2884,23 +2884,8 @@ describe('Mouse interactions', () => {
 
 describe('Composition', () => {
   it(
-    'should be possible to go to the next item (activation = `auto`) with a Dialog component',
+    'should be possible to go to the next item containing a Dialog component',
     suppressConsoleLogs(async () => {
-      function Example() {
-        let [isDialogOpen, setIsDialogOpen] = useState(false)
-        return (
-          <>
-            <button id="openDialog">Open dialog</button>
-            <Dialog open={isDialogOpen} onClose={console.log}>
-              <Dialog.Panel>
-                <button id="closeDialog" onClick={() => setIsDialogOpen(false)}>
-                  Close Dialog
-                </button>
-              </Dialog.Panel>
-            </Dialog>
-          </>
-        )
-      }
       render(
         <>
           <Tab.Group>
@@ -2911,11 +2896,14 @@ describe('Composition', () => {
             </Tab.List>
 
             <Tab.Panels>
-              <Tab.Panel>Content 1</Tab.Panel>
-              <Tab.Panel>
-                <Example />
+              <Tab.Panel data-panel="0">Content 1</Tab.Panel>
+              <Tab.Panel data-panel="1">
+                <>
+                  <button>open</button>
+                  <Dialog open={false} onClose={console.log} />
+                </>
               </Tab.Panel>
-              <Tab.Panel>Content 3</Tab.Panel>
+              <Tab.Panel data-panel="2">Content 3</Tab.Panel>
             </Tab.Panels>
           </Tab.Group>
         </>
@@ -2926,26 +2914,33 @@ describe('Composition', () => {
       await press(Keys.Tab)
       assertTabs({ active: 0 })
 
+      // Navigate to Dialog tab
       await press(Keys.ArrowRight)
       assertTabs({ active: 1 })
 
+      // Focus on to the Dialog panel
       await press(Keys.Tab)
-      expect(document.querySelector('#openDialog')).toHaveTextContent('Open dialog')
+      assertActiveElement(document.querySelector('[data-panel="1"]'))
 
+      // Focus on to the Dialog trigger button
       await press(Keys.Tab)
-      assertActiveElement(getByText('Open dialog'))
+      assertActiveElement(getByText('open'))
 
+      // Focus back to the panel
       await press(shift(Keys.Tab))
-      expect(document.querySelector('#openDialog')).toHaveTextContent('Open dialog')
+      assertActiveElement(document.querySelector('[data-panel="1"]'))
 
+      // Focus back to tabs
       await press(shift(Keys.Tab))
       assertTabs({ active: 1 })
 
+      // Navigate to the next tab
       await press(Keys.ArrowRight)
       assertTabs({ active: 2 })
 
+      // Focus on to the content panel
       await press(Keys.Tab)
-      assertActiveElement(getByText('Content 3'))
+      assertActiveElement(document.querySelector('[data-panel="2"]'))
     })
   )
 })

--- a/packages/@headlessui-react/src/hooks/use-on-unmount.ts
+++ b/packages/@headlessui-react/src/hooks/use-on-unmount.ts
@@ -1,0 +1,18 @@
+import { useRef, useEffect } from 'react'
+import { microTask } from '../utils/micro-task'
+
+export function useOnUnmount(cb: () => void) {
+  let trulyUnmounted = useRef(false)
+  useEffect(() => {
+    trulyUnmounted.current = false
+
+    return () => {
+      trulyUnmounted.current = true
+      microTask(() => {
+        if (!trulyUnmounted.current) return
+
+        cb()
+      })
+    }
+  }, [])
+}

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix memory leak in `Popover` component ([#2430](https://github.com/tailwindlabs/headlessui/pull/2430))
+- Ensure `FocusTrap` is only active when the given `enabled` value is `true` ([#2456](https://github.com/tailwindlabs/headlessui/pull/2456))
 
 ## [1.7.13] - 2023-04-12
 

--- a/packages/@headlessui-vue/src/components/focus-trap/focus-trap.ts
+++ b/packages/@headlessui-vue/src/components/focus-trap/focus-trap.ts
@@ -284,6 +284,8 @@ function useRestoreFocus(
 
   // Restore the focus when we unmount the component
   onUnmounted(() => {
+    if (!enabled.value) return
+
     focusElement(getRestoreElement())
   })
 }


### PR DESCRIPTION
Currently, the tab focus is wrong when navigating on a `Tab` containing a `Dialog` component. 

### Previous Behavior
[Screencast from 04-26-2023 04:22:32 PM.webm](https://user-images.githubusercontent.com/35242329/234532495-b43652d6-d1ef-4844-a3d1-a83958b94c53.webm)

### This PR Fix
[Screencast from 04-26-2023 04:23:58 PM.webm](https://user-images.githubusercontent.com/35242329/234532996-96f65814-8710-410b-832b-2e3fb15516f0.webm)



Fixes https://github.com/tailwindlabs/headlessui/issues/2406