### PR TITLE
Skip updating state if sentinel has been unmounted

### DIFF
--- a/packages/@headlessui-react/src/internal/focus-sentinel.tsx
+++ b/packages/@headlessui-react/src/internal/focus-sentinel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, FocusEvent as ReactFocusEvent } from 'react'
+import React, { useEffect, useRef, useState, FocusEvent as ReactFocusEvent } from 'react'
 
 import { Hidden, Features } from './hidden'
 
@@ -7,7 +7,16 @@ interface FocusSentinelProps {
 }
 
 export function FocusSentinel({ onFocus }: FocusSentinelProps) {
+  let mounted = useRef(false)
   let [enabled, setEnabled] = useState(true)
+
+  useEffect(() => {
+    mounted.current = true
+
+    return () => {
+      mounted.current = false
+    }
+  }, [])
 
   if (!enabled) return null
 
@@ -31,7 +40,10 @@ export function FocusSentinel({ onFocus }: FocusSentinelProps) {
           // Try to move focus to the correct element. This depends on the implementation
           // of `onFocus` of course since it would be different for each place we use it in.
           if (onFocus()) {
-            setEnabled(false)
+            if (mounted.current) {
+              setEnabled(false)
+            }
+
             cancelAnimationFrame(frame)
             return
           }


### PR DESCRIPTION
Adds mount check to sentinel. Solves issue of warnings in console and Jest output in terminal when including tabs inside of a dialog. Barebones example below which will reproduce error,

<img width="1157" alt="Screenshot 2023-07-08 at 3 33 10 PM" src="https://github.com/tailwindlabs/headlessui/assets/9314/36230d01-b686-4538-9d67-e5d8d7f46c1e">


```jsx
import { Dialog, Tab, Transition } from '@headlessui/react'

export default () => (
  <Transition.Root show={true}>
    <Dialog onClose={() => null}>
      <Transition.Child>
        <Tab.Group>
          <Tab.List>
            <Tab>A</Tab>
            <Tab>B</Tab>
            <Tab>C</Tab>
          </Tab.List>
        </Tab.Group>
      </Transition.Child>
    </Dialog>
  </Transition.Root>
)
```