### PR TITLE
Add `not-focus-visible` variant to Tailwind plugin

### DIFF
--- a/packages/@headlessui-tailwindcss/src/index.ts
+++ b/packages/@headlessui-tailwindcss/src/index.ts
@@ -31,8 +31,12 @@ export default plugin.withOptions<Options>(({ prefix = 'ui' } = {}) => {
         `&[data-headlessui-state]:not([data-headlessui-state~="${state}"])`,
         `:where([data-headlessui-state]:not([data-headlessui-state~="${state}"])) &:not([data-headlessui-state])`,
       ])
-
-      addVariant(`${prefix}-focus-visible`, ':where([data-headlessui-focus-visible]) &:focus')
     }
+
+    addVariant(`${prefix}-focus-visible`, ':where([data-headlessui-focus-visible]) &:focus')
+    addVariant(
+      `${prefix}-not-focus-visible`,
+      '&:focus:where(:not([data-headlessui-focus-visible] &))'
+    )
   }
 })


### PR DESCRIPTION
This is useful for using browser-default focus styles, but disabling them when the focus visible state is not active, i.e. `ui-not-focus-visible:outline-none`

I have also moved the `focus-visible` variant out of the state loop