### PR TITLE
Improve "outside click" behaviour in combination with 3rd party libraries

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ensure the caret is in a consistent position when syncing the `Combobox.Input` value ([#2568](https://github.com/tailwindlabs/headlessui/pull/2568))
+- Improve "outside click" behaviour in combination with 3rd party libraries ([#2572](https://github.com/tailwindlabs/headlessui/pull/2572))
 
 ## [1.7.15] - 2023-06-01
 

--- a/packages/@headlessui-react/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-react/src/hooks/use-outside-click.ts
@@ -152,12 +152,13 @@ export function useOutsideClick(
   // and we can consider it an "outside click"
   useWindowEvent(
     'blur',
-    (event) =>
-      handleOutsideClick(event, () =>
-        window.document.activeElement instanceof HTMLIFrameElement
+    (event) => {
+      return handleOutsideClick(event, () => {
+        return window.document.activeElement instanceof HTMLIFrameElement
           ? window.document.activeElement
           : null
-      ),
+      })
+    },
     true
   )
 }

--- a/packages/@headlessui-react/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-react/src/hooks/use-outside-click.ts
@@ -103,6 +103,16 @@ export function useOutsideClick(
   let initialClickTarget = useRef<EventTarget | null>(null)
 
   useDocumentEvent(
+    'pointerdown',
+    (event) => {
+      if (enabledRef.current) {
+        initialClickTarget.current = event.composedPath?.()?.[0] || event.target
+      }
+    },
+    true
+  )
+
+  useDocumentEvent(
     'mousedown',
     (event) => {
       if (enabledRef.current) {

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ensure the caret is in a consistent position when syncing the `Combobox.Input` value ([#2568](https://github.com/tailwindlabs/headlessui/pull/2568))
+- Improve "outside click" behaviour in combination with 3rd party libraries ([#2572](https://github.com/tailwindlabs/headlessui/pull/2572))
 
 ## [1.7.14] - 2023-06-01
 

--- a/packages/@headlessui-vue/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-vue/src/hooks/use-outside-click.ts
@@ -86,6 +86,16 @@ export function useOutsideClick(
   let initialClickTarget = ref<EventTarget | null>(null)
 
   useDocumentEvent(
+    'pointerdown',
+    (event) => {
+      if (enabled.value) {
+        initialClickTarget.value = event.composedPath?.()?.[0] || event.target
+      }
+    },
+    true
+  )
+
+  useDocumentEvent(
     'mousedown',
     (event) => {
       if (enabled.value) {

--- a/packages/@headlessui-vue/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-vue/src/hooks/use-outside-click.ts
@@ -135,12 +135,13 @@ export function useOutsideClick(
   // and we can consider it an "outside click"
   useWindowEvent(
     'blur',
-    (event) =>
-      handleOutsideClick(event, () =>
-        window.document.activeElement instanceof HTMLIFrameElement
+    (event) => {
+      return handleOutsideClick(event, () => {
+        return window.document.activeElement instanceof HTMLIFrameElement
           ? window.document.activeElement
           : null
-      ),
+      })
+    },
     true
   )
 }

--- a/packages/@headlessui-vue/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-vue/src/hooks/use-outside-click.ts
@@ -10,10 +10,10 @@ type ContainerInput = Container | ContainerCollection
 
 export function useOutsideClick(
   containers: ContainerInput | (() => ContainerInput),
-  cb: (event: MouseEvent | PointerEvent | FocusEvent, target: HTMLElement) => void,
+  cb: (event: MouseEvent | PointerEvent | FocusEvent | TouchEvent, target: HTMLElement) => void,
   enabled: ComputedRef<boolean> = computed(() => true)
 ) {
-  function handleOutsideClick<E extends MouseEvent | PointerEvent | FocusEvent>(
+  function handleOutsideClick<E extends MouseEvent | PointerEvent | FocusEvent | TouchEvent>(
     event: E,
     resolveTarget: (event: E) => HTMLElement | null
   ) {
@@ -117,6 +117,24 @@ export function useOutsideClick(
       })
 
       initialClickTarget.value = null
+    },
+
+    // We will use the `capture` phase so that layers in between with `event.stopPropagation()`
+    // don't "cancel" this outside click check. E.g.: A `Menu` inside a `DialogPanel` if the `Menu`
+    // is open, and you click outside of it in the `DialogPanel` the `Menu` should close. However,
+    // the `DialogPanel` has a `onClick(e) { e.stopPropagation() }` which would cancel this.
+    true
+  )
+
+  useDocumentEvent(
+    'touchend',
+    (event) => {
+      return handleOutsideClick(event, () => {
+        if (event.target instanceof HTMLElement) {
+          return event.target
+        }
+        return null
+      })
     },
 
     // We will use the `capture` phase so that layers in between with `event.stopPropagation()`


### PR DESCRIPTION
This PR improves the outside click behaviour when using our components in combination with 3rd party libraries. It also improves the outside click behaviour on touch devices.

We already use some logic to try and capture the target element outside of the main `click` listener. We do this by listening to a `mousedown` on the `document` while using the `capture` phase (instead of the bubble phase). Some 3rd party tools already use en `event.preventDefault()` in these scenarios.

To try and solve this, we will also listen for `pointerdown` events to capture the target element instead of only relying on the `mousedown` event. We can't just switch to `pointerdown` alone because those events aren't available on older versions of iOS for example.

Another small improvement is to also listen for `touchend` events. This will also be triggered on mobile devices which also improves the "outside click" behaviour in case the `mousedown` event is using `e.preventDefault()`.

Fixes: #2564
