### PR TITLE
Ensure the exposed `activeIndex` is up to date for the `Combobox` component

### DIFF
--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix memory leak in `Popover` component ([#2430](https://github.com/tailwindlabs/headlessui/pull/2430))
 - Ensure `FocusTrap` is only active when the given `enabled` value is `true` ([#2456](https://github.com/tailwindlabs/headlessui/pull/2456))
+- Ensure the exposed `activeIndex` is up to date for the `Combobox` component ([#2463](https://github.com/tailwindlabs/headlessui/pull/2463))
 
 ## [1.7.13] - 2023-04-12
 

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -232,7 +232,7 @@ export let Combobox = defineComponent({
         ) {
           let localActiveOptionIndex = options.value.findIndex((option) => !option.dataRef.disabled)
           if (localActiveOptionIndex !== -1) {
-            return localActiveOptionIndex
+            activeOptionIndex.value = localActiveOptionIndex
           }
         }
 
@@ -391,6 +391,15 @@ export let Combobox = defineComponent({
         options.value = adjustedState.options
         activeOptionIndex.value = adjustedState.activeOptionIndex
         activationTrigger.value = ActivationTrigger.Other
+
+        // If some of the DOM elements aren't ready yet, then we can retry in the next tick.
+        if (adjustedState.options.some((option) => !dom(option.dataRef.domRef))) {
+          requestAnimationFrame(() => {
+            let adjustedState = adjustOrderedState()
+            options.value = adjustedState.options
+            activeOptionIndex.value = adjustedState.activeOptionIndex
+          })
+        }
       },
       unregisterOption(id: string) {
         // When we are unregistering the currently active option, then we also have to make sure to


### PR DESCRIPTION
This PR fixes an issue where the exposed `activeIndex` value is out of sync with reality even though the `activeOption` itself contains the correct state.

Fixes: #2447

