### PR TITLE
Add `immediate` prop to `<Combobox />` for immediately opening the Combobox when the `input` receives focus

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for `role="alertdialog"` to `<Dialog>` component ([#2709](https://github.com/tailwindlabs/headlessui/pull/2709))
 - Ensure blurring the `Combobox.Input` component closes the `Combobox` ([#2712](https://github.com/tailwindlabs/headlessui/pull/2712))
 
+### Added
+
+- Add `immediate` prop to `<Combobox />` for immediately opening the Combobox when the `input` receives focus ([#2686](https://github.com/tailwindlabs/headlessui/pull/2686))
+
 ## [1.7.17] - 2023-08-17
 
 ### Fixed

--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -4831,6 +4831,7 @@ describe('Mouse interactions', () => {
       // Verify it is closed
       assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
       assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
+      assertActiveElement(getComboboxInput())
     })
   )
 
@@ -4863,6 +4864,7 @@ describe('Mouse interactions', () => {
       // Verify it is closed
       assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
       assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
+      assertActiveElement(getComboboxInput())
     })
   )
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -4699,6 +4699,174 @@ describe('Mouse interactions', () => {
   )
 
   it(
+    'should be possible to open the combobox by focusing the input with openOnFocus enabled',
+    suppressConsoleLogs(async () => {
+      render(
+        <Combobox value="test">
+          <Combobox.Input onChange={NOOP} openOnFocus />
+          <Combobox.Button>Trigger</Combobox.Button>
+          <Combobox.Options>
+            <Combobox.Option value="a">Option A</Combobox.Option>
+            <Combobox.Option value="b">Option B</Combobox.Option>
+            <Combobox.Option value="c">Option C</Combobox.Option>
+          </Combobox.Options>
+        </Combobox>
+      )
+
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: 'headlessui-combobox-button-2' },
+      })
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
+
+      // Focus the input
+      await focus(getComboboxInput())
+
+      // Verify it is visible
+      assertComboboxButton({ state: ComboboxState.Visible })
+      assertComboboxList({
+        state: ComboboxState.Visible,
+        attributes: { id: 'headlessui-combobox-options-3' },
+      })
+      assertActiveElement(getComboboxInput())
+      assertComboboxButtonLinkedWithCombobox()
+
+      // Verify we have combobox options
+      let options = getComboboxOptions()
+      expect(options).toHaveLength(3)
+      options.forEach((option) => assertComboboxOption(option))
+    })
+  )
+
+  it(
+    'should not be possible to open the combobox by focusing the input with openOnFocus disabled',
+    suppressConsoleLogs(async () => {
+      render(
+        <Combobox value="test">
+          <Combobox.Input onChange={NOOP} />
+          <Combobox.Button>Trigger</Combobox.Button>
+          <Combobox.Options>
+            <Combobox.Option value="a">Option A</Combobox.Option>
+            <Combobox.Option value="b">Option B</Combobox.Option>
+            <Combobox.Option value="c">Option C</Combobox.Option>
+          </Combobox.Options>
+        </Combobox>
+      )
+
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: 'headlessui-combobox-button-2' },
+      })
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
+
+      // Focus the input
+      await focus(getComboboxInput())
+
+      // Verify it is invisible
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: 'headlessui-combobox-button-2' },
+      })
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
+    })
+  )
+
+  it(
+    'should not be possible to open the combobox by focusing the input with openOnFocus enabled when button is disabled',
+    suppressConsoleLogs(async () => {
+      render(
+        <Combobox value="test" disabled>
+          <Combobox.Input onChange={NOOP} openOnFocus />
+          <Combobox.Button>Trigger</Combobox.Button>
+          <Combobox.Options>
+            <Combobox.Option value="a">Option A</Combobox.Option>
+            <Combobox.Option value="b">Option B</Combobox.Option>
+            <Combobox.Option value="c">Option C</Combobox.Option>
+          </Combobox.Options>
+        </Combobox>
+      )
+
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: 'headlessui-combobox-button-2' },
+      })
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
+
+      // Focus the input
+      await focus(getComboboxInput())
+
+      // Verify it is invisible
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: 'headlessui-combobox-button-2' },
+      })
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
+    })
+  )
+
+  it(
+    'should be possible to close a combobox on click with openOnFocus enabled',
+    suppressConsoleLogs(async () => {
+      render(
+        <Combobox value="test">
+          <Combobox.Input onChange={NOOP} openOnFocus />
+          <Combobox.Button>Trigger</Combobox.Button>
+          <Combobox.Options>
+            <Combobox.Option value="a">Option A</Combobox.Option>
+            <Combobox.Option value="b">Option B</Combobox.Option>
+            <Combobox.Option value="c">Option C</Combobox.Option>
+          </Combobox.Options>
+        </Combobox>
+      )
+
+      // Open combobox
+      await click(getComboboxButton())
+
+      // Verify it is visible
+      assertComboboxButton({ state: ComboboxState.Visible })
+
+      // Click to close
+      await click(getComboboxButton())
+
+      // Verify it is closed
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
+    })
+  )
+
+  it(
+    'should be possible to close a focused combobox on click with openOnFocus enabled',
+    suppressConsoleLogs(async () => {
+      render(
+        <Combobox value="test">
+          <Combobox.Input onChange={NOOP} openOnFocus />
+          <Combobox.Button>Trigger</Combobox.Button>
+          <Combobox.Options>
+            <Combobox.Option value="a">Option A</Combobox.Option>
+            <Combobox.Option value="b">Option B</Combobox.Option>
+            <Combobox.Option value="c">Option C</Combobox.Option>
+          </Combobox.Options>
+        </Combobox>
+      )
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
+
+      // Open combobox by focusing input
+      await focus(getComboboxInput())
+      assertActiveElement(getComboboxInput())
+
+      // Verify it is visible
+      assertComboboxButton({ state: ComboboxState.Visible })
+
+      // Click to close
+      await click(getComboboxButton())
+
+      // Verify it is closed
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
+    })
+  )
+
+  it(
     'should be possible to open the combobox on click',
     suppressConsoleLogs(async () => {
       render(
@@ -5355,6 +5523,35 @@ describe('Mouse interactions', () => {
 
       // Verify the active option is the previously selected one
       assertActiveComboboxOption(getComboboxOptions()[1])
+    })
+  )
+
+  it(
+    'should be possible to click a combobox option, which closes the combobox with openOnFocus enabled',
+    suppressConsoleLogs(async () => {
+      render(
+        <Combobox value="test">
+          <Combobox.Input onChange={NOOP} openOnFocus />
+          <Combobox.Button>Trigger</Combobox.Button>
+          <Combobox.Options>
+            <Combobox.Option value="a">Option A</Combobox.Option>
+            <Combobox.Option value="b">Option B</Combobox.Option>
+            <Combobox.Option value="c">Option C</Combobox.Option>
+          </Combobox.Options>
+        </Combobox>
+      )
+
+      // Open combobox by focusing input
+      await focus(getComboboxInput())
+      assertActiveElement(getComboboxInput())
+
+      assertComboboxList({ state: ComboboxState.Visible })
+
+      let options = getComboboxOptions()
+
+      // We should be able to click the first option
+      await click(options[1])
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
     })
   )
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -4699,11 +4699,11 @@ describe('Mouse interactions', () => {
   )
 
   it(
-    'should be possible to open the combobox by focusing the input with openOnFocus enabled',
+    'should be possible to open the combobox by focusing the input with immediate mode enabled',
     suppressConsoleLogs(async () => {
       render(
-        <Combobox value="test">
-          <Combobox.Input onChange={NOOP} openOnFocus />
+        <Combobox value="test" immediate>
+          <Combobox.Input onChange={NOOP} />
           <Combobox.Button>Trigger</Combobox.Button>
           <Combobox.Options>
             <Combobox.Option value="a">Option A</Combobox.Option>
@@ -4739,7 +4739,7 @@ describe('Mouse interactions', () => {
   )
 
   it(
-    'should not be possible to open the combobox by focusing the input with openOnFocus disabled',
+    'should not be possible to open the combobox by focusing the input with immediate mode disabled',
     suppressConsoleLogs(async () => {
       render(
         <Combobox value="test">
@@ -4772,11 +4772,11 @@ describe('Mouse interactions', () => {
   )
 
   it(
-    'should not be possible to open the combobox by focusing the input with openOnFocus enabled when button is disabled',
+    'should not be possible to open the combobox by focusing the input with immediate mode enabled when button is disabled',
     suppressConsoleLogs(async () => {
       render(
-        <Combobox value="test" disabled>
-          <Combobox.Input onChange={NOOP} openOnFocus />
+        <Combobox value="test" disabled immediate>
+          <Combobox.Input onChange={NOOP} />
           <Combobox.Button>Trigger</Combobox.Button>
           <Combobox.Options>
             <Combobox.Option value="a">Option A</Combobox.Option>
@@ -4805,11 +4805,11 @@ describe('Mouse interactions', () => {
   )
 
   it(
-    'should be possible to close a combobox on click with openOnFocus enabled',
+    'should be possible to close a combobox on click with immediate mode enabled',
     suppressConsoleLogs(async () => {
       render(
-        <Combobox value="test">
-          <Combobox.Input onChange={NOOP} openOnFocus />
+        <Combobox value="test" immediate>
+          <Combobox.Input onChange={NOOP} />
           <Combobox.Button>Trigger</Combobox.Button>
           <Combobox.Options>
             <Combobox.Option value="a">Option A</Combobox.Option>
@@ -4836,11 +4836,11 @@ describe('Mouse interactions', () => {
   )
 
   it(
-    'should be possible to close a focused combobox on click with openOnFocus enabled',
+    'should be possible to close a focused combobox on click with immediate mode enabled',
     suppressConsoleLogs(async () => {
       render(
-        <Combobox value="test">
-          <Combobox.Input onChange={NOOP} openOnFocus />
+        <Combobox value="test" immediate>
+          <Combobox.Input onChange={NOOP} />
           <Combobox.Button>Trigger</Combobox.Button>
           <Combobox.Options>
             <Combobox.Option value="a">Option A</Combobox.Option>
@@ -5529,11 +5529,11 @@ describe('Mouse interactions', () => {
   )
 
   it(
-    'should be possible to click a combobox option, which closes the combobox with openOnFocus enabled',
+    'should be possible to click a combobox option, which closes the combobox with immediate mode enabled',
     suppressConsoleLogs(async () => {
       render(
-        <Combobox value="test">
-          <Combobox.Input onChange={NOOP} openOnFocus />
+        <Combobox value="test" immediate>
+          <Combobox.Input onChange={NOOP} />
           <Combobox.Button>Trigger</Combobox.Button>
           <Combobox.Options>
             <Combobox.Option value="a">Option A</Combobox.Option>

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -29,6 +29,7 @@ import { useOutsideClick } from '../../hooks/use-outside-click'
 import { useResolveButtonType } from '../../hooks/use-resolve-button-type'
 import { useSyncRefs } from '../../hooks/use-sync-refs'
 import { useTreeWalker } from '../../hooks/use-tree-walker'
+import { history } from '../../utils/active-element-history'
 
 import { calculateActiveIndex, Focus } from '../../utils/calculate-active-index'
 import { disposables } from '../../utils/disposables'
@@ -1043,14 +1044,16 @@ function InputFn<
   })
 
   let handleBlur = useEvent((event: ReactFocusEvent) => {
+    let relatedTarget =
+      (event.relatedTarget as HTMLElement) ?? history.find((x) => x !== event.currentTarget)
     isTyping.current = false
 
     // Focus is moved into the list, we don't want to close yet.
-    if (data.optionsRef.current?.contains(event.relatedTarget)) {
+    if (data.optionsRef.current?.contains(relatedTarget)) {
       return
     }
 
-    if (data.buttonRef.current?.contains(event.relatedTarget)) {
+    if (data.buttonRef.current?.contains(relatedTarget)) {
       return
     }
 
@@ -1078,8 +1081,10 @@ function InputFn<
   })
 
   let handleFocus = useEvent((event: ReactFocusEvent) => {
-    if (data.buttonRef.current?.contains(event.relatedTarget as HTMLElement)) return
-    if (data.optionsRef.current?.contains(event.relatedTarget as HTMLElement)) return
+    let relatedTarget =
+      (event.relatedTarget as HTMLElement) ?? history.find((x) => x !== event.currentTarget)
+    if (data.buttonRef.current?.contains(relatedTarget)) return
+    if (data.optionsRef.current?.contains(relatedTarget)) return
     if (data.disabled) return
 
     if (!data.immediate) return
@@ -1214,7 +1219,7 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
     }
   })
 
-  let handleClick = useEvent((event: ReactMouseEvent) => {
+  let handleClick = useEvent((event: ReactMouseEvent<HTMLButtonElement>) => {
     if (isDisabledReactIssue7711(event.currentTarget)) return event.preventDefault()
     if (data.comboboxState === ComboboxState.Open) {
       actions.closeCombobox()

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1065,8 +1065,9 @@ function InputFn<
         clear()
       }
 
-      // We do have a value, so let's select the active option
-      else {
+      // We do have a value, so let's select the active option, unless we were just going through
+      // the form and we opened it due to the focus event.
+      else if (data.activationTrigger !== ActivationTrigger.Focus) {
         actions.selectActiveOption()
       }
     }

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -298,6 +298,7 @@ let ComboboxDataContext = createContext<
       mode: ValueMode
       activeOptionIndex: number | null
       nullable: boolean
+      immediate: boolean
       compare(a: unknown, z: unknown): boolean
       isSelected(value: unknown): boolean
       __demoMode: boolean
@@ -395,6 +396,7 @@ export type ComboboxProps<
   __demoMode?: boolean
   form?: string
   name?: string
+  immediate?: boolean
 }
 
 function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG>(
@@ -429,6 +431,7 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
     __demoMode = false,
     nullable = false,
     multiple = false,
+    immediate = false,
     ...theirProps
   } = props
   let [value = multiple ? [] : undefined, theirOnChange] = useControllable<any>(
@@ -479,6 +482,7 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
   let data = useMemo<_Data>(
     () => ({
       ...state,
+      immediate,
       optionsPropsRef,
       labelRef,
       inputRef,
@@ -734,7 +738,6 @@ export type ComboboxInputProps<TTag extends ElementType, TType> = Props<
     defaultValue?: TType
     displayValue?(item: TType): string
     onChange?(event: React.ChangeEvent<HTMLInputElement>): void
-    openOnFocus?: boolean
   }
 >
 
@@ -749,7 +752,6 @@ function InputFn<
     id = `headlessui-combobox-input-${internalId}`,
     onChange,
     displayValue,
-    openOnFocus = false,
     // @ts-ignore: We know this MAY NOT exist for a given tag but we only care when it _does_ exist.
     type = 'text',
     ...theirProps
@@ -1080,7 +1082,7 @@ function InputFn<
     if (data.optionsRef.current?.contains(event.relatedTarget as HTMLElement)) return
     if (data.disabled) return
 
-    if (!openOnFocus) return
+    if (!data.immediate) return
     if (data.comboboxState === ComboboxState.Open) return
 
     actions.openCombobox()

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1040,24 +1040,6 @@ function InputFn<
     actions.openCombobox()
   })
 
-  let handleFocus = useEvent((event: ReactFocusEvent) => {
-    if (data.buttonRef.current?.contains(event.relatedTarget as HTMLElement)) return
-    if (data.optionsRef.current?.contains(event.relatedTarget as HTMLElement)) return
-    if (data.disabled) return
-
-    if (!openOnFocus) return
-    if (data.comboboxState === ComboboxState.Open) return
-
-    actions.openCombobox()
-
-    // We need to make sure that tabbing through a form doesn't result in incorrectly setting the
-    // value of the combobox. We will set the activation trigger to `Focus`, and we will ignore
-    // selecting the active option when the user tabs away.
-    d.nextFrame(() => {
-      actions.setActivationTrigger(ActivationTrigger.Focus)
-    })
-  })
-
   let handleBlur = useEvent((event: ReactFocusEvent) => {
     isTyping.current = false
 
@@ -1090,6 +1072,24 @@ function InputFn<
     }
 
     return actions.closeCombobox()
+  })
+
+  let handleFocus = useEvent((event: ReactFocusEvent) => {
+    if (data.buttonRef.current?.contains(event.relatedTarget as HTMLElement)) return
+    if (data.optionsRef.current?.contains(event.relatedTarget as HTMLElement)) return
+    if (data.disabled) return
+
+    if (!openOnFocus) return
+    if (data.comboboxState === ComboboxState.Open) return
+
+    actions.openCombobox()
+
+    // We need to make sure that tabbing through a form doesn't result in incorrectly setting the
+    // value of the combobox. We will set the activation trigger to `Focus`, and we will ignore
+    // selecting the active option when the user tabs away.
+    d.nextFrame(() => {
+      actions.setActivationTrigger(ActivationTrigger.Focus)
+    })
   })
 
   // TODO: Verify this. The spec says that, for the input/combobox, the label is the labelling element when present

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1215,7 +1215,9 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
       actions.openCombobox()
     }
 
-    d.nextFrame(() => data.inputRef.current?.focus({ preventScroll: true }))
+    if (!data.openOnFocus) {
+      d.nextFrame(() => data.inputRef.current?.focus({ preventScroll: true }))
+    }
   })
 
   let labelledby = useComputed(() => {

--- a/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
+++ b/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
@@ -23,8 +23,8 @@ import { useEventListener } from '../../hooks/use-event-listener'
 import { microTask } from '../../utils/micro-task'
 import { useWatch } from '../../hooks/use-watch'
 import { useDisposables } from '../../hooks/use-disposables'
-import { onDocumentReady } from '../../utils/document-ready'
 import { useOnUnmount } from '../../hooks/use-on-unmount'
+import { history } from '../../utils/active-element-history'
 
 type Containers =
   // Lazy resolved containers
@@ -211,29 +211,6 @@ export let FocusTrap = Object.assign(FocusTrapRoot, {
 })
 
 // ---
-
-let history: HTMLElement[] = []
-onDocumentReady(() => {
-  function handle(e: Event) {
-    if (!(e.target instanceof HTMLElement)) return
-    if (e.target === document.body) return
-    if (history[0] === e.target) return
-
-    history.unshift(e.target)
-
-    // Filter out DOM Nodes that don't exist anymore
-    history = history.filter((x) => x != null && x.isConnected)
-    history.splice(10) // Only keep the 10 most recent items
-  }
-
-  window.addEventListener('click', handle, { capture: true })
-  window.addEventListener('mousedown', handle, { capture: true })
-  window.addEventListener('focus', handle, { capture: true })
-
-  document.body.addEventListener('click', handle, { capture: true })
-  document.body.addEventListener('mousedown', handle, { capture: true })
-  document.body.addEventListener('focus', handle, { capture: true })
-})
 
 function useRestoreElement(enabled: boolean = true) {
   let localHistory = useRef<HTMLElement[]>(history.slice())

--- a/packages/@headlessui-react/src/utils/active-element-history.ts
+++ b/packages/@headlessui-react/src/utils/active-element-history.ts
@@ -1,0 +1,24 @@
+import { onDocumentReady } from './document-ready'
+
+export let history: HTMLElement[] = []
+onDocumentReady(() => {
+  function handle(e: Event) {
+    if (!(e.target instanceof HTMLElement)) return
+    if (e.target === document.body) return
+    if (history[0] === e.target) return
+
+    history.unshift(e.target)
+
+    // Filter out DOM Nodes that don't exist anymore
+    history = history.filter((x) => x != null && x.isConnected)
+    history.splice(10) // Only keep the 10 most recent items
+  }
+
+  window.addEventListener('click', handle, { capture: true })
+  window.addEventListener('mousedown', handle, { capture: true })
+  window.addEventListener('focus', handle, { capture: true })
+
+  document.body.addEventListener('click', handle, { capture: true })
+  document.body.addEventListener('mousedown', handle, { capture: true })
+  document.body.addEventListener('focus', handle, { capture: true })
+})

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow `<button>` to be in nested components in `<PopoverButton>` ([#2715](https://github.com/tailwindlabs/headlessui/pull/2715))
 - Don't overwrite user-defined template refs when rendering ([#2720](https://github.com/tailwindlabs/headlessui/pull/2720))
 
+### Added
+
+- Add `immediate` prop to `<Combobox />` for immediately opening the Combobox when the `input` receives focus ([#2686](https://github.com/tailwindlabs/headlessui/pull/2686))
+
 ## [1.7.16] - 2023-08-17
 
 ### Fixed

--- a/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
@@ -5004,6 +5004,192 @@ describe('Mouse interactions', () => {
   )
 
   it(
+    'should be possible to open the combobox by focusing the input with openOnFocus enabled',
+    suppressConsoleLogs(async () => {
+      renderTemplate({
+        template: html`
+          <Combobox v-model="value" as="div">
+            <ComboboxInput openOnFocus />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="a">Option A</ComboboxOption>
+              <ComboboxOption value="b">Option B</ComboboxOption>
+              <ComboboxOption value="c">Option C</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+        `,
+        setup: () => ({ value: ref('test') }),
+      })
+
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: 'headlessui-combobox-button-2' },
+      })
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
+
+      // Focus the input
+      await focus(getComboboxInput())
+
+      // Verify it is visible
+      assertComboboxButton({ state: ComboboxState.Visible })
+      assertComboboxList({
+        state: ComboboxState.Visible,
+        attributes: { id: 'headlessui-combobox-options-3' },
+      })
+      assertActiveElement(getComboboxInput())
+      assertComboboxButtonLinkedWithCombobox()
+
+      // Verify we have combobox options
+      let options = getComboboxOptions()
+      expect(options).toHaveLength(3)
+      options.forEach((option) => assertComboboxOption(option))
+
+      // Verify that the first combobox option is active
+      assertActiveComboboxOption(options[0])
+    })
+  )
+
+  it(
+    'should not be possible to open the combobox by focusing the input with openOnFocus disabled',
+    suppressConsoleLogs(async () => {
+      renderTemplate({
+        template: html`
+          <Combobox v-model="value" as="div">
+            <ComboboxInput />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="a">Option A</ComboboxOption>
+              <ComboboxOption value="b">Option B</ComboboxOption>
+              <ComboboxOption value="c">Option C</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+        `,
+        setup: () => ({ value: ref('test') }),
+      })
+
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: 'headlessui-combobox-button-2' },
+      })
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
+
+      // Focus the input
+      await focus(getComboboxInput())
+
+      // Verify it is invisible
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
+      assertComboboxList({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: 'headlessui-combobox-options-3' },
+      })
+    })
+  )
+
+  it(
+    'should not be possible to open the combobox by focusing the input with openOnFocus enabled when button is disabled',
+    suppressConsoleLogs(async () => {
+      renderTemplate({
+        template: html`
+          <Combobox v-model="value" as="div" disabled>
+            <ComboboxInput openOnFocus />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="a">Option A</ComboboxOption>
+              <ComboboxOption value="b">Option B</ComboboxOption>
+              <ComboboxOption value="c">Option C</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+        `,
+        setup: () => ({ value: ref('test') }),
+      })
+
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: 'headlessui-combobox-button-2' },
+      })
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
+
+      // Focus the input
+      await focus(getComboboxInput())
+
+      // Verify it is invisible
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
+      assertComboboxList({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: 'headlessui-combobox-options-3' },
+      })
+    })
+  )
+
+  it(
+    'should be possible to close a combobox on click with openOnFocus enabled',
+    suppressConsoleLogs(async () => {
+      renderTemplate({
+        template: html`
+          <Combobox v-model="value">
+            <ComboboxInput openOnFocus />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="a">Option A</ComboboxOption>
+              <ComboboxOption value="b">Option B</ComboboxOption>
+              <ComboboxOption value="c">Option C</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+        `,
+        setup: () => ({ value: ref(null) }),
+      })
+
+      // Open combobox
+      await click(getComboboxButton())
+
+      // Verify it is visible
+      assertComboboxButton({ state: ComboboxState.Visible })
+
+      // Click to close
+      await click(getComboboxButton())
+
+      // Verify it is closed
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
+    })
+  )
+
+  it(
+    'should be possible to close a focused combobox on click with openOnFocus enabled',
+    suppressConsoleLogs(async () => {
+      renderTemplate({
+        template: html`
+          <Combobox v-model="value">
+            <ComboboxInput openOnFocus />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="a">Option A</ComboboxOption>
+              <ComboboxOption value="b">Option B</ComboboxOption>
+              <ComboboxOption value="c">Option C</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+        `,
+        setup: () => ({ value: ref(null) }),
+      })
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
+
+      // Open combobox by focusing input
+      await focus(getComboboxInput())
+      assertActiveElement(getComboboxInput())
+
+      // Verify it is visible
+      assertComboboxButton({ state: ComboboxState.Visible })
+
+      // Click to close
+      await click(getComboboxButton())
+
+      // Verify it is closed
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
+    })
+  )
+
+  it(
     'should be possible to open the combobox on click',
     suppressConsoleLogs(async () => {
       renderTemplate({
@@ -5699,6 +5885,38 @@ describe('Mouse interactions', () => {
 
       // Verify the active option is the previously selected one
       assertActiveComboboxOption(getComboboxOptions()[1])
+    })
+  )
+
+  it(
+    'should be possible to click a combobox option, which closes the combobox with openOnFocus enabled',
+    suppressConsoleLogs(async () => {
+      renderTemplate({
+        template: html`
+          <Combobox v-model="value">
+            <ComboboxInput openOnFocus />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="alice">alice</ComboboxOption>
+              <ComboboxOption value="bob">bob</ComboboxOption>
+              <ComboboxOption value="charlie">charlie</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+        `,
+        setup: () => ({ value: ref(null) }),
+      })
+
+      // Open combobox by focusing input
+      await focus(getComboboxInput())
+      assertActiveElement(getComboboxInput())
+
+      assertComboboxList({ state: ComboboxState.Visible })
+
+      let options = getComboboxOptions()
+
+      // We should be able to click the first option
+      await click(options[1])
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
     })
   )
 

--- a/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
@@ -5004,12 +5004,12 @@ describe('Mouse interactions', () => {
   )
 
   it(
-    'should be possible to open the combobox by focusing the input with openOnFocus enabled',
+    'should be possible to open the combobox by focusing the input with immediate mode enabled',
     suppressConsoleLogs(async () => {
       renderTemplate({
         template: html`
-          <Combobox v-model="value" as="div">
-            <ComboboxInput openOnFocus />
+          <Combobox v-model="value" as="div" immediate>
+            <ComboboxInput />
             <ComboboxButton>Trigger</ComboboxButton>
             <ComboboxOptions>
               <ComboboxOption value="a">Option A</ComboboxOption>
@@ -5050,7 +5050,7 @@ describe('Mouse interactions', () => {
   )
 
   it(
-    'should not be possible to open the combobox by focusing the input with openOnFocus disabled',
+    'should not be possible to open the combobox by focusing the input with immediate mode disabled',
     suppressConsoleLogs(async () => {
       renderTemplate({
         template: html`
@@ -5086,12 +5086,12 @@ describe('Mouse interactions', () => {
   )
 
   it(
-    'should not be possible to open the combobox by focusing the input with openOnFocus enabled when button is disabled',
+    'should not be possible to open the combobox by focusing the input with immediate mode enabled when button is disabled',
     suppressConsoleLogs(async () => {
       renderTemplate({
         template: html`
-          <Combobox v-model="value" as="div" disabled>
-            <ComboboxInput openOnFocus />
+          <Combobox v-model="value" as="div" disabled immediate>
+            <ComboboxInput />
             <ComboboxButton>Trigger</ComboboxButton>
             <ComboboxOptions>
               <ComboboxOption value="a">Option A</ComboboxOption>
@@ -5122,12 +5122,12 @@ describe('Mouse interactions', () => {
   )
 
   it(
-    'should be possible to close a combobox on click with openOnFocus enabled',
+    'should be possible to close a combobox on click with immediate mode enabled',
     suppressConsoleLogs(async () => {
       renderTemplate({
         template: html`
-          <Combobox v-model="value">
-            <ComboboxInput openOnFocus />
+          <Combobox v-model="value" immediate>
+            <ComboboxInput />
             <ComboboxButton>Trigger</ComboboxButton>
             <ComboboxOptions>
               <ComboboxOption value="a">Option A</ComboboxOption>
@@ -5156,12 +5156,12 @@ describe('Mouse interactions', () => {
   )
 
   it(
-    'should be possible to close a focused combobox on click with openOnFocus enabled',
+    'should be possible to close a focused combobox on click with immediate mode enabled',
     suppressConsoleLogs(async () => {
       renderTemplate({
         template: html`
-          <Combobox v-model="value">
-            <ComboboxInput openOnFocus />
+          <Combobox v-model="value" immediate>
+            <ComboboxInput />
             <ComboboxButton>Trigger</ComboboxButton>
             <ComboboxOptions>
               <ComboboxOption value="a">Option A</ComboboxOption>
@@ -5891,12 +5891,12 @@ describe('Mouse interactions', () => {
   )
 
   it(
-    'should be possible to click a combobox option, which closes the combobox with openOnFocus enabled',
+    'should be possible to click a combobox option, which closes the combobox with immediate mode enabled',
     suppressConsoleLogs(async () => {
       renderTemplate({
         template: html`
-          <Combobox v-model="value">
-            <ComboboxInput openOnFocus />
+          <Combobox v-model="value" immediate>
+            <ComboboxInput />
             <ComboboxButton>Trigger</ComboboxButton>
             <ComboboxOptions>
               <ComboboxOption value="alice">alice</ComboboxOption>

--- a/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
@@ -5151,6 +5151,7 @@ describe('Mouse interactions', () => {
       // Verify it is closed
       assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
       assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
+      assertActiveElement(getComboboxInput())
     })
   )
 
@@ -5186,6 +5187,7 @@ describe('Mouse interactions', () => {
       // Verify it is closed
       assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
       assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
+      assertActiveElement(getComboboxInput())
     })
   )
 

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -1023,8 +1023,9 @@ export let ComboboxInput = defineComponent({
           clear()
         }
 
-        // We do have a value, so let's select the active option
-        else {
+        // We do have a value, so let's select the active option, unless we were just going through
+        // the form and we opened it due to the focus event.
+        else if (api.activationTrigger.value !== ActivationTrigger.Focus) {
           api.selectActiveOption()
         }
       }

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -607,7 +607,9 @@ export let ComboboxButton = defineComponent({
         api.openCombobox()
       }
 
-      nextTick(() => dom(api.inputRef)?.focus({ preventScroll: true }))
+      if (!api.openOnFocus.value) {
+        nextTick(() => dom(api.inputRef)?.focus({ preventScroll: true }))
+      }
     }
 
     function handleKeydown(event: KeyboardEvent) {

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -39,6 +39,7 @@ import { useTrackedPointer } from '../../hooks/use-tracked-pointer'
 import { isMobile } from '../../utils/platform'
 import { disposables } from '../../utils/disposables'
 import { getOwnerDocument } from '../../utils/owner'
+import { history } from '../../utils/active-element-history'
 
 function defaultComparator<T>(a: T, z: T): boolean {
   return a === z
@@ -996,20 +997,16 @@ export let ComboboxInput = defineComponent({
     }
 
     function handleBlur(event: FocusEvent) {
+      let relatedTarget =
+        (event.relatedTarget as HTMLElement) ?? history.find((x) => x !== event.currentTarget)
       isTyping.value = false
 
       // Focus is moved into the list, we don't want to close yet.
-      if (
-        event.relatedTarget instanceof Node &&
-        dom(api.optionsRef)?.contains(event.relatedTarget)
-      ) {
+      if (dom(api.optionsRef)?.contains(relatedTarget)) {
         return
       }
 
-      if (
-        event.relatedTarget instanceof Node &&
-        dom(api.buttonRef)?.contains(event.relatedTarget)
-      ) {
+      if (dom(api.buttonRef)?.contains(relatedTarget)) {
         return
       }
 
@@ -1037,8 +1034,11 @@ export let ComboboxInput = defineComponent({
     }
 
     function handleFocus(event: FocusEvent) {
-      if (dom(api.buttonRef)?.contains(event.relatedTarget as HTMLElement)) return
-      if (dom(api.optionsRef)?.contains(event.relatedTarget as HTMLElement)) return
+      let relatedTarget =
+        (event.relatedTarget as HTMLElement) ?? history.find((x) => x !== event.currentTarget)
+
+      if (dom(api.buttonRef)?.contains(relatedTarget)) return
+      if (dom(api.optionsRef)?.contains(relatedTarget)) return
       if (api.disabled.value) return
 
       if (!api.immediate.value) return

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -73,6 +73,7 @@ type StateDefinition = {
 
   mode: ComputedRef<ValueMode>
   nullable: ComputedRef<boolean>
+  immediate: ComputedRef<boolean>
 
   compare: (a: unknown, z: unknown) => boolean
 
@@ -140,6 +141,7 @@ export let Combobox = defineComponent({
     name: { type: String, optional: true },
     nullable: { type: Boolean, default: false },
     multiple: { type: [Boolean], default: false },
+    immediate: { type: [Boolean], default: false },
   },
   inheritAttrs: false,
   setup(props, { slots, attrs, emit }) {
@@ -223,6 +225,7 @@ export let Combobox = defineComponent({
       },
       defaultValue: computed(() => props.defaultValue),
       nullable,
+      immediate: computed(() => props.immediate),
       inputRef,
       labelRef,
       buttonRef,
@@ -536,6 +539,7 @@ export let Combobox = defineComponent({
               'defaultValue',
               'nullable',
               'multiple',
+              'immediate',
               'onUpdate:modelValue',
               'by',
             ]),
@@ -700,7 +704,6 @@ export let ComboboxInput = defineComponent({
     displayValue: { type: Function as PropType<(item: unknown) => string> },
     defaultValue: { type: String, default: undefined },
     id: { type: String, default: () => `headlessui-combobox-input-${useId()}` },
-    openOnFocus: { type: Boolean, default: false },
   },
   emits: {
     change: (_value: Event & { target: HTMLInputElement }) => true,
@@ -1038,7 +1041,7 @@ export let ComboboxInput = defineComponent({
       if (dom(api.optionsRef)?.contains(event.relatedTarget as HTMLElement)) return
       if (api.disabled.value) return
 
-      if (!props.openOnFocus) return
+      if (!api.immediate.value) return
       if (api.comboboxState.value === ComboboxStates.Open) return
 
       api.openCombobox()

--- a/packages/@headlessui-vue/src/components/focus-trap/focus-trap.ts
+++ b/packages/@headlessui-vue/src/components/focus-trap/focus-trap.ts
@@ -22,7 +22,7 @@ import { useTabDirection, Direction as TabDirection } from '../../hooks/use-tab-
 import { getOwnerDocument } from '../../utils/owner'
 import { useEventListener } from '../../hooks/use-event-listener'
 import { microTask } from '../../utils/micro-task'
-import { onDocumentReady } from '../../utils/document-ready'
+import { history } from '../../utils/active-element-history'
 
 type Containers =
   // Lazy resolved containers
@@ -208,29 +208,6 @@ export let FocusTrap = Object.assign(
   }),
   { features: Features }
 )
-
-let history: HTMLElement[] = []
-onDocumentReady(() => {
-  function handle(e: Event) {
-    if (!(e.target instanceof HTMLElement)) return
-    if (e.target === document.body) return
-    if (history[0] === e.target) return
-
-    history.unshift(e.target)
-
-    // Filter out DOM Nodes that don't exist anymore
-    history = history.filter((x) => x != null && x.isConnected)
-    history.splice(10) // Only keep the 10 most recent items
-  }
-
-  window.addEventListener('click', handle, { capture: true })
-  window.addEventListener('mousedown', handle, { capture: true })
-  window.addEventListener('focus', handle, { capture: true })
-
-  document.body.addEventListener('click', handle, { capture: true })
-  document.body.addEventListener('mousedown', handle, { capture: true })
-  document.body.addEventListener('focus', handle, { capture: true })
-})
 
 function useRestoreElement(enabled: Ref<boolean>) {
   let localHistory = ref<HTMLElement[]>(history.slice())

--- a/packages/@headlessui-vue/src/utils/active-element-history.ts
+++ b/packages/@headlessui-vue/src/utils/active-element-history.ts
@@ -1,0 +1,24 @@
+import { onDocumentReady } from './document-ready'
+
+export let history: HTMLElement[] = []
+onDocumentReady(() => {
+  function handle(e: Event) {
+    if (!(e.target instanceof HTMLElement)) return
+    if (e.target === document.body) return
+    if (history[0] === e.target) return
+
+    history.unshift(e.target)
+
+    // Filter out DOM Nodes that don't exist anymore
+    history = history.filter((x) => x != null && x.isConnected)
+    history.splice(10) // Only keep the 10 most recent items
+  }
+
+  window.addEventListener('click', handle, { capture: true })
+  window.addEventListener('mousedown', handle, { capture: true })
+  window.addEventListener('focus', handle, { capture: true })
+
+  document.body.addEventListener('click', handle, { capture: true })
+  document.body.addEventListener('mousedown', handle, { capture: true })
+  document.body.addEventListener('focus', handle, { capture: true })
+})

--- a/packages/playground-react/pages/combobox/combobox-open-on-focus.tsx
+++ b/packages/playground-react/pages/combobox/combobox-open-on-focus.tsx
@@ -1,0 +1,139 @@
+import React, { useState, useEffect } from 'react'
+import { Combobox } from '@headlessui/react'
+
+import { classNames } from '../../utils/class-names'
+import { Button } from '../../components/button'
+
+let everybody = [
+  'Wade Cooper',
+  'Arlene Mccoy',
+  'Devon Webb',
+  'Tom Cook',
+  'Tanya Fox',
+  'Hellen Schmidt',
+  'Caroline Schultz',
+  'Mason Heaney',
+  'Claudie Smitham',
+  'Emil Schaefer',
+]
+
+function useDebounce<T>(value: T, delay: number) {
+  let [debouncedValue, setDebouncedValue] = useState(value)
+  useEffect(() => {
+    let timer = setTimeout(() => setDebouncedValue(value), delay)
+    return () => clearTimeout(timer)
+  }, [value, delay])
+  return debouncedValue
+}
+export default function Home() {
+  let [query, setQuery] = useState('')
+  let [activePerson, setActivePerson] = useState(everybody[2])
+
+  // Mimic delayed response from an API
+  let actualQuery = useDebounce(query, 0 /* Change to higher value like 100 for testing purposes */)
+
+  // Choose a random person on mount
+  useEffect(() => {
+    setActivePerson(everybody[Math.floor(Math.random() * everybody.length)])
+  }, [])
+
+  let people =
+    actualQuery === ''
+      ? everybody
+      : everybody.filter((person) => person.toLowerCase().includes(actualQuery.toLowerCase()))
+
+  return (
+    <div className="flex h-full w-screen justify-center bg-gray-50 p-12">
+      <div className="mx-auto w-full max-w-xs">
+        <div className="py-8 font-mono text-xs">Selected person: {activePerson}</div>
+        <div className="space-y-1">
+          <Combobox
+            value={activePerson}
+            onChange={(value) => {
+              setActivePerson(value)
+              setQuery('')
+            }}
+            as="div"
+          >
+            <Combobox.Label className="block text-sm font-medium leading-5 text-gray-700">
+              Assigned to
+            </Combobox.Label>
+
+            <div className="relative">
+              <span className="relative inline-flex flex-row overflow-hidden rounded-md border shadow-sm">
+                <Combobox.Input
+                  onChange={(e) => setQuery(e.target.value)}
+                  className="border-none px-3 py-1 outline-none"
+                  openOnFocus
+                />
+                <Combobox.Button as={Button}>
+                  <span className="pointer-events-none flex items-center px-2">
+                    <svg
+                      className="h-5 w-5 text-gray-400"
+                      viewBox="0 0 20 20"
+                      fill="none"
+                      stroke="currentColor"
+                    >
+                      <path
+                        d="M7 7l3-3 3 3m0 6l-3 3-3-3"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  </span>
+                </Combobox.Button>
+              </span>
+
+              <div className="absolute mt-1 w-full rounded-md bg-white shadow-lg">
+                <Combobox.Options className="shadow-xs max-h-60 overflow-auto rounded-md py-1 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5">
+                  {people.map((name) => (
+                    <Combobox.Option
+                      key={name}
+                      value={name}
+                      className={({ active }) => {
+                        return classNames(
+                          'relative cursor-default select-none py-2 pl-3 pr-9 focus:outline-none',
+                          active ? 'bg-indigo-600 text-white' : 'text-gray-900'
+                        )
+                      }}
+                    >
+                      {({ active, selected }) => (
+                        <>
+                          <span
+                            className={classNames(
+                              'block truncate',
+                              selected ? 'font-semibold' : 'font-normal'
+                            )}
+                          >
+                            {name}
+                          </span>
+                          {selected && (
+                            <span
+                              className={classNames(
+                                'absolute inset-y-0 right-0 flex items-center pr-4',
+                                active ? 'text-white' : 'text-indigo-600'
+                              )}
+                            >
+                              <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                                <path
+                                  fillRule="evenodd"
+                                  d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                                  clipRule="evenodd"
+                                />
+                              </svg>
+                            </span>
+                          )}
+                        </>
+                      )}
+                    </Combobox.Option>
+                  ))}
+                </Combobox.Options>
+              </div>
+            </div>
+          </Combobox>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/playground-react/pages/combobox/combobox-open-on-focus.tsx
+++ b/packages/playground-react/pages/combobox/combobox-open-on-focus.tsx
@@ -53,6 +53,7 @@ export default function Home() {
               setActivePerson(value)
               setQuery('')
             }}
+            immediate
             as="div"
           >
             <Combobox.Label className="block text-sm font-medium leading-5 text-gray-700">
@@ -64,7 +65,6 @@ export default function Home() {
                 <Combobox.Input
                   onChange={(e) => setQuery(e.target.value)}
                   className="border-none px-3 py-1 outline-none"
-                  openOnFocus
                 />
                 <Combobox.Button as={Button}>
                   <span className="pointer-events-none flex items-center px-2">

--- a/packages/playground-vue/src/components/combobox/combobox-open-on-focus.vue
+++ b/packages/playground-vue/src/components/combobox/combobox-open-on-focus.vue
@@ -1,0 +1,147 @@
+<script>
+import { ref, defineComponent, computed, onMounted, watch } from 'vue'
+import {
+  Combobox,
+  ComboboxButton,
+  ComboboxInput,
+  ComboboxLabel,
+  ComboboxOption,
+  ComboboxOptions,
+} from '@headlessui/vue'
+
+let everybody = [
+  { id: 1, name: 'Wade Cooper' },
+  { id: 2, name: 'Arlene Mccoy' },
+  { id: 3, name: 'Devon Webb' },
+  { id: 4, name: 'Tom Cook' },
+  { id: 5, name: 'Tanya Fox' },
+  { id: 6, name: 'Hellen Schmidt' },
+  { id: 7, name: 'Caroline Schultz' },
+  { id: 8, name: 'Mason Heaney' },
+  { id: 9, name: 'Claudie Smitham' },
+  { id: 10, name: 'Emil Schaefer' },
+]
+
+export default defineComponent({
+  components: {
+    Combobox,
+    ComboboxButton,
+    ComboboxInput,
+    ComboboxLabel,
+    ComboboxOption,
+    ComboboxOptions,
+  },
+  setup() {
+    let query = ref('')
+    let activePerson = ref(everybody[2]) // everybody[Math.floor(Math.random() * everybody.length)]
+    let filteredPeople = computed(() => {
+      return query.value === ''
+        ? everybody
+        : everybody.filter((person) => {
+            return person.name.toLowerCase().includes(query.value.toLowerCase())
+          })
+    })
+
+    // Choose a random person on mount
+    onMounted(() => {
+      activePerson.value = everybody[Math.floor(Math.random() * everybody.length)]
+    })
+
+    watch(activePerson, () => {
+      query.value = ''
+    })
+
+    return {
+      query,
+      activePerson,
+      filteredPeople,
+    }
+  },
+})
+</script>
+
+<template>
+  <div class="flex h-full w-screen justify-center bg-gray-50 p-12">
+    <div class="mx-auto w-full max-w-xs">
+      <div class="py-8 font-mono text-xs">
+        Selected person: {{ activePerson?.name ?? 'Nobody yet' }}
+      </div>
+      <div class="space-y-1">
+        <Combobox v-model="activePerson" as="div">
+          <ComboboxLabel class="block text-sm font-medium leading-5 text-gray-700">
+            Assigned to
+          </ComboboxLabel>
+
+          <div class="relative">
+            <span class="relative inline-flex flex-row overflow-hidden rounded-md border shadow-sm">
+              <ComboboxInput
+                @change="query = $event.target.value"
+                :displayValue="(person) => person?.name ?? ''"
+                :open-on-focus="true"
+                class="border-none px-3 py-1 outline-none"
+              />
+              <ComboboxButton
+                class="cursor-default border-l bg-gray-100 px-1 text-indigo-600 focus:outline-none"
+              >
+                <span class="pointer-events-none flex items-center px-2">
+                  <svg
+                    class="h-5 w-5 text-gray-400"
+                    viewBox="0 0 20 20"
+                    fill="none"
+                    stroke="currentColor"
+                  >
+                    <path
+                      d="M7 7l3-3 3 3m0 6l-3 3-3-3"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </span>
+              </ComboboxButton>
+            </span>
+
+            <div class="absolute mt-1 w-full rounded-md bg-white shadow-lg">
+              <ComboboxOptions
+                class="shadow-xs max-h-60 overflow-auto rounded-md py-1 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5"
+              >
+                <ComboboxOption
+                  v-for="person in filteredPeople"
+                  :key="person.id"
+                  :value="person"
+                  v-slot="{ active, selected }"
+                >
+                  <div
+                    :class="[
+                      'relative cursor-default select-none py-2 pl-3 pr-9 focus:outline-none',
+                      active ? 'bg-indigo-600 text-white' : 'text-gray-900',
+                    ]"
+                  >
+                    <span :class="['block truncate', selected ? 'font-semibold' : 'font-normal']">
+                      {{ person.name }}
+                    </span>
+                    <span
+                      v-if="selected"
+                      :class="[
+                        'absolute inset-y-0 right-0 flex items-center pr-4',
+                        active ? 'text-white' : 'text-indigo-600',
+                      ]"
+                    >
+                      <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                        <path
+                          fillRule="evenodd"
+                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                </ComboboxOption>
+              </ComboboxOptions>
+            </div>
+          </div>
+        </Combobox>
+      </div>
+    </div>
+  </div>
+</template>

--- a/packages/playground-vue/src/components/combobox/combobox-open-on-focus.vue
+++ b/packages/playground-vue/src/components/combobox/combobox-open-on-focus.vue
@@ -67,7 +67,7 @@ export default defineComponent({
         Selected person: {{ activePerson?.name ?? 'Nobody yet' }}
       </div>
       <div class="space-y-1">
-        <Combobox v-model="activePerson" as="div">
+        <Combobox v-model="activePerson" as="div" immediate>
           <ComboboxLabel class="block text-sm font-medium leading-5 text-gray-700">
             Assigned to
           </ComboboxLabel>
@@ -77,7 +77,6 @@ export default defineComponent({
               <ComboboxInput
                 @change="query = $event.target.value"
                 :displayValue="(person) => person?.name ?? ''"
-                :open-on-focus="true"
                 class="border-none px-3 py-1 outline-none"
               />
               <ComboboxButton


### PR DESCRIPTION
Maintainers note:

This PR introduces a new `immediate` prop on the `<Combobox />` component to open the `<Combobox />` immediately once the `<Combobox.Input />` receives focus.

It does handle edge cases where focus is moved into the `<Combobox.Input />` without opening the `<Combobox />` again. These edge cases are:

- Clicking the `<Combobox.Button />` to close the `<Combobox />` will move focus into the `<Combobox.Input />` this will not open the `<Combobox />` again.
- Clicking on a `<Combobox.Option />` will temporarely move focus to the `<Combobox.Option />`, then focus is moved back into the `<Combobox.Input />`. This will not open the `<Combobox />` again.

Another edge case that is important to mention:
- When a `<Combobox />` is open, the first `<Combobox.Option />` is selected. Tabbing away will select the currently active `<Combobox.Option />`. If `immediate` mode is enabled, and you are tabbing through a form with multiple inputs, once you hit the `<Combobox.Input />` the `<Combobox />` will be opened and the first `<Combobox.Option />` will be selected. Tabbing again **will not** select this option to prevent accidental and unwanted state mutations to the current form.

---

This is my attempt to make combobox options open on input focus, as there're many requests in discussions (#1236).

This adds boolean `openOnFocus` prop both to Vue's `ComboboxInput` & React's `Combobox.Input` components. Initially I tried to add it to root `Combobox` components, but due to my lack of React & TS types knowledge, I couldn't figure out how to introduce new boolean prop on React's component.

If `openOnFocus` is present, focusing on input (by clicking on label/input or tabbing into input) will make options list appear. I made sure that this changes properly work when options list is already visible and user tries to close it by clicking the combobox button. Also it won't show options list if combobox button is disabled.

`handleFocus` function inside `ComboboxInput` components checks if options list should be opened. The `HTMLBodyElement` instance check added mostly for tests because for some reason body element is being passed as `relatedTarget` in test environment and it breaks the checks.

The only UI change this PR introduces is when user clicks on some option in single-mode combobox or clicks the button, input won't be refocused. I added additional check for `openOnFocus` prop (to the `!isMobile()` condition and to button's `handleClick`) before refocusing input because without it options list will stay open until user clicks on something non-related to combobox.

I'm not sure what scenario is better (not refocusing input or not closing combobox), so I decided to make it at least visually similar to how combobox works now.

Also, in React component I added new action `SetOpenOnFocus` because I needed to somehow mutate `openOnFocus` value of `ComboboxDataContext` so `ComboboxOption` component can perform check before refocusing input. I have limited experience with React, so I don't know if this is the best way to do it.

I added several new tests around openOnFocus prop and created new playground pages (`http://localhost:3000/combobox/combobox-open-on-focus`) for both frameworks (they are copy-pasted from pure Tailwind examples).