### PR TITLE
Missing "disabled" prop in a Tab type declaration

### DIFF
--- a/packages/@headlessui-react/src/components/tabs/tabs.tsx
+++ b/packages/@headlessui-react/src/components/tabs/tabs.tsx
@@ -383,7 +383,7 @@ export type TabProps<TTag extends ElementType> = Props<
   TabRenderPropArg,
   TabPropsWeControl
 > & {
-  //
+  disabled?: boolean
 }
 
 function TabFn<TTag extends ElementType = typeof DEFAULT_TAB_TAG>(


### PR DESCRIPTION
Added missing "disabled" prop declaration.