### PR TITLE
fix: double onClose on mobile dialog outClick

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Don't call `<Dialog>`'s `onClose` twice on mobile devices ([#2690](https://github.com/tailwindlabs/headlessui/pull/2690))
 
 ## [1.7.17] - 2023-08-17
 

--- a/packages/@headlessui-react/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-react/src/hooks/use-outside-click.ts
@@ -2,6 +2,7 @@ import { MutableRefObject, useEffect, useRef } from 'react'
 import { FocusableMode, isFocusableElement } from '../utils/focus-management'
 import { useDocumentEvent } from './use-document-event'
 import { useWindowEvent } from './use-window-event'
+import { isMobile } from '../utils/platform'
 
 type Container = MutableRefObject<HTMLElement | null> | HTMLElement | null
 type ContainerCollection = Container[] | Set<Container>
@@ -96,7 +97,6 @@ export function useOutsideClick(
     ) {
       event.preventDefault()
     }
-
     return cb(event, target)
   }
 
@@ -125,6 +125,9 @@ export function useOutsideClick(
   useDocumentEvent(
     'click',
     (event) => {
+      if (isMobile()) {
+        return
+      }
       if (!initialClickTarget.current) {
         return
       }
@@ -132,7 +135,6 @@ export function useOutsideClick(
       handleOutsideClick(event, () => {
         return initialClickTarget.current as HTMLElement
       })
-
       initialClickTarget.current = null
     },
 

--- a/packages/@headlessui-react/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-react/src/hooks/use-outside-click.ts
@@ -137,6 +137,7 @@ export function useOutsideClick(
       handleOutsideClick(event, () => {
         return initialClickTarget.current as HTMLElement
       })
+
       initialClickTarget.current = null
     },
 

--- a/packages/@headlessui-react/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-react/src/hooks/use-outside-click.ts
@@ -97,6 +97,7 @@ export function useOutsideClick(
     ) {
       event.preventDefault()
     }
+
     return cb(event, target)
   }
 
@@ -128,6 +129,7 @@ export function useOutsideClick(
       if (isMobile()) {
         return
       }
+
       if (!initialClickTarget.current) {
         return
       }

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Don't call `<Dialog>`'s `onClose` twice on mobile devices ([#2690](https://github.com/tailwindlabs/headlessui/pull/2690))
 
 ## [1.7.16] - 2023-08-17
 

--- a/packages/@headlessui-vue/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-vue/src/hooks/use-outside-click.ts
@@ -3,6 +3,7 @@ import { FocusableMode, isFocusableElement } from '../utils/focus-management'
 import { dom } from '../utils/dom'
 import { useDocumentEvent } from './use-document-event'
 import { useWindowEvent } from './use-window-event'
+import { isMobile } from '../utils/platform'
 
 type Container = Ref<HTMLElement | null> | HTMLElement | null
 type ContainerCollection = Container[] | Set<Container>
@@ -108,6 +109,10 @@ export function useOutsideClick(
   useDocumentEvent(
     'click',
     (event) => {
+      if (isMobile()) {
+        return
+      }
+
       if (!initialClickTarget.value) {
         return
       }


### PR DESCRIPTION
Closes: #2671 

Removed click event on mobile that was fired before onTouchEnd causing a the onClose function to fire twice.