### PR TITLE
Improve control over `Menu` and `Listbox` options while searching

### DIFF
--- a/jest/create-jest-config.cjs
+++ b/jest/create-jest-config.cjs
@@ -3,7 +3,11 @@ module.exports = function createJestConfig(root, options) {
   return Object.assign(
     {
       rootDir: root,
-      setupFilesAfterEnv: ['<rootDir>../../jest/custom-matchers.ts', ...setupFilesAfterEnv],
+      setupFilesAfterEnv: [
+        '<rootDir>../../jest/custom-matchers.ts',
+        '<rootDir>../../jest/polyfills.ts',
+        ...setupFilesAfterEnv,
+      ],
       transform: {
         '^.+\\.(t|j)sx?$': '@swc/jest',
         ...transform,

--- a/jest/polyfills.ts
+++ b/jest/polyfills.ts
@@ -1,0 +1,15 @@
+// JSDOM Doesn't implement innerText yet: https://github.com/jsdom/jsdom/issues/1245
+// So this is a hacky way of implementing it using `textContent`.
+// Real implementation doesn't use textContent because:
+// > textContent gets the content of all elements, including <script> and <style> elements. In
+// > contrast, innerText only shows "human-readable" elements.
+// >
+// > — https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent#differences_from_innertext
+Object.defineProperty(HTMLElement.prototype, 'innerText', {
+  get() {
+    return this.textContent
+  },
+  set(value) {
+    this.textContent = value
+  },
+})

--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure `FocusTrap` is only active when the given `enabled` value is `true` ([#2456](https://github.com/tailwindlabs/headlessui/pull/2456))
 - Stop `<Transition appear>` from overwriting classes on re-render ([#2457](https://github.com/tailwindlabs/headlessui/pull/2457))
+- Improve control over `Menu` and `Listbox` options while searching ([#2471](https://github.com/tailwindlabs/headlessui/pull/2471))
 
 ## [1.7.14] - 2023-04-12
 

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -48,7 +48,7 @@ import { useEvent } from '../../hooks/use-event'
 import { useControllable } from '../../hooks/use-controllable'
 import { useLatestValue } from '../../hooks/use-latest-value'
 import { useTrackedPointer } from '../../hooks/use-tracked-pointer'
-import { getTextValue } from '../../utils/get-text-value'
+import { useTextValue } from '../../hooks/use-text-value'
 
 enum ListboxStates {
   Open,
@@ -935,16 +935,13 @@ function OptionFn<
 
   let selected = data.isSelected(value)
   let internalOptionRef = useRef<HTMLLIElement | null>(null)
+  let getTextValue = useTextValue(internalOptionRef)
   let bag = useLatestValue<ListboxOptionDataRef<TType>['current']>({
     disabled,
     value,
     domRef: internalOptionRef,
     get textValue() {
-      let element = internalOptionRef.current
-      if (element) {
-        return getTextValue(element).trim().toLowerCase()
-      }
-      return ''
+      return getTextValue()
     },
   })
   let optionRef = useSyncRefs(ref, internalOptionRef)

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -48,6 +48,7 @@ import { useEvent } from '../../hooks/use-event'
 import { useControllable } from '../../hooks/use-controllable'
 import { useLatestValue } from '../../hooks/use-latest-value'
 import { useTrackedPointer } from '../../hooks/use-tracked-pointer'
+import { getTextValue } from '../../utils/get-text-value'
 
 enum ListboxStates {
   Open,
@@ -939,7 +940,11 @@ function OptionFn<
     value,
     domRef: internalOptionRef,
     get textValue() {
-      return internalOptionRef.current?.textContent?.toLowerCase()
+      let element = internalOptionRef.current
+      if (element) {
+        return getTextValue(element).trim().toLowerCase()
+      }
+      return ''
     },
   })
   let optionRef = useSyncRefs(ref, internalOptionRef)

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -51,7 +51,7 @@ import { useResolveButtonType } from '../../hooks/use-resolve-button-type'
 import { useOwnerDocument } from '../../hooks/use-owner'
 import { useEvent } from '../../hooks/use-event'
 import { useTrackedPointer } from '../../hooks/use-tracked-pointer'
-import { getTextValue } from '../../utils/get-text-value'
+import { useTextValue } from '../../hooks/use-text-value'
 
 enum MenuStates {
   Open,
@@ -637,15 +637,13 @@ function ItemFn<TTag extends ElementType = typeof DEFAULT_ITEM_TAG>(
     /* We also want to trigger this when the position of the active item changes so that we can re-trigger the scrollIntoView */ state.activeItemIndex,
   ])
 
+  let getTextValue = useTextValue(internalItemRef)
+
   let bag = useRef<MenuItemDataRef['current']>({
     disabled,
     domRef: internalItemRef,
     get textValue() {
-      let element = internalItemRef.current
-      if (element) {
-        return getTextValue(element).trim().toLowerCase()
-      }
-      return ''
+      return getTextValue()
     },
   })
 

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -51,6 +51,7 @@ import { useResolveButtonType } from '../../hooks/use-resolve-button-type'
 import { useOwnerDocument } from '../../hooks/use-owner'
 import { useEvent } from '../../hooks/use-event'
 import { useTrackedPointer } from '../../hooks/use-tracked-pointer'
+import { getTextValue } from '../../utils/get-text-value'
 
 enum MenuStates {
   Open,
@@ -636,14 +637,21 @@ function ItemFn<TTag extends ElementType = typeof DEFAULT_ITEM_TAG>(
     /* We also want to trigger this when the position of the active item changes so that we can re-trigger the scrollIntoView */ state.activeItemIndex,
   ])
 
-  let bag = useRef<MenuItemDataRef['current']>({ disabled, domRef: internalItemRef })
+  let bag = useRef<MenuItemDataRef['current']>({
+    disabled,
+    domRef: internalItemRef,
+    get textValue() {
+      let element = internalItemRef.current
+      if (element) {
+        return getTextValue(element).trim().toLowerCase()
+      }
+      return ''
+    },
+  })
 
   useIsoMorphicEffect(() => {
     bag.current.disabled = disabled
   }, [bag, disabled])
-  useIsoMorphicEffect(() => {
-    bag.current.textValue = internalItemRef.current?.textContent?.toLowerCase()
-  }, [bag, internalItemRef])
 
   useIsoMorphicEffect(() => {
     dispatch({ type: ActionTypes.RegisterItem, id, dataRef: bag })

--- a/packages/@headlessui-react/src/hooks/use-text-value.ts
+++ b/packages/@headlessui-react/src/hooks/use-text-value.ts
@@ -1,0 +1,25 @@
+import { useRef, MutableRefObject } from 'react'
+import { getTextValue } from '../utils/get-text-value'
+import { useEvent } from './use-event'
+
+export function useTextValue(element: MutableRefObject<HTMLElement | null>) {
+  let cacheKey = useRef<string>('')
+  let cacheValue = useRef<string>('')
+
+  return useEvent(() => {
+    let el = element.current
+    if (!el) return ''
+
+    // Check for a cached version
+    let currentKey = el.innerText
+    if (cacheKey.current === currentKey) {
+      return cacheValue.current
+    }
+
+    // Calculate the value
+    let value = getTextValue(el).trim().toLowerCase()
+    cacheKey.current = currentKey
+    cacheValue.current = value
+    return value
+  })
+}

--- a/packages/@headlessui-react/src/utils/get-text-value.test.ts
+++ b/packages/@headlessui-react/src/utils/get-text-value.test.ts
@@ -1,0 +1,69 @@
+import { getTextValue } from './get-text-value'
+
+let html = String.raw
+
+it('should be possible to get the text value from an element', () => {
+  let element = document.createElement('div')
+  element.innerText = 'Hello World'
+  expect(getTextValue(element)).toEqual('Hello World')
+})
+
+it('should strip out emojis when receiving the text from the element', () => {
+  let element = document.createElement('div')
+  element.innerText = '🇨🇦 Canada'
+  expect(getTextValue(element)).toEqual('Canada')
+})
+
+it('should strip out hidden elements', () => {
+  let element = document.createElement('div')
+  element.innerHTML = html`<div><span hidden>Hello</span> world</div>`
+  expect(getTextValue(element)).toEqual('world')
+})
+
+it('should strip out aria-hidden elements', () => {
+  let element = document.createElement('div')
+  element.innerHTML = html`<div><span aria-hidden>Hello</span> world</div>`
+  expect(getTextValue(element)).toEqual('world')
+})
+
+it('should strip out role="img" elements', () => {
+  let element = document.createElement('div')
+  element.innerHTML = html`<div><span role="img">°</span> world</div>`
+  expect(getTextValue(element)).toEqual('world')
+})
+
+it('should be possible to get the text value from the aria-label', () => {
+  let element = document.createElement('div')
+  element.setAttribute('aria-label', 'Hello World')
+  expect(getTextValue(element)).toEqual('Hello World')
+})
+
+it('should be possible to get the text value from the aria-label (even if there is content)', () => {
+  let element = document.createElement('div')
+  element.setAttribute('aria-label', 'Hello World')
+  element.innerHTML = 'Hello Universe'
+  element.innerText = 'Hello Universe'
+  expect(getTextValue(element)).toEqual('Hello World')
+})
+
+it('should be possible to get the text value from the element referenced by aria-labelledby (using `aria-label`)', () => {
+  document.body.innerHTML = html`
+    <div>
+      <div id="foo" aria-labelledby="bar">Contents of foo</div>
+      <div id="bar" aria-label="Actual value of bar">Contents of bar</div>
+    </div>
+  `
+
+  expect(getTextValue(document.querySelector('#foo')!)).toEqual('Actual value of bar')
+})
+
+it('should be possible to get the text value from the element referenced by aria-labelledby (using its contents)', () => {
+  document.body.innerHTML = html`
+    <div>
+      <div id="foo" aria-labelledby="bar">Contents of foo</div>
+      <div id="bar">Contents of bar</div>
+    </div>
+  `
+
+  expect(getTextValue(document.querySelector('#foo')!)).toEqual('Contents of bar')
+})

--- a/packages/@headlessui-react/src/utils/get-text-value.test.ts
+++ b/packages/@headlessui-react/src/utils/get-text-value.test.ts
@@ -67,3 +67,29 @@ it('should be possible to get the text value from the element referenced by aria
 
   expect(getTextValue(document.querySelector('#foo')!)).toEqual('Contents of bar')
 })
+
+it('should be possible to get the text value from the element referenced by aria-labelledby (using `aria-label`, multiple)', () => {
+  document.body.innerHTML = html`
+    <div>
+      <div id="foo" aria-labelledby="bar baz">Contents of foo</div>
+      <div id="bar" aria-label="Actual value of bar">Contents of bar</div>
+      <div id="baz" aria-label="Actual value of baz">Contents of baz</div>
+    </div>
+  `
+
+  expect(getTextValue(document.querySelector('#foo')!)).toEqual(
+    'Actual value of bar, Actual value of baz'
+  )
+})
+
+it('should be possible to get the text value from the element referenced by aria-labelledby (using its contents, multiple)', () => {
+  document.body.innerHTML = html`
+    <div>
+      <div id="foo" aria-labelledby="bar baz">Contents of foo</div>
+      <div id="bar">Contents of bar</div>
+      <div id="baz">Contents of baz</div>
+    </div>
+  `
+
+  expect(getTextValue(document.querySelector('#foo')!)).toEqual('Contents of bar, Contents of baz')
+})

--- a/packages/@headlessui-react/src/utils/get-text-value.ts
+++ b/packages/@headlessui-react/src/utils/get-text-value.ts
@@ -51,16 +51,27 @@ export function getTextValue(element: HTMLElement): string {
   // Try to use the `aria-labelledby` second
   let labelledby = element.getAttribute('aria-labelledby')
   if (labelledby) {
-    let labelEl = document.getElementById(labelledby)
-    if (labelEl) {
-      let label = labelEl.getAttribute('aria-label')
-      // Try to use the `aria-label` first (of the referenced element)
-      if (typeof label === 'string') return label.trim()
+    // aria-labelledby can be a space-separated list of IDs, so we need to split them up and
+    // combine them into a single string.
+    let labels = labelledby
+      .split(' ')
+      .map((labelledby) => {
+        let labelEl = document.getElementById(labelledby)
+        if (labelEl) {
+          let label = labelEl.getAttribute('aria-label')
+          // Try to use the `aria-label` first (of the referenced element)
+          if (typeof label === 'string') return label.trim()
 
-      // This time, the `aria-labelledby` isn't used anymore (in Safari), so we just have to
-      // look at the contents itself.
-      return getTextContents(labelEl).trim()
-    }
+          // This time, the `aria-labelledby` isn't used anymore (in Safari), so we just have to
+          // look at the contents itself.
+          return getTextContents(labelEl).trim()
+        }
+
+        return null
+      })
+      .filter(Boolean)
+
+    if (labels.length > 0) return labels.join(', ')
   }
 
   // Try to use the text contents of the element itself

--- a/packages/@headlessui-react/src/utils/get-text-value.ts
+++ b/packages/@headlessui-react/src/utils/get-text-value.ts
@@ -2,22 +2,13 @@ let emojiRegex =
   /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g
 
 function getTextContents(element: HTMLElement): string {
-  // Using innerText instad of textContent because:
+  // Using innerText instead of textContent because:
   //
   // > textContent gets the content of all elements, including <script> and <style> elements. In
   // > contrast, innerText only shows "human-readable" elements.
   // >
   // > — https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent#differences_from_innertext
-  let value = element.innerText ?? ''
-
-  // Check if it contains some emojis or not, if so, we need to remove them
-  // because ideally we work with simple text values.
-
-  // Ideally we can use the much simpler RegEx: /\p{Extended_Pictographic}/u
-  // but we can't rely on this yet, so we use the more complex one.
-  if (emojiRegex.test(value)) {
-    value = value.replace(emojiRegex, '')
-  }
+  let currentInnerText = element.innerText ?? ''
 
   // Remove all the elements that shouldn't be there.
   //
@@ -25,15 +16,30 @@ function getTextContents(element: HTMLElement): string {
   // [aria-hidden]  — The screen reader doesn't see it
   // [role="img"]   — Even if it is text, it is used as an image
   //
-  // This is probably the slowest part, but if you want complete control over the text value,
-  // you better set an `aria-label` instead.
-  let children = element.querySelectorAll('[hidden],[aria-hidden],[role="img"]')
-  if (children.length > 0) {
-    for (let el of children) {
-      if (el instanceof HTMLElement) {
-        value = value.replace(el.innerText ?? '', '')
-      }
-    }
+  // This is probably the slowest part, but if you want complete control over the text value, then
+  // it is better to set an `aria-label` instead.
+  let copy = element.cloneNode(true)
+  if (!(copy instanceof HTMLElement)) {
+    return currentInnerText
+  }
+
+  let dropped = false
+  // Drop the elements that shouldn't be there.
+  for (let child of copy.querySelectorAll('[hidden],[aria-hidden],[role="img"]')) {
+    child.remove()
+    dropped = true
+  }
+
+  // Now that the elements are removed, we can get the innerText such that we can strip the emojis.
+  let value = dropped ? copy.innerText ?? '' : currentInnerText
+
+  // Check if it contains some emojis or not, if so, we need to remove them
+  // because ideally we work with simple text values.
+  //
+  // Ideally we can use the much simpler RegEx: /\p{Extended_Pictographic}/u
+  // but we can't rely on this yet, so we use the more complex one.
+  if (emojiRegex.test(value)) {
+    value = value.replace(emojiRegex, '')
   }
 
   return value

--- a/packages/@headlessui-react/src/utils/get-text-value.ts
+++ b/packages/@headlessui-react/src/utils/get-text-value.ts
@@ -1,3 +1,6 @@
+let emojiRegex =
+  /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g
+
 function getTextContents(element: HTMLElement): string {
   // Using innerText instad of textContent because:
   //
@@ -12,15 +15,8 @@ function getTextContents(element: HTMLElement): string {
 
   // Ideally we can use the much simpler RegEx: /\p{Extended_Pictographic}/u
   // but we can't rely on this yet, so we use the more complex one.
-  if (
-    /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/.test(
-      value
-    )
-  ) {
-    value = value.replace(
-      /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g,
-      ''
-    )
+  if (emojiRegex.test(value)) {
+    value = value.replace(emojiRegex, '')
   }
 
   // Remove all the elements that shouldn't be there.

--- a/packages/@headlessui-react/src/utils/get-text-value.ts
+++ b/packages/@headlessui-react/src/utils/get-text-value.ts
@@ -1,0 +1,68 @@
+function getTextContents(element: HTMLElement): string {
+  // Using innerText instad of textContent because:
+  //
+  // > textContent gets the content of all elements, including <script> and <style> elements. In
+  // > contrast, innerText only shows "human-readable" elements.
+  // >
+  // > — https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent#differences_from_innertext
+  let value = element.innerText ?? ''
+
+  // Check if it contains some emojis or not, if so, we need to remove them
+  // because ideally we work with simple text values.
+
+  // Ideally we can use the much simpler RegEx: /\p{Extended_Pictographic}/u
+  // but we can't rely on this yet, so we use the more complex one.
+  if (
+    /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/.test(
+      value
+    )
+  ) {
+    value = value.replace(
+      /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g,
+      ''
+    )
+  }
+
+  // Remove all the elements that shouldn't be there.
+  //
+  // [hidden]       — The user doesn't see it
+  // [aria-hidden]  — The screen reader doesn't see it
+  // [role="img"]   — Even if it is text, it is used as an image
+  //
+  // This is probably the slowest part, but if you want complete control over the text value,
+  // you better set an `aria-label` instead.
+  let children = element.querySelectorAll('[hidden],[aria-hidden],[role="img"]')
+  if (children.length > 0) {
+    for (let el of children) {
+      if (el instanceof HTMLElement) {
+        value = value.replace(el.innerText ?? '', '')
+      }
+    }
+  }
+
+  return value
+}
+
+export function getTextValue(element: HTMLElement): string {
+  // Try to use the `aria-label` first
+  let label = element.getAttribute('aria-label')
+  if (typeof label === 'string') return label.trim()
+
+  // Try to use the `aria-labelledby` second
+  let labelledby = element.getAttribute('aria-labelledby')
+  if (labelledby) {
+    let labelEl = document.getElementById(labelledby)
+    if (labelEl) {
+      let label = labelEl.getAttribute('aria-label')
+      // Try to use the `aria-label` first (of the referenced element)
+      if (typeof label === 'string') return label.trim()
+
+      // This time, the `aria-labelledby` isn't used anymore (in Safari), so we just have to
+      // look at the contents itself.
+      return getTextContents(labelEl).trim()
+    }
+  }
+
+  // Try to use the text contents of the element itself
+  return getTextContents(element).trim()
+}

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix memory leak in `Popover` component ([#2430](https://github.com/tailwindlabs/headlessui/pull/2430))
 - Ensure `FocusTrap` is only active when the given `enabled` value is `true` ([#2456](https://github.com/tailwindlabs/headlessui/pull/2456))
 - Ensure the exposed `activeIndex` is up to date for the `Combobox` component ([#2463](https://github.com/tailwindlabs/headlessui/pull/2463))
+- Improve control over `Menu` and `Listbox` options while searching ([#2471](https://github.com/tailwindlabs/headlessui/pull/2471))
 
 ## [1.7.13] - 2023-04-12
 

--- a/packages/@headlessui-vue/src/components/listbox/listbox.ts
+++ b/packages/@headlessui-vue/src/components/listbox/listbox.ts
@@ -35,7 +35,7 @@ import { Hidden, Features as HiddenFeatures } from '../../internal/hidden'
 import { objectToFormEntries } from '../../utils/form'
 import { useControllable } from '../../hooks/use-controllable'
 import { useTrackedPointer } from '../../hooks/use-tracked-pointer'
-import { getTextValue } from '../../utils/get-text-value'
+import { useTextValue } from '../../hooks/use-text-value'
 
 function defaultComparator<T>(a: T, z: T): boolean {
   return a === z
@@ -732,15 +732,12 @@ export let ListboxOption = defineComponent({
       })
     })
 
+    let getTextValue = useTextValue(internalOptionRef)
     let dataRef = computed<ListboxOptionData>(() => ({
       disabled: props.disabled,
       value: props.value,
       get textValue() {
-        let element = dom(internalOptionRef)
-        if (element) {
-          return getTextValue(element).trim().toLowerCase()
-        }
-        return ''
+        return getTextValue()
       },
       domRef: internalOptionRef,
     }))

--- a/packages/@headlessui-vue/src/components/listbox/listbox.ts
+++ b/packages/@headlessui-vue/src/components/listbox/listbox.ts
@@ -35,6 +35,7 @@ import { Hidden, Features as HiddenFeatures } from '../../internal/hidden'
 import { objectToFormEntries } from '../../utils/form'
 import { useControllable } from '../../hooks/use-controllable'
 import { useTrackedPointer } from '../../hooks/use-tracked-pointer'
+import { getTextValue } from '../../utils/get-text-value'
 
 function defaultComparator<T>(a: T, z: T): boolean {
   return a === z
@@ -734,13 +735,15 @@ export let ListboxOption = defineComponent({
     let dataRef = computed<ListboxOptionData>(() => ({
       disabled: props.disabled,
       value: props.value,
-      textValue: '',
+      get textValue() {
+        let element = dom(internalOptionRef)
+        if (element) {
+          return getTextValue(element).trim().toLowerCase()
+        }
+        return ''
+      },
       domRef: internalOptionRef,
     }))
-    onMounted(() => {
-      let textValue = dom(internalOptionRef)?.textContent?.toLowerCase().trim()
-      if (textValue !== undefined) dataRef.value.textValue = textValue
-    })
 
     onMounted(() => api.registerOption(props.id, dataRef))
     onUnmounted(() => api.unregisterOption(props.id))

--- a/packages/@headlessui-vue/src/components/menu/menu.ts
+++ b/packages/@headlessui-vue/src/components/menu/menu.ts
@@ -32,7 +32,7 @@ import {
 } from '../../utils/focus-management'
 import { useOutsideClick } from '../../hooks/use-outside-click'
 import { useTrackedPointer } from '../../hooks/use-tracked-pointer'
-import { getTextValue } from '../../utils/get-text-value'
+import { useTextValue } from '../../hooks/use-text-value'
 
 enum MenuStates {
   Open,
@@ -512,14 +512,11 @@ export let MenuItem = defineComponent({
         : false
     })
 
+    let getTextValue = useTextValue(internalItemRef)
     let dataRef = computed<MenuItemData>(() => ({
       disabled: props.disabled,
       get textValue() {
-        let element = dom(internalItemRef)
-        if (element) {
-          return getTextValue(element).trim().toLowerCase()
-        }
-        return ''
+        return getTextValue()
       },
       domRef: internalItemRef,
     }))

--- a/packages/@headlessui-vue/src/components/menu/menu.ts
+++ b/packages/@headlessui-vue/src/components/menu/menu.ts
@@ -32,6 +32,7 @@ import {
 } from '../../utils/focus-management'
 import { useOutsideClick } from '../../hooks/use-outside-click'
 import { useTrackedPointer } from '../../hooks/use-tracked-pointer'
+import { getTextValue } from '../../utils/get-text-value'
 
 enum MenuStates {
   Open,
@@ -513,13 +514,15 @@ export let MenuItem = defineComponent({
 
     let dataRef = computed<MenuItemData>(() => ({
       disabled: props.disabled,
-      textValue: '',
+      get textValue() {
+        let element = dom(internalItemRef)
+        if (element) {
+          return getTextValue(element).trim().toLowerCase()
+        }
+        return ''
+      },
       domRef: internalItemRef,
     }))
-    onMounted(() => {
-      let textValue = dom(internalItemRef)?.textContent?.toLowerCase().trim()
-      if (textValue !== undefined) dataRef.value.textValue = textValue
-    })
 
     onMounted(() => api.registerItem(props.id, dataRef))
     onUnmounted(() => api.unregisterItem(props.id))

--- a/packages/@headlessui-vue/src/hooks/use-text-value.ts
+++ b/packages/@headlessui-vue/src/hooks/use-text-value.ts
@@ -1,0 +1,25 @@
+import { ref, Ref } from 'vue'
+import { getTextValue } from '../utils/get-text-value'
+import { dom } from '../utils/dom'
+
+export function useTextValue(element: Ref<HTMLElement | null>) {
+  let cacheKey = ref<string>('')
+  let cacheValue = ref<string>('')
+
+  return () => {
+    let el = dom(element)
+    if (!el) return ''
+
+    // Check for a cached version
+    let currentKey = el.innerText
+    if (cacheKey.value === currentKey) {
+      return cacheValue.value
+    }
+
+    // Calculate the value
+    let value = getTextValue(el).trim().toLowerCase()
+    cacheKey.value = currentKey
+    cacheValue.value = value
+    return value
+  }
+}

--- a/packages/@headlessui-vue/src/utils/get-text-value.test.ts
+++ b/packages/@headlessui-vue/src/utils/get-text-value.test.ts
@@ -1,0 +1,69 @@
+import { getTextValue } from './get-text-value'
+
+let html = String.raw
+
+it('should be possible to get the text value from an element', () => {
+  let element = document.createElement('div')
+  element.innerText = 'Hello World'
+  expect(getTextValue(element)).toEqual('Hello World')
+})
+
+it('should strip out emojis when receiving the text from the element', () => {
+  let element = document.createElement('div')
+  element.innerText = '🇨🇦 Canada'
+  expect(getTextValue(element)).toEqual('Canada')
+})
+
+it('should strip out hidden elements', () => {
+  let element = document.createElement('div')
+  element.innerHTML = html`<div><span hidden>Hello</span> world</div>`
+  expect(getTextValue(element)).toEqual('world')
+})
+
+it('should strip out aria-hidden elements', () => {
+  let element = document.createElement('div')
+  element.innerHTML = html`<div><span aria-hidden>Hello</span> world</div>`
+  expect(getTextValue(element)).toEqual('world')
+})
+
+it('should strip out role="img" elements', () => {
+  let element = document.createElement('div')
+  element.innerHTML = html`<div><span role="img">°</span> world</div>`
+  expect(getTextValue(element)).toEqual('world')
+})
+
+it('should be possible to get the text value from the aria-label', () => {
+  let element = document.createElement('div')
+  element.setAttribute('aria-label', 'Hello World')
+  expect(getTextValue(element)).toEqual('Hello World')
+})
+
+it('should be possible to get the text value from the aria-label (even if there is content)', () => {
+  let element = document.createElement('div')
+  element.setAttribute('aria-label', 'Hello World')
+  element.innerHTML = 'Hello Universe'
+  element.innerText = 'Hello Universe'
+  expect(getTextValue(element)).toEqual('Hello World')
+})
+
+it('should be possible to get the text value from the element referenced by aria-labelledby (using `aria-label`)', () => {
+  document.body.innerHTML = html`
+    <div>
+      <div id="foo" aria-labelledby="bar">Contents of foo</div>
+      <div id="bar" aria-label="Actual value of bar">Contents of bar</div>
+    </div>
+  `
+
+  expect(getTextValue(document.querySelector('#foo')!)).toEqual('Actual value of bar')
+})
+
+it('should be possible to get the text value from the element referenced by aria-labelledby (using its contents)', () => {
+  document.body.innerHTML = html`
+    <div>
+      <div id="foo" aria-labelledby="bar">Contents of foo</div>
+      <div id="bar">Contents of bar</div>
+    </div>
+  `
+
+  expect(getTextValue(document.querySelector('#foo')!)).toEqual('Contents of bar')
+})

--- a/packages/@headlessui-vue/src/utils/get-text-value.test.ts
+++ b/packages/@headlessui-vue/src/utils/get-text-value.test.ts
@@ -67,3 +67,29 @@ it('should be possible to get the text value from the element referenced by aria
 
   expect(getTextValue(document.querySelector('#foo')!)).toEqual('Contents of bar')
 })
+
+it('should be possible to get the text value from the element referenced by aria-labelledby (using `aria-label`, multiple)', () => {
+  document.body.innerHTML = html`
+    <div>
+      <div id="foo" aria-labelledby="bar baz">Contents of foo</div>
+      <div id="bar" aria-label="Actual value of bar">Contents of bar</div>
+      <div id="baz" aria-label="Actual value of baz">Contents of baz</div>
+    </div>
+  `
+
+  expect(getTextValue(document.querySelector('#foo')!)).toEqual(
+    'Actual value of bar, Actual value of baz'
+  )
+})
+
+it('should be possible to get the text value from the element referenced by aria-labelledby (using its contents, multiple)', () => {
+  document.body.innerHTML = html`
+    <div>
+      <div id="foo" aria-labelledby="bar baz">Contents of foo</div>
+      <div id="bar">Contents of bar</div>
+      <div id="baz">Contents of baz</div>
+    </div>
+  `
+
+  expect(getTextValue(document.querySelector('#foo')!)).toEqual('Contents of bar, Contents of baz')
+})

--- a/packages/@headlessui-vue/src/utils/get-text-value.ts
+++ b/packages/@headlessui-vue/src/utils/get-text-value.ts
@@ -51,16 +51,27 @@ export function getTextValue(element: HTMLElement): string {
   // Try to use the `aria-labelledby` second
   let labelledby = element.getAttribute('aria-labelledby')
   if (labelledby) {
-    let labelEl = document.getElementById(labelledby)
-    if (labelEl) {
-      let label = labelEl.getAttribute('aria-label')
-      // Try to use the `aria-label` first (of the referenced element)
-      if (typeof label === 'string') return label.trim()
+    // aria-labelledby can be a space-separated list of IDs, so we need to split them up and
+    // combine them into a single string.
+    let labels = labelledby
+      .split(' ')
+      .map((labelledby) => {
+        let labelEl = document.getElementById(labelledby)
+        if (labelEl) {
+          let label = labelEl.getAttribute('aria-label')
+          // Try to use the `aria-label` first (of the referenced element)
+          if (typeof label === 'string') return label.trim()
 
-      // This time, the `aria-labelledby` isn't used anymore (in Safari), so we just have to
-      // look at the contents itself.
-      return getTextContents(labelEl).trim()
-    }
+          // This time, the `aria-labelledby` isn't used anymore (in Safari), so we just have to
+          // look at the contents itself.
+          return getTextContents(labelEl).trim()
+        }
+
+        return null
+      })
+      .filter(Boolean)
+
+    if (labels.length > 0) return labels.join(', ')
   }
 
   // Try to use the text contents of the element itself

--- a/packages/@headlessui-vue/src/utils/get-text-value.ts
+++ b/packages/@headlessui-vue/src/utils/get-text-value.ts
@@ -2,22 +2,13 @@ let emojiRegex =
   /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g
 
 function getTextContents(element: HTMLElement): string {
-  // Using innerText instad of textContent because:
+  // Using innerText instead of textContent because:
   //
   // > textContent gets the content of all elements, including <script> and <style> elements. In
   // > contrast, innerText only shows "human-readable" elements.
   // >
   // > — https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent#differences_from_innertext
-  let value = element.innerText ?? ''
-
-  // Check if it contains some emojis or not, if so, we need to remove them
-  // because ideally we work with simple text values.
-
-  // Ideally we can use the much simpler RegEx: /\p{Extended_Pictographic}/u
-  // but we can't rely on this yet, so we use the more complex one.
-  if (emojiRegex.test(value)) {
-    value = value.replace(emojiRegex, '')
-  }
+  let currentInnerText = element.innerText ?? ''
 
   // Remove all the elements that shouldn't be there.
   //
@@ -25,15 +16,30 @@ function getTextContents(element: HTMLElement): string {
   // [aria-hidden]  — The screen reader doesn't see it
   // [role="img"]   — Even if it is text, it is used as an image
   //
-  // This is probably the slowest part, but if you want complete control over the text value,
-  // you better set an `aria-label` instead.
-  let children = element.querySelectorAll('[hidden],[aria-hidden],[role="img"]')
-  if (children.length > 0) {
-    for (let el of children) {
-      if (el instanceof HTMLElement) {
-        value = value.replace(el.innerText ?? '', '')
-      }
-    }
+  // This is probably the slowest part, but if you want complete control over the text value, then
+  // it is better to set an `aria-label` instead.
+  let copy = element.cloneNode(true)
+  if (!(copy instanceof HTMLElement)) {
+    return currentInnerText
+  }
+
+  let dropped = false
+  // Drop the elements that shouldn't be there.
+  for (let child of copy.querySelectorAll('[hidden],[aria-hidden],[role="img"]')) {
+    child.remove()
+    dropped = true
+  }
+
+  // Now that the elements are removed, we can get the innerText such that we can strip the emojis.
+  let value = dropped ? copy.innerText ?? '' : currentInnerText
+
+  // Check if it contains some emojis or not, if so, we need to remove them
+  // because ideally we work with simple text values.
+  //
+  // Ideally we can use the much simpler RegEx: /\p{Extended_Pictographic}/u
+  // but we can't rely on this yet, so we use the more complex one.
+  if (emojiRegex.test(value)) {
+    value = value.replace(emojiRegex, '')
   }
 
   return value

--- a/packages/@headlessui-vue/src/utils/get-text-value.ts
+++ b/packages/@headlessui-vue/src/utils/get-text-value.ts
@@ -1,3 +1,6 @@
+let emojiRegex =
+  /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g
+
 function getTextContents(element: HTMLElement): string {
   // Using innerText instad of textContent because:
   //
@@ -12,15 +15,8 @@ function getTextContents(element: HTMLElement): string {
 
   // Ideally we can use the much simpler RegEx: /\p{Extended_Pictographic}/u
   // but we can't rely on this yet, so we use the more complex one.
-  if (
-    /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/.test(
-      value
-    )
-  ) {
-    value = value.replace(
-      /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g,
-      ''
-    )
+  if (emojiRegex.test(value)) {
+    value = value.replace(emojiRegex, '')
   }
 
   // Remove all the elements that shouldn't be there.

--- a/packages/@headlessui-vue/src/utils/get-text-value.ts
+++ b/packages/@headlessui-vue/src/utils/get-text-value.ts
@@ -1,0 +1,68 @@
+function getTextContents(element: HTMLElement): string {
+  // Using innerText instad of textContent because:
+  //
+  // > textContent gets the content of all elements, including <script> and <style> elements. In
+  // > contrast, innerText only shows "human-readable" elements.
+  // >
+  // > — https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent#differences_from_innertext
+  let value = element.innerText ?? ''
+
+  // Check if it contains some emojis or not, if so, we need to remove them
+  // because ideally we work with simple text values.
+
+  // Ideally we can use the much simpler RegEx: /\p{Extended_Pictographic}/u
+  // but we can't rely on this yet, so we use the more complex one.
+  if (
+    /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/.test(
+      value
+    )
+  ) {
+    value = value.replace(
+      /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g,
+      ''
+    )
+  }
+
+  // Remove all the elements that shouldn't be there.
+  //
+  // [hidden]       — The user doesn't see it
+  // [aria-hidden]  — The screen reader doesn't see it
+  // [role="img"]   — Even if it is text, it is used as an image
+  //
+  // This is probably the slowest part, but if you want complete control over the text value,
+  // you better set an `aria-label` instead.
+  let children = element.querySelectorAll('[hidden],[aria-hidden],[role="img"]')
+  if (children.length > 0) {
+    for (let el of children) {
+      if (el instanceof HTMLElement) {
+        value = value.replace(el.innerText ?? '', '')
+      }
+    }
+  }
+
+  return value
+}
+
+export function getTextValue(element: HTMLElement): string {
+  // Try to use the `aria-label` first
+  let label = element.getAttribute('aria-label')
+  if (typeof label === 'string') return label.trim()
+
+  // Try to use the `aria-labelledby` second
+  let labelledby = element.getAttribute('aria-labelledby')
+  if (labelledby) {
+    let labelEl = document.getElementById(labelledby)
+    if (labelEl) {
+      let label = labelEl.getAttribute('aria-label')
+      // Try to use the `aria-label` first (of the referenced element)
+      if (typeof label === 'string') return label.trim()
+
+      // This time, the `aria-labelledby` isn't used anymore (in Safari), so we just have to
+      // look at the contents itself.
+      return getTextContents(labelEl).trim()
+    }
+  }
+
+  // Try to use the text contents of the element itself
+  return getTextContents(element).trim()
+}


### PR DESCRIPTION
This PR improves the control over the "text value" of a `Menu.Item` or `Listbox.Option`.

When a `Menu` or a `Listbox` is in an open state, then you can just start typing to search for a specific item. It uses a simple algorithm where it looks at the beginning of the option and if it matches your search or not. If you are on an option and you re-type the same thing, then it will jump to the next option that matches.

Concretely, let's look at this setup:

```js
<Listbox>
  <Listbox.Button>Country</Listbox.Button>
  <Listbox.Options>
    <Listbox.Option value="us">United States of America</Listbox.Option>
    <Listbox.Option value="ca">Canada</Listbox.Option>
    <Listbox.Option value="be">Belgium</Listbox.Option>
    <Listbox.Option value="by">Belarus</Listbox.Option>
  </Listbox.Options>
</Listbox>
```

If you open the Listbox, then type:

- `united` then it will jump to the `United States of America`
- `bel` then it will jump to the `Belgium`
- `bel` (again) then it will jump to `Belarus`

> Note: you won't "see" what you type because there is no input field. It's just a quick way of typing a few letters and jumping to the nearest match which could help you to navigate quicker in a list. If you do want more control over the searching algorithm and if you want to see what you type, then you can look at the `Combobox` component instead.

That said, there is a bit of a problem. If you include an emoji in the beginning (for example a country flag) then typing `bel` for `Belgium` won't work because you need to type the emoji first.

To solve this, we will strip out emojis from the text value representation of the option.

```js
<Listbox>
  <Listbox.Button>Country</Listbox.Button>
  <Listbox.Options>
    <Listbox.Option value="us">🇺🇸 United States of America</Listbox.Option>
    <Listbox.Option value="ca">🇨🇦 Canada</Listbox.Option>
    <Listbox.Option value="be">🇧🇪 Belgium</Listbox.Option>
    <Listbox.Option value="by">🇧🇾 Belarus</Listbox.Option>
  </Listbox.Options>
</Listbox>
```

This example will behave the same as the example without the flags.

If you open the Listbox, then type:

- `united` then it will jump to the `United States of America`
- `bel` then it will jump to the `Belgium`
- `bel` (again) then it will jump to `Belarus`

But there is an additional problem. It could be that the contents of the option contains "image"-like text, such as ASCII art. Or for a more realistic example, an icon font that uses some special characters to display a certain "image" using a font.

Example using ASCII art:

```js
<Listbox>
  <Listbox.Button>Country</Listbox.Button>
  <Listbox.Options>
    <Listbox.Option value="us">🇺🇸 United States of America</Listbox.Option>
    <Listbox.Option value="ca">🇨🇦 Canada</Listbox.Option>
    <Listbox.Option value="be">🇧🇪 Belgium</Listbox.Option>
    <Listbox.Option value="by">🇧🇾 Belarus</Listbox.Option>
    <Listbox.Option value="delete">
      <div role="img">
        <p>(╯°□°）╯︵ ┻━┻</p>
      </div>
      Delete
    </Listbox.Option>
  </Listbox.Options>
</Listbox>
```

This now means that you won't be able to "delete", because these strange characters are in front of the "delete" word. They are also not emojis so they won't be stripped by default.

To solve this, we will also make sure to drop any text content that is in an element with one of these characteristics:

- Contains a `hidden` attribute (e.g.: `<div hidden>Hidden for everyone</div>`)
- Contains a `aria-hidden` attribute (e.g.: `<div aria-hidden="true">Hidden for assistive technology</div>`)
- Contains a `role="img"` attribute (e.g.: `<div role="img">image-like text</div>`)

This has to crawl the DOM and can be expensive, however in some scenarios you know _exactly_ what should happen, in those cases you can also drop all the "visual" artifacts and use an `aria-label="delete"` attribute to describe what this means exactly.

Note: Assistive technology will also use `aria-label` and `aria-labelledby` when it is present on the element instead of the contents of the element.

Now you have complete control over the items:

```js
<Listbox>
  <Listbox.Button>Country</Listbox.Button>
  <Listbox.Options>
    <Listbox.Option value="us" aria-label="united states of america">
      🇺🇸 United States of America
    </Listbox.Option>
    <Listbox.Option value="ca" aria-label="canada">
      🇨🇦 Canada
    </Listbox.Option>
    <Listbox.Option value="be" aria-label="belgium">
      🇧🇪 Belgium
    </Listbox.Option>
    <Listbox.Option value="by" aria-label="belarus">
      🇧🇾 Belarus
    </Listbox.Option>
    <Listbox.Option value="del" aria-label="delete">
      <div role="img">
        <p>(╯°□°）╯︵ ┻━┻</p>
      </div>
      Delete
    </Listbox.Option>
  </Listbox.Options>
</Listbox>
```

To be complete with the `aria-label` attribute, this PR also tries to resolve the contents of the element referenced via `aria-labelledby` if you use that attribute instead.

Fixes: #2454
