### PR TITLE
Fix incorrectly focused `Combobox.Input` component on page load

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Render `<MainTreeNode />` in `Popover.Group` component only ([#2634](https://github.com/tailwindlabs/headlessui/pull/2634))
 - Disable smooth scrolling when opening/closing `Dialog` components on iOS ([#2635](https://github.com/tailwindlabs/headlessui/pull/2635))
 - Don't assume `<Tab />` components are available when setting the next index ([#2642](https://github.com/tailwindlabs/headlessui/pull/2642))
+- Fix incorrectly focused `Combobox.Input` component on page load ([#2654](https://github.com/tailwindlabs/headlessui/pull/2654))
 
 ## [1.7.16] - 2023-07-27
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -53,6 +53,7 @@ import { useControllable } from '../../hooks/use-controllable'
 import { useWatch } from '../../hooks/use-watch'
 import { useTrackedPointer } from '../../hooks/use-tracked-pointer'
 import { isMobile } from '../../utils/platform'
+import { useOwnerDocument } from '../../hooks/use-owner'
 
 enum ComboboxState {
   Open,
@@ -738,6 +739,7 @@ function InputFn<
   let actions = useActions('Combobox.Input')
 
   let inputRef = useSyncRefs(data.inputRef, ref)
+  let ownerDocument = useOwnerDocument(data.inputRef)
 
   let isTyping = useRef(false)
 
@@ -799,6 +801,11 @@ function InputFn<
         if (isTyping.current) return
         if (!input) return
 
+        // Bail when the input is not the currently focused element. When it is not the focused
+        // element, and we call the `setSelectionRange`, then it will become the focused
+        // element which may be unwanted.
+        if (ownerDocument?.activeElement !== input) return
+
         let { selectionStart, selectionEnd } = input
 
         // A custom selection is used, no need to move the caret
@@ -811,7 +818,7 @@ function InputFn<
         input.setSelectionRange(input.value.length, input.value.length)
       })
     },
-    [currentDisplayValue, data.comboboxState]
+    [currentDisplayValue, data.comboboxState, ownerDocument]
   )
 
   // Trick VoiceOver in behaving a little bit better. Manually "resetting" the input makes VoiceOver

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Disable smooth scrolling when opening/closing `Dialog` components on iOS ([#2635](https://github.com/tailwindlabs/headlessui/pull/2635))
 - Don't assume `<Tab />` components are available when setting the next index ([#2642](https://github.com/tailwindlabs/headlessui/pull/2642))
 - Improve SSR of the `Disclosure` component ([#2645](https://github.com/tailwindlabs/headlessui/pull/2645))
+- Fix incorrectly focused `ComboboxInput` component on page load ([#2654](https://github.com/tailwindlabs/headlessui/pull/2654))
 
 ## [1.7.15] - 2023-07-27
 


### PR DESCRIPTION
This PR fixes an odd issue in the `Combobox` where it incorrectly focuses the `Combobox.Input`.

We have some code that ensures that the selection range of the `Combobox.Input` is correct when syncing values to the input field. However, calling `setSelectionRange` _will_ actually focus the `input` DOM element if it is not focused yet.

This PR will only try to set the selection range if the input is the focused element.

Fixes: #2653
