### PR TITLE
Update Radio's OptionFn effect deps to fix infinite loop.

### DIFF
--- a/packages/@headlessui-react/src/components/radio-group/radio-group.tsx
+++ b/packages/@headlessui-react/src/components/radio-group/radio-group.tsx
@@ -426,7 +426,7 @@ function OptionFn<
 
   useIsoMorphicEffect(
     () => actions.registerOption({ id, element: internalOptionRef, propsRef }),
-    [id, actions, internalOptionRef, props]
+    [id, actions, internalOptionRef, propsRef]
   )
 
   let handleClick = useEvent((event: ReactMouseEvent) => {


### PR DESCRIPTION
Hello!

I've been migrating my React project to Preact. There seems to have been a longstanding infinite loop bug with HUI's RadioGroup over in Preact. (https://github.com/preactjs/preact/issues/3827)

I was looking into it, and its a simple line change to fix. To be honest I've no idea how this works fine in React!

Hopefully this can be merged and there isn't a reason why this isn't possible, looking over at the `vue` RadioGroup version for comparison, this effect seems to be only needed on mount rather than every render (which is what was happening when `props` was a dep causing parent to re-render, leading to an infinite loop), so this looks like it makes sense.

Thanks!