### PR TITLE
move `types` condition to the front

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure `FocusTrap` is only active when the given `enabled` value is `true` ([#2456](https://github.com/tailwindlabs/headlessui/pull/2456))
 - Stop `<Transition appear>` from overwriting classes on re-render ([#2457](https://github.com/tailwindlabs/headlessui/pull/2457))
 
+### Changed
+
+- Move `types` condition to the front ([#2469](https://github.com/tailwindlabs/headlessui/pull/2469))
+
 ## [1.7.14] - 2023-04-12
 
 ### Fixed

--- a/packages/@headlessui-react/package.json
+++ b/packages/@headlessui-react/package.json
@@ -11,9 +11,9 @@
     "dist"
   ],
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/headlessui.esm.js",
-    "require": "./dist/index.cjs",
-    "types": "./dist/index.d.ts"
+    "require": "./dist/index.cjs"
   },
   "type": "module",
   "sideEffects": false,

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure `FocusTrap` is only active when the given `enabled` value is `true` ([#2456](https://github.com/tailwindlabs/headlessui/pull/2456))
 - Ensure the exposed `activeIndex` is up to date for the `Combobox` component ([#2463](https://github.com/tailwindlabs/headlessui/pull/2463))
 
+### Changed
+
+- Move `types` condition to the front ([#2469](https://github.com/tailwindlabs/headlessui/pull/2469))
+
 ## [1.7.13] - 2023-04-12
 
 ### Fixed

--- a/packages/@headlessui-vue/package.json
+++ b/packages/@headlessui-vue/package.json
@@ -11,9 +11,9 @@
     "dist"
   ],
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/headlessui.esm.js",
-    "require": "./dist/index.cjs",
-    "types": "./dist/index.d.ts"
+    "require": "./dist/index.cjs"
   },
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
I moved `types` condition to the front. `package.json#exports` are **order-sensitive** - they are always matched from the top to the bottom. When a match is found then it should be used and no further matching should occur. 

Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.

⚠️ this PR focuses solely on fixing "🐛 Used fallback condition" problem but the "👺 Masquerading as ESM" and "⚠️ ESM (dynamic import only)" remain here. You can check the reported errors for [@headlessui/react](https://arethetypeswrong.github.io/?p=%40headlessui%2Freact%401.7.14), [@headlessui/tailwindcss](https://arethetypeswrong.github.io/?p=%40headlessui%2Ftailwindcss%400.1.3) and [@headlessui/vue](https://arethetypeswrong.github.io/?p=%40headlessui%2Fvue%401.7.13)