### PR TITLE
Improve resetting values when using the `nullable` prop on the `Combobox` component

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't assume `<Tab />` components are available when setting the next index ([#2642](https://github.com/tailwindlabs/headlessui/pull/2642))
 - Fix incorrectly focused `Combobox.Input` component on page load ([#2654](https://github.com/tailwindlabs/headlessui/pull/2654))
 - Ensure `appear` works using the `Transition` component (even when used with SSR) ([#2646](https://github.com/tailwindlabs/headlessui/pull/2646))
+- Improve resetting values when using the `nullable` prop on the `Combobox` component ([#2660](https://github.com/tailwindlabs/headlessui/pull/2660))
 
 ## [1.7.16] - 2023-07-27
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -2735,9 +2735,9 @@ describe('Keyboard interactions', () => {
         await press(Keys.Backspace)
         expect(getComboboxInput()?.value).toBe('')
 
-        // Verify that we don't have an active option anymore since we are in `nullable` mode
+        // Verify that we don't have an selected option anymore since we are in `nullable` mode
         assertNotActiveComboboxOption(options[1])
-        assertNoActiveComboboxOption()
+        assertNoSelectedComboboxOption()
 
         // Verify that we saw the `null` change coming in
         expect(handleChange).toHaveBeenCalledTimes(1)

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1004,7 +1004,7 @@ function InputFn<
     // options while typing won't work at all because we are still in "composing" mode.
     onChange?.(event)
 
-    // When the value becomes empty in a single value mode while being nullable than we want to clear
+    // When the value becomes empty in a single value mode while being nullable then we want to clear
     // the option entirely.
     //
     // This is can happen when you press backspace, but also when you select all the text and press

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -745,6 +745,14 @@ function InputFn<
 
   let d = useDisposables()
 
+  let clear = useEvent(() => {
+    actions.onChange(null)
+    if (data.optionsRef.current) {
+      data.optionsRef.current.scrollTop = 0
+    }
+    actions.goToOption(Focus.Nothing)
+  })
+
   // When a `displayValue` prop is given, we should use it to transform the current selected
   // option(s) so that the format can be chosen by developers implementing this. This is useful if
   // your data is an object and you just want to pick a certain property or want to create a dynamic
@@ -964,6 +972,18 @@ function InputFn<
         if (data.optionsRef.current && !data.optionsPropsRef.current.static) {
           event.stopPropagation()
         }
+
+        if (data.nullable && data.mode === ValueMode.Single) {
+          // We want to clear the value when the user presses escape if and only if the current
+          // value is not set (aka, they didn't select anything yet, or they cleared the input which
+          // caused the value to be set to `null`). If the current value is set, then we want to
+          // fallback to that value when we press escape (this part is handled in the watcher that
+          // syncs the value with the input field again).
+          if (data.value === null) {
+            clear()
+          }
+        }
+
         return actions.closeCombobox()
 
       case Keys.Tab:
@@ -991,11 +1011,7 @@ function InputFn<
     // ctrl/cmd+x.
     if (data.nullable && data.mode === ValueMode.Single) {
       if (event.target.value === '') {
-        actions.onChange(null)
-        if (data.optionsRef.current) {
-          data.optionsRef.current.scrollTop = 0
-        }
-        actions.goToOption(Focus.Nothing)
+        clear()
       }
     }
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -871,23 +871,6 @@ function InputFn<
     switch (event.key) {
       // Ref: https://www.w3.org/WAI/ARIA/apg/patterns/menu/#keyboard-interaction-12
 
-      case Keys.Backspace:
-      case Keys.Delete:
-        if (data.mode !== ValueMode.Single) return
-        if (!data.nullable) return
-
-        let input = event.currentTarget
-        d.requestAnimationFrame(() => {
-          if (input.value === '') {
-            actions.onChange(null)
-            if (data.optionsRef.current) {
-              data.optionsRef.current.scrollTop = 0
-            }
-            actions.goToOption(Focus.Nothing)
-          }
-        })
-        break
-
       case Keys.Enter:
         isTyping.current = false
         if (data.comboboxState !== ComboboxState.Open) return
@@ -1000,6 +983,21 @@ function InputFn<
     // compositionend event is fired to trigger an onChange is not enough, because then filtering
     // options while typing won't work at all because we are still in "composing" mode.
     onChange?.(event)
+
+    // When the value becomes empty in a single value mode while being nullable than we want to clear
+    // the option entirely.
+    //
+    // This is can happen when you press backspace, but also when you select all the text and press
+    // ctrl/cmd+x.
+    if (data.nullable && data.mode === ValueMode.Single) {
+      if (event.target.value === '') {
+        actions.onChange(null)
+        if (data.optionsRef.current) {
+          data.optionsRef.current.scrollTop = 0
+        }
+        actions.goToOption(Focus.Nothing)
+      }
+    }
 
     // Open the combobox to show the results based on what the user has typed
     actions.openCombobox()

--- a/packages/@headlessui-react/src/test-utils/interactions.ts
+++ b/packages/@headlessui-react/src/test-utils/interactions.ts
@@ -157,7 +157,9 @@ let order: Record<
             value: element.value.slice(0, -1),
           }),
         })
-        return fireEvent.keyDown(element, ev)
+
+        fireEvent.keyDown(element, ev)
+        return fireEvent.input(element, ev)
       }
 
       return fireEvent.keyDown(element, event)

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't assume `<Tab />` components are available when setting the next index ([#2642](https://github.com/tailwindlabs/headlessui/pull/2642))
 - Improve SSR of the `Disclosure` component ([#2645](https://github.com/tailwindlabs/headlessui/pull/2645))
 - Fix incorrectly focused `ComboboxInput` component on page load ([#2654](https://github.com/tailwindlabs/headlessui/pull/2654))
+- Improve resetting values when using the `nullable` prop on the `Combobox` component ([#2660](https://github.com/tailwindlabs/headlessui/pull/2660))
 
 ## [1.7.15] - 2023-07-27
 

--- a/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
@@ -4554,9 +4554,9 @@ describe('Keyboard interactions', () => {
           await press(Keys.Backspace)
           expect(getComboboxInput()?.value).toBe('')
 
-          // Verify that we don't have an active option anymore since we are in `nullable` mode
+          // Verify that we don't have an selected option anymore since we are in `nullable` mode
           assertNotActiveComboboxOption(options[1])
-          assertNoActiveComboboxOption()
+          assertNoSelectedComboboxOption()
 
           // Verify that we saw the `null` change coming in
           expect(handleChange).toHaveBeenCalledTimes(1)

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -707,6 +707,15 @@ export let ComboboxInput = defineComponent({
 
     expose({ el: api.inputRef, $el: api.inputRef })
 
+    function clear() {
+      api.change(null)
+      let options = dom(api.optionsRef)
+      if (options) {
+        options.scrollTop = 0
+      }
+      api.goToOption(Focus.Nothing)
+    }
+
     // When a `displayValue` prop is given, we should use it to transform the current selected
     // option(s) so that the format can be chosen by developers implementing this. This is useful if
     // your data is an object and you just want to pick a certain property or want to create a dynamic
@@ -924,6 +933,18 @@ export let ComboboxInput = defineComponent({
           if (api.optionsRef.value && !api.optionsPropsRef.value.static) {
             event.stopPropagation()
           }
+
+          if (api.nullable.value && api.mode.value === ValueMode.Single) {
+            // We want to clear the value when the user presses escape if and only if the current
+            // value is not set (aka, they didn't select anything yet, or they cleared the input which
+            // caused the value to be set to `null`). If the current value is set, then we want to
+            // fallback to that value when we press escape (this part is handled in the watcher that
+            // syncs the value with the input field again).
+            if (api.value.value === null) {
+              clear()
+            }
+          }
+
           api.closeCombobox()
           break
 
@@ -952,12 +973,7 @@ export let ComboboxInput = defineComponent({
       // ctrl/cmd+x.
       if (api.nullable.value && api.mode.value === ValueMode.Single) {
         if (event.target.value === '') {
-          api.change(null)
-          let options = dom(api.optionsRef)
-          if (options) {
-            options.scrollTop = 0
-          }
-          api.goToOption(Focus.Nothing)
+          clear()
         }
       }
 

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -837,24 +837,6 @@ export let ComboboxInput = defineComponent({
       switch (event.key) {
         // Ref: https://www.w3.org/WAI/ARIA/apg/patterns/menu/#keyboard-interaction-12
 
-        case Keys.Backspace:
-        case Keys.Delete:
-          if (api.mode.value !== ValueMode.Single) return
-          if (!api.nullable.value) return
-
-          let input = event.currentTarget as HTMLInputElement
-          requestAnimationFrame(() => {
-            if (input.value === '') {
-              api.change(null)
-              let options = dom(api.optionsRef)
-              if (options) {
-                options.scrollTop = 0
-              }
-              api.goToOption(Focus.Nothing)
-            }
-          })
-          break
-
         case Keys.Enter:
           isTyping.value = false
           if (api.comboboxState.value !== ComboboxStates.Open) return
@@ -962,6 +944,22 @@ export let ComboboxInput = defineComponent({
       // compositionend event is fired to trigger an onChange is not enough, because then filtering
       // options while typing won't work at all because we are still in "composing" mode.
       emit('change', event)
+
+      // When the value becomes empty in a single value mode while being nullable than we want to clear
+      // the option entirely.
+      //
+      // This is can happen when you press backspace, but also when you select all the text and press
+      // ctrl/cmd+x.
+      if (api.nullable.value && api.mode.value === ValueMode.Single) {
+        if (event.target.value === '') {
+          api.change(null)
+          let options = dom(api.optionsRef)
+          if (options) {
+            options.scrollTop = 0
+          }
+          api.goToOption(Focus.Nothing)
+        }
+      }
 
       // Open the combobox to show the results based on what the user has typed
       api.openCombobox()

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -281,13 +281,13 @@ export let Combobox = defineComponent({
         comboboxState.value = ComboboxStates.Open
       },
       goToOption(focus: Focus, id?: string, trigger?: ActivationTrigger) {
+        defaultToFirstOption.value = false
+
         if (goToOptionRaf !== null) {
           cancelAnimationFrame(goToOptionRaf)
         }
 
         goToOptionRaf = requestAnimationFrame(() => {
-          defaultToFirstOption.value = false
-
           if (props.disabled) return
           if (
             optionsRef.value &&

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -966,7 +966,7 @@ export let ComboboxInput = defineComponent({
       // options while typing won't work at all because we are still in "composing" mode.
       emit('change', event)
 
-      // When the value becomes empty in a single value mode while being nullable than we want to clear
+      // When the value becomes empty in a single value mode while being nullable then we want to clear
       // the option entirely.
       //
       // This is can happen when you press backspace, but also when you select all the text and press

--- a/packages/@headlessui-vue/src/components/transitions/utils/transition.ts
+++ b/packages/@headlessui-vue/src/components/transitions/utils/transition.ts
@@ -86,7 +86,7 @@ export function transition(
   // then we have some leftovers that should be cleaned.
   d.add(() => removeClasses(node, ...base, ...from, ...to, ...entered))
 
-  // When we get disposed early, than we should also call the done method but switch the reason.
+  // When we get disposed early, then we should also call the done method but switch the reason.
   d.add(() => _done(Reason.Cancelled))
 
   return d.dispose

--- a/packages/@headlessui-vue/src/test-utils/interactions.ts
+++ b/packages/@headlessui-vue/src/test-utils/interactions.ts
@@ -155,7 +155,9 @@ let order: Record<
             value: element.value.slice(0, -1),
           }),
         })
-        return fireEvent.keyDown(element, ev)
+
+        fireEvent.keyDown(element, ev)
+        return fireEvent.input(element, ev)
       }
 
       return fireEvent.keyDown(element, event)


### PR DESCRIPTION
This PR fixes a bug where clearing out the value of the `Combobox.Input` didn't always reset the value properly.

We will now make sure to:
1. Ensure that pressing escape when in `nullable` mode goes back to the previous option
2. Ensure that pressing escape when in `nullable` mode, after the input has been cleared doesn't go to any option
3. Ensure that the `onChange` (React) or `@update:modelValue` (Vue) is being called with `null` when a reset happens (this is important for you to reset a potential `query` value for filtering purposes)
4. Ensure that all kinds of "clearing the input" works, not only when working with <kbd>escape</kbd>/<kbd>delete</kbd>. This now also works with <kbd>ctrl/cmd</kbd>+<kbd>x</kbd>

One gotcha is that typically you reset the `query` for filtering in the `onChange`/`@change` of the `Combobox.Input`. However, when pressing escape the value is cleared but the `onChange`/`@change` won't be fired because it is cleared programmatically and not by the end user.

To solve this, you can use the following snippet to ensure that the `query` is still being cleared when the value changes to `null`:

**React:**
```diff
  import { useState } from 'react'
  import { Combobox } from '@headlessui/react'
  
  const people = [
    'Durward Reynolds',
    'Kenton Towne',
    'Therese Wunsch',
    'Benedict Kessler',
    'Katelyn Rohan',
  ]
  
  const App = () => {
    const [selectedPerson, setSelectedPerson] = useState(people[0])
    const [query, setQuery] = useState('')
  
    const filteredPeople =
      query === ''
        ? people
        : people.filter((person) => {
            return person.toLowerCase().includes(query.toLowerCase())
          })
  
    return (
      <div className="p-12">
        <Combobox
          value={selectedPerson}
          onChange={(value) => {
+           if (value === null) {
+               setQuery('') // You can also call this unconditionally
+           }
            setSelectedPerson(value)
          }}
          nullable
        >
          <Combobox.Input onChange={(event) => setQuery(event.target.value)} />
          <Combobox.Options>
            {filteredPeople.map((person) => (
              <Combobox.Option key={person} value={person}>
                {person}
              </Combobox.Option>
            ))}
          </Combobox.Options>
        </Combobox>
      </div>
    )
  }
  
  export default App
```

**Vue:**
```diff
  <template>
    <div class="p-12">
      <Combobox
        v-model="selectedPerson"
+       @update:modelValue="
+         (value) => {
+           if (value === null) {
+             query = '' // You can also call this unconditionally
+           }
+         }
+       "
        nullable
      >
        <ComboboxInput @change="query = $event.target.value" />
        <ComboboxOptions>
          <ComboboxOption v-for="person in filteredPeople" :key="person" :value="person">
            {{ person }}
          </ComboboxOption>
        </ComboboxOptions>
      </Combobox>
    </div>
  </template>
  
  <script setup>
  import { ref, computed } from 'vue'
  import { Combobox, ComboboxInput, ComboboxOptions, ComboboxOption } from '@headlessui/vue'
  
  const people = [
    'Durward Reynolds',
    'Kenton Towne',
    'Therese Wunsch',
    'Benedict Kessler',
    'Katelyn Rohan',
  ]
  
  let selectedPerson = ref(people[0])
  let query = ref('')
  
  const filteredPeople = computed(() =>
    query.value === ''
      ? people
      : people.filter((person) => {
          return person.toLowerCase().includes(query.value.toLowerCase())
        })
  )
  </script>
```

Fixes: #2433
