### PR TITLE
Render `<MainTreeNode />` indicators in `Popover.Group` only

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Use correct value when resetting `<Listbox multiple>` and `<Combobox multiple>` ([#2626](https://github.com/tailwindlabs/headlessui/pull/2626))
+- Render `<MainTreeNode />` in `Popover.Group` component only ([#2634](https://github.com/tailwindlabs/headlessui/pull/2634))
 
 ## [1.7.16] - 2023-07-27
 

--- a/packages/@headlessui-react/src/components/popover/popover.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.tsx
@@ -54,7 +54,7 @@ import { useTabDirection, Direction as TabDirection } from '../../hooks/use-tab-
 import { microTask } from '../../utils/micro-task'
 import { useLatestValue } from '../../hooks/use-latest-value'
 import { useIsoMorphicEffect } from '../../hooks/use-iso-morphic-effect'
-import { useRootContainers } from '../../hooks/use-root-containers'
+import { useMainTreeNode, useRootContainers } from '../../hooks/use-root-containers'
 import { useNestedPortals } from '../../components/portal/portal'
 
 type MouseEvent<T> = Parameters<MouseEventHandler<T>>[0]
@@ -177,6 +177,7 @@ let PopoverGroupContext = createContext<{
   unregisterPopover(registerbag: PopoverRegisterBag): void
   isFocusWithinPopoverGroup(): boolean
   closeOthers(buttonId: string): void
+  mainTreeNodeRef: MutableRefObject<HTMLElement | null>
 } | null>(null)
 PopoverGroupContext.displayName = 'PopoverGroupContext'
 
@@ -313,6 +314,7 @@ function PopoverFn<TTag extends ElementType = typeof DEFAULT_POPOVER_TAG>(
 
   let [portals, PortalWrapper] = useNestedPortals()
   let root = useRootContainers({
+    mainTreeNodeRef: groupContext?.mainTreeNodeRef,
     portals,
     defaultContainers: [button, panel],
   })
@@ -971,6 +973,7 @@ function GroupFn<TTag extends ElementType = typeof DEFAULT_PANEL_TAG>(
   let internalGroupRef = useRef<HTMLElement | null>(null)
   let groupRef = useSyncRefs(internalGroupRef, ref)
   let [popovers, setPopovers] = useState<PopoverRegisterBag[]>([])
+  let root = useMainTreeNode()
 
   let unregisterPopover = useEvent((registerbag: PopoverRegisterBag) => {
     setPopovers((existing) => {
@@ -1017,8 +1020,15 @@ function GroupFn<TTag extends ElementType = typeof DEFAULT_PANEL_TAG>(
       unregisterPopover: unregisterPopover,
       isFocusWithinPopoverGroup,
       closeOthers,
+      mainTreeNodeRef: root.mainTreeNodeRef,
     }),
-    [registerPopover, unregisterPopover, isFocusWithinPopoverGroup, closeOthers]
+    [
+      registerPopover,
+      unregisterPopover,
+      isFocusWithinPopoverGroup,
+      closeOthers,
+      root.mainTreeNodeRef,
+    ]
   )
 
   let slot = useMemo<GroupRenderPropArg>(() => ({}), [])
@@ -1035,6 +1045,7 @@ function GroupFn<TTag extends ElementType = typeof DEFAULT_PANEL_TAG>(
         defaultTag: DEFAULT_GROUP_TAG,
         name: 'Popover.Group',
       })}
+      <root.MainTreeNode />
     </PopoverGroupContext.Provider>
   )
 }

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix form elements for uncontrolled `<Listbox multiple>` and `<Combobox multiple>` ([#2626](https://github.com/tailwindlabs/headlessui/pull/2626))
 - Use correct value when resetting `<Listbox multiple>` and `<Combobox multiple>` ([#2626](https://github.com/tailwindlabs/headlessui/pull/2626))
+- Render `<MainTreeNode />` in `PopoverGroup` component only ([#2634](https://github.com/tailwindlabs/headlessui/pull/2634))
 
 ## [1.7.15] - 2023-07-27
 

--- a/packages/@headlessui-vue/src/components/popover/popover.ts
+++ b/packages/@headlessui-vue/src/components/popover/popover.ts
@@ -37,7 +37,7 @@ import { useEventListener } from '../../hooks/use-event-listener'
 import { Hidden, Features as HiddenFeatures } from '../../internal/hidden'
 import { useTabDirection, Direction as TabDirection } from '../../hooks/use-tab-direction'
 import { microTask } from '../../utils/micro-task'
-import { useRootContainers } from '../../hooks/use-root-containers'
+import { useMainTreeNode, useRootContainers } from '../../hooks/use-root-containers'
 import { useNestedPortals } from '../../components/portal/portal'
 
 enum PopoverStates {
@@ -82,6 +82,7 @@ let PopoverGroupContext = Symbol('PopoverGroupContext') as InjectionKey<{
   unregisterPopover(registerbag: PopoverRegisterBag): void
   isFocusWithinPopoverGroup(): boolean
   closeOthers(buttonId: string): void
+  mainTreeNodeRef: Ref<HTMLElement | null>
 } | null>
 
 function usePopoverGroupContext() {
@@ -209,6 +210,7 @@ export let Popover = defineComponent({
 
     let [portals, PortalWrapper] = useNestedPortals()
     let root = useRootContainers({
+      mainTreeNodeRef: groupContext?.mainTreeNodeRef,
       portals,
       defaultContainers: [button, panel],
     })
@@ -749,6 +751,7 @@ export let PopoverPanel = defineComponent({
 
 export let PopoverGroup = defineComponent({
   name: 'PopoverGroup',
+  inheritAttrs: false,
   props: {
     as: { type: [Object, String], default: 'div' },
   },
@@ -756,6 +759,7 @@ export let PopoverGroup = defineComponent({
     let groupRef = ref<HTMLElement | null>(null)
     let popovers = shallowRef<PopoverRegisterBag[]>([])
     let ownerDocument = computed(() => getOwnerDocument(groupRef))
+    let root = useMainTreeNode()
 
     expose({ el: groupRef, $el: groupRef })
 
@@ -798,19 +802,23 @@ export let PopoverGroup = defineComponent({
       unregisterPopover,
       isFocusWithinPopoverGroup,
       closeOthers,
+      mainTreeNodeRef: root.mainTreeNodeRef,
     })
 
     return () => {
       let ourProps = { ref: groupRef }
 
-      return render({
-        ourProps,
-        theirProps: props,
-        slot: {},
-        attrs,
-        slots,
-        name: 'PopoverGroup',
-      })
+      return h(Fragment, [
+        render({
+          ourProps,
+          theirProps: { ...props, ...attrs },
+          slot: {},
+          attrs,
+          slots,
+          name: 'PopoverGroup',
+        }),
+        h(root.MainTreeNode),
+      ])
     }
   },
 })

--- a/packages/@headlessui-vue/src/components/popover/popover.ts
+++ b/packages/@headlessui-vue/src/components/popover/popover.ts
@@ -103,6 +103,7 @@ interface PopoverRegisterBag {
 
 export let Popover = defineComponent({
   name: 'Popover',
+  inheritAttrs: false,
   props: {
     as: { type: [Object, String], default: 'div' },
   },
@@ -259,16 +260,19 @@ export let Popover = defineComponent({
 
     return () => {
       let slot = { open: popoverState.value === PopoverStates.Open, close: api.close }
-      return h(PortalWrapper, {}, () =>
-        render({
-          theirProps: { ...props, ...attrs },
-          ourProps: { ref: internalPopoverRef },
-          slot,
-          slots,
-          attrs,
-          name: 'Popover',
-        })
-      )
+      return h(Fragment, [
+        h(PortalWrapper, {}, () =>
+          render({
+            theirProps: { ...props, ...attrs },
+            ourProps: { ref: internalPopoverRef },
+            slot,
+            slots,
+            attrs,
+            name: 'Popover',
+          })
+        ),
+        h(root.MainTreeNode),
+      ])
     }
   },
 })

--- a/packages/@headlessui-vue/src/hooks/use-root-containers.ts
+++ b/packages/@headlessui-vue/src/hooks/use-root-containers.ts
@@ -1,4 +1,4 @@
-import { ref, h, Ref } from 'vue'
+import { ref, h, Ref, computed } from 'vue'
 import { Hidden, Features as HiddenFeatures } from '../internal/hidden'
 import { getOwnerDocument } from '../utils/owner'
 import { dom } from '../utils/dom'
@@ -6,12 +6,14 @@ import { dom } from '../utils/dom'
 export function useRootContainers({
   defaultContainers = [],
   portals,
+  mainTreeNodeRef: _mainTreeNodeRef,
 }: {
   defaultContainers?: (HTMLElement | null | Ref<HTMLElement | null>)[]
   portals?: Ref<HTMLElement[]>
+  mainTreeNodeRef?: Ref<HTMLElement | null>
 } = {}) {
   // Reference to a node in the "main" tree, not in the portalled Dialog tree.
-  let mainTreeNodeRef = ref<HTMLDivElement | null>(null)
+  let mainTreeNodeRef = ref<HTMLElement | null>(null)
   let ownerDocument = getOwnerDocument(mainTreeNodeRef)
 
   function resolveContainers() {
@@ -54,6 +56,19 @@ export function useRootContainers({
     contains(element: HTMLElement) {
       return resolveContainers().some((container) => container.contains(element))
     },
+    mainTreeNodeRef,
+    MainTreeNode() {
+      let hasPassedInMainTreeNode = (_mainTreeNodeRef?.value ?? null) !== null
+      if (hasPassedInMainTreeNode) return null
+      return h(Hidden, { features: HiddenFeatures.Hidden, ref: mainTreeNodeRef })
+    },
+  }
+}
+
+export function useMainTreeNode() {
+  let mainTreeNodeRef = ref<HTMLElement | null>(null)
+
+  return {
     mainTreeNodeRef,
     MainTreeNode() {
       return h(Hidden, { features: HiddenFeatures.Hidden, ref: mainTreeNodeRef })


### PR DESCRIPTION
This PR improves the rendered DOM structure for `Popover` components.

Some of our components auto close when you click outside of them, the `Popover` component is one of them. However, there are a few exceptions to this rule:

- If you render a notification on top of them and click on the `×` to close the notification then we don't want to close the currently open `Popover`.
- If you render a 3rd party library inside of the `Popover.Panel` component, and the 3rd party component happens to render in its own `Portal` component and you interact with that component then we don't want it to close either.

If the components are using our `Portal` component, then everything is fine, but if they are not using ours, then we have to make some assumptions. Right now, we assume that your applications is rendered in the "main" tree:

```html
<body>
  <div id="root"> <!-- Main tree -->
    <div>
        <Popover>...</Popover>
    </div>
    <div>
      <!-- Sibling -->
    </div>
  </div>

  <!-- Other branches -->
  <known-portal-roots />
  <3rd-party-portal-roots />
  <browser-extensions />
</body>
```

All of the interactions inside the Main tree that are not happening _inside_ the Popover are considered "outside" of the Popover. But everything happening in the other branches from the root (typically the parts we don't have control over) are considered "allowed" (this is where those notifications or 3rd party libraries are typically rendered).

Next, we require some element in the main tree so that we can run checks against this element compared to the `event.target` elements for outside click behaviour. This way we can determine where elements are and if they should trigger an outside click or not.

Our `Dialog` and `Popover` components render a hidden `<MainTreeNode />` component for this. But every `Popover` component did this, even if you are in a `Popover.Group`. This resulted in a confusisng DOM structure:

```html
<div> <!-- Popover.Group -->
  <div></div> <!-- Popover -->
  <div></div> <!-- MainTreeNode -->

  <div></div> <!-- Popover -->
  <div></div> <!-- MainTreeNode -->

  <div></div> <!-- Popover -->
  <div></div> <!-- MainTreeNode -->
</div>
```

If you used `ul` and `li` elements, this becomes:

```html
<ul> <!-- Popover.Group -->
  <li></li> <!-- Popover -->
  <div></div> <!-- MainTreeNode -->

  <li></li> <!-- Popover -->
  <div></div> <!-- MainTreeNode -->

  <li></li> <!-- Popover -->
  <div></div> <!-- MainTreeNode -->
</ul>
```

To solve this, this PR will move the `MainTreeNode` after the `Popover.Group` instead, which results in:

```html
<div> <!-- Popover.Group -->
  <div></div> <!-- Popover -->
  <div></div> <!-- Popover -->
  <div></div> <!-- Popover -->
</div>
<div></div> <!-- MainTreeNode -->
```

If you used `ul` and `li` elements, this becomes:

```html
<ul> <!-- Popover.Group -->
  <li></li> <!-- Popover -->
  <li></li> <!-- Popover -->
  <li></li> <!-- Popover -->
</ul>
<div></div> <!-- MainTreeNode -->
```

