### PR TITLE
Fix hydration of components inside `<Suspense>`

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix incorrectly focused `Combobox.Input` component on page load ([#2654](https://github.com/tailwindlabs/headlessui/pull/2654))
 - Ensure `appear` works using the `Transition` component (even when used with SSR) ([#2646](https://github.com/tailwindlabs/headlessui/pull/2646))
 - Improve resetting values when using the `nullable` prop on the `Combobox` component ([#2660](https://github.com/tailwindlabs/headlessui/pull/2660))
+- Fix hydration of components inside `<Suspense>` ([#2663](https://github.com/tailwindlabs/headlessui/pull/2663))
 
 ## [1.7.16] - 2023-07-27
 

--- a/packages/@headlessui-react/src/hooks/use-server-handoff-complete.ts
+++ b/packages/@headlessui-react/src/hooks/use-server-handoff-complete.ts
@@ -9,10 +9,8 @@ import { env } from '../utils/env'
  *
  * Given that the problem only exists in React 18 we can rely
  * on newer APIs to determine if hydration is happening.
- *
- * @returns
  */
-function useIsHydratingInReact18() {
+function useIsHydratingInReact18(): boolean {
   let isServer = typeof document === 'undefined'
 
   // React < 18 doesn't have any way to figure this out afaik

--- a/packages/@headlessui-react/src/hooks/use-server-handoff-complete.ts
+++ b/packages/@headlessui-react/src/hooks/use-server-handoff-complete.ts
@@ -1,8 +1,8 @@
-import { useState, useEffect } from 'react'
+import * as React from 'react'
 import { env } from '../utils/env'
 
 export function useServerHandoffComplete() {
-  let [complete, setComplete] = useState(env.isHandoffComplete)
+  let [complete, setComplete] = React.useState(env.isHandoffComplete)
 
   if (complete && env.isHandoffComplete === false) {
     // This means we are in a test environment and we need to reset the handoff state
@@ -11,13 +11,13 @@ export function useServerHandoffComplete() {
     setComplete(false)
   }
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (complete === true) return
     setComplete(true)
   }, [complete])
 
   // Transition from pending to complete (forcing a re-render when server rendering)
-  useEffect(() => env.handoff(), [])
+  React.useEffect(() => env.handoff(), [])
 
   return complete
 }

--- a/packages/playground-react/pages/suspense/portal.tsx
+++ b/packages/playground-react/pages/suspense/portal.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { Portal } from '@headlessui/react'
+import { Suspense, lazy } from 'react'
+
+function MyComponent({ children }: { children(message: string): JSX.Element }) {
+  return <>{children('test')}</>
+}
+
+let MyComponentLazy = lazy(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 4000))
+
+  return { default: MyComponent }
+})
+
+export default function Index() {
+  return (
+    <div>
+      <h1>@headlessui/react & Suspense</h1>
+
+      <Portal>
+        <h2>Portal 1</h2>
+      </Portal>
+      <Portal>
+        <h2>Portal 2</h2>
+      </Portal>
+
+      <Suspense fallback={<span>Loading ...</span>}>
+        <MyComponentLazy>
+          {(env) => (
+            <div>
+              <Portal>Portal, suspense 1: {env}</Portal>
+              <Portal>Portal, suspense 2: {env}</Portal>
+            </div>
+          )}
+        </MyComponentLazy>
+      </Suspense>
+    </div>
+  )
+}

--- a/packages/playground-react/pages/suspense/portal.tsx
+++ b/packages/playground-react/pages/suspense/portal.tsx
@@ -16,7 +16,7 @@ let MyComponentLazy = lazy(async () => {
 export default function Index() {
   return (
     <div>
-      <h1>@headlessui/react & Suspense</h1>
+      <h1 className="p-8 text-3xl font-bold">Suspense + Portals</h1>
 
       <Portal>
         <div className="absolute top-24 right-48 z-10 flex h-32 w-32 flex-col items-center justify-center rounded border border-black/5 bg-white bg-clip-padding p-px shadow">

--- a/packages/playground-react/pages/suspense/portal.tsx
+++ b/packages/playground-react/pages/suspense/portal.tsx
@@ -19,18 +19,50 @@ export default function Index() {
       <h1>@headlessui/react & Suspense</h1>
 
       <Portal>
-        <h2>Portal 1</h2>
+        <div className="absolute top-24 right-48 z-10 flex h-32 w-32 flex-col items-center justify-center rounded border border-black/5 bg-white bg-clip-padding p-px shadow">
+          <div className="w-full rounded-t-sm bg-gray-100 p-1 text-center text-gray-700">
+            Instant
+          </div>
+          <div className="flex w-full flex-1 items-center justify-center text-3xl font-bold text-gray-400">
+            1
+          </div>
+        </div>
       </Portal>
       <Portal>
-        <h2>Portal 2</h2>
+        <div className="absolute top-24 right-8 z-10 flex h-32 w-32 flex-col items-center justify-center rounded border border-black/5 bg-white bg-clip-padding p-px shadow">
+          <div className="w-full rounded-t-sm bg-gray-100 p-1 text-center text-gray-700">
+            Instant
+          </div>
+          <div className="flex w-full flex-1 items-center justify-center text-3xl font-bold text-gray-400">
+            2
+          </div>
+        </div>
       </Portal>
 
       <Suspense fallback={<span>Loading ...</span>}>
         <MyComponentLazy>
           {(env) => (
             <div>
-              <Portal>Portal, suspense 1: {env}</Portal>
-              <Portal>Portal, suspense 2: {env}</Portal>
+              <Portal>
+                <div className="absolute top-64 right-48 z-10 flex h-32 w-32 flex-col items-center justify-center rounded border border-black/5 bg-white bg-clip-padding p-px shadow">
+                  <div className="w-full rounded-t-sm bg-gray-100 p-1 text-center text-gray-700">
+                    Suspense
+                  </div>
+                  <div className="flex w-full flex-1 items-center justify-center text-3xl font-bold text-gray-400">
+                    {env} 1
+                  </div>
+                </div>
+              </Portal>
+              <Portal>
+                <div className="absolute top-64 right-8 z-10 flex h-32 w-32 flex-col items-center justify-center rounded border border-black/5 bg-white bg-clip-padding p-px shadow">
+                  <div className="w-full rounded-t-sm bg-gray-100 p-1 text-center text-gray-700">
+                    Suspense
+                  </div>
+                  <div className="flex w-full flex-1 items-center justify-center text-3xl font-bold text-gray-400">
+                    {env} 2
+                  </div>
+                </div>
+              </Portal>
             </div>
           )}
         </MyComponentLazy>


### PR DESCRIPTION
This is a redo of #2633 but with a more targeted fix for just React 18+

Previously, when dealing with SSR, we had a hook that would basically force a re-render of all components on page load. This also used some global state so we didn't unnecessarily cause re-renders for components that were mounting after the page had already loaded.

However, because `<Suspense>` delays hydration this is no longer a viable solution. I've implemented a targeted fix by (mis)using the `useSyncExternalStore` API. You can provide a `getServerSnapshot` callback that only runs on the server AND in the browser but only _when hydrating_. This gives us just enough info to know when hydration is happening.

I've slotted that into our `useServerHandoffComplete()` hook to handle the `<Suspense>` case. I'm also using wildcard imports, a `"useSyncExternalStore" in React` guard, and a lazy closure to ensure that bundlers don't statically analyze this in a way that errors for React < 18.

Fixes #2400