### PR TITLE
Implement new `virtual` API for the `Combobox` component

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `immediate` prop to `<Combobox />` for immediately opening the Combobox when the `input` receives focus ([#2686](https://github.com/tailwindlabs/headlessui/pull/2686))
-- Add `virtual` prop to `Combobox` component ([#2740](https://github.com/tailwindlabs/headlessui/pull/2740))
+- Add `virtual` prop to `Combobox` component ([#2779](https://github.com/tailwindlabs/headlessui/pull/2779))
 
 ## [1.7.17] - 2023-08-17
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -9,7 +9,7 @@ import React, {
   useMemo,
   useReducer,
   useRef,
-  type CSSProperties,
+  useState,
   type ElementType,
   type FocusEvent as ReactFocusEvent,
   type KeyboardEvent as ReactKeyboardEvent,
@@ -74,12 +74,13 @@ type ComboboxOptionDataRef<T> = MutableRefObject<{
   value: T
   domRef: MutableRefObject<HTMLElement | null>
   order: number | null
-  onVirtualRangeUpdate: (virtualizer: Virtualizer<any, any>) => void
 }>
 
 interface StateDefinition<T> {
   dataRef: MutableRefObject<_Data | null>
   labelId: string | null
+
+  virtual: { options: T[]; disabled: (value: unknown) => boolean } | null
 
   comboboxState: ComboboxState
 
@@ -100,6 +101,8 @@ enum ActionTypes {
   RegisterLabel,
 
   SetActivationTrigger,
+
+  UpdateVirtualOptions,
 }
 
 function adjustOrderedState<T>(
@@ -137,16 +140,25 @@ function adjustOrderedState<T>(
 type Actions<T> =
   | { type: ActionTypes.CloseCombobox }
   | { type: ActionTypes.OpenCombobox }
-  | { type: ActionTypes.GoToOption; focus: Focus.Specific; id: string; trigger?: ActivationTrigger }
+  | {
+      type: ActionTypes.GoToOption
+      focus: Focus.Specific
+      idx: number
+      trigger?: ActivationTrigger
+    }
   | {
       type: ActionTypes.GoToOption
       focus: Exclude<Focus, Focus.Specific>
       trigger?: ActivationTrigger
     }
-  | { type: ActionTypes.RegisterOption; id: string; dataRef: ComboboxOptionDataRef<T> }
+  | {
+      type: ActionTypes.RegisterOption
+      payload: { id: string; dataRef: ComboboxOptionDataRef<T> }
+    }
   | { type: ActionTypes.RegisterLabel; id: string | null }
   | { type: ActionTypes.UnregisterOption; id: string }
   | { type: ActionTypes.SetActivationTrigger; trigger: ActivationTrigger }
+  | { type: ActionTypes.UpdateVirtualOptions; options: T[] }
 
 let reducers: {
   [P in ActionTypes]: <T>(
@@ -157,6 +169,7 @@ let reducers: {
   [ActionTypes.CloseCombobox](state) {
     if (state.dataRef.current?.disabled) return state
     if (state.comboboxState === ComboboxState.Closed) return state
+
     return { ...state, activeOptionIndex: null, comboboxState: ComboboxState.Closed }
   },
   [ActionTypes.OpenCombobox](state) {
@@ -164,18 +177,18 @@ let reducers: {
     if (state.comboboxState === ComboboxState.Open) return state
 
     // Check if we have a selected value that we can make active
-    let activeOptionIndex = state.activeOptionIndex
-
-    if (state.dataRef.current) {
-      let { isSelected } = state.dataRef.current
-      let optionIdx = state.options.findIndex((option) => isSelected(option.dataRef.current.value))
-
-      if (optionIdx !== -1) {
-        activeOptionIndex = optionIdx
+    if (state.dataRef.current?.value) {
+      let idx = state.dataRef.current.calculateIndex(state.dataRef.current.value)
+      if (idx !== -1) {
+        return {
+          ...state,
+          activeOptionIndex: idx,
+          comboboxState: ComboboxState.Open,
+        }
       }
     }
 
-    return { ...state, comboboxState: ComboboxState.Open, activeOptionIndex }
+    return { ...state, comboboxState: ComboboxState.Open }
   },
   [ActionTypes.GoToOption](state, action) {
     if (state.dataRef.current?.disabled) return state
@@ -185,6 +198,38 @@ let reducers: {
       state.comboboxState === ComboboxState.Closed
     ) {
       return state
+    }
+
+    if (state.virtual) {
+      let activeOptionIndex =
+        action.focus === Focus.Specific
+          ? action.idx
+          : calculateActiveIndex(action, {
+              resolveItems: () => state.virtual!.options,
+              resolveActiveIndex: () =>
+                state.activeOptionIndex ??
+                state.virtual!.options.findIndex((option) => !state.virtual!.disabled(option)) ??
+                null,
+              resolveDisabled: state.virtual!.disabled,
+              resolveId() {
+                throw new Error('Function not implemented.')
+              },
+            })
+
+      let activationTrigger = action.trigger ?? ActivationTrigger.Other
+
+      if (
+        state.activeOptionIndex === activeOptionIndex &&
+        state.activationTrigger === activationTrigger
+      ) {
+        return state
+      }
+
+      return {
+        ...state,
+        activeOptionIndex,
+        activationTrigger,
+      }
     }
 
     let adjustedState = adjustOrderedState(state)
@@ -202,12 +247,15 @@ let reducers: {
       }
     }
 
-    let activeOptionIndex = calculateActiveIndex(action, {
-      resolveItems: () => adjustedState.options,
-      resolveActiveIndex: () => adjustedState.activeOptionIndex,
-      resolveId: (item) => item.id,
-      resolveDisabled: (item) => item.dataRef.current.disabled,
-    })
+    let activeOptionIndex =
+      action.focus === Focus.Specific
+        ? action.idx
+        : calculateActiveIndex(action, {
+            resolveItems: () => adjustedState.options,
+            resolveActiveIndex: () => adjustedState.activeOptionIndex,
+            resolveId: (item) => item.id,
+            resolveDisabled: (item) => item.dataRef.current.disabled,
+          })
     let activationTrigger = action.trigger ?? ActivationTrigger.Other
 
     if (
@@ -225,7 +273,14 @@ let reducers: {
     }
   },
   [ActionTypes.RegisterOption]: (state, action) => {
-    let option = { id: action.id, dataRef: action.dataRef }
+    if (state.dataRef.current?.virtual) {
+      return {
+        ...state,
+        options: [...state.options, action.payload],
+      }
+    }
+
+    let option = action.payload
 
     let adjustedState = adjustOrderedState(state, (options) => {
       options.push(option)
@@ -234,7 +289,7 @@ let reducers: {
 
     // Check if we need to make the newly registered option active.
     if (state.activeOptionIndex === null) {
-      if (state.dataRef.current?.isSelected(action.dataRef.current.value)) {
+      if (state.dataRef.current?.isSelected(action.payload.dataRef.current.value)) {
         adjustedState.activeOptionIndex = adjustedState.options.indexOf(option)
       }
     }
@@ -252,8 +307,15 @@ let reducers: {
     return nextState
   },
   [ActionTypes.UnregisterOption]: (state, action) => {
+    if (state.dataRef.current?.virtual) {
+      return {
+        ...state,
+        options: state.options.filter((option) => option.id !== action.id),
+      }
+    }
+
     let adjustedState = adjustOrderedState(state, (options) => {
-      let idx = options.findIndex((a) => a.id === action.id)
+      let idx = options.findIndex((option) => option.id === action.id)
       if (idx !== -1) options.splice(idx, 1)
       return options
     })
@@ -265,15 +327,44 @@ let reducers: {
     }
   },
   [ActionTypes.RegisterLabel]: (state, action) => {
+    if (state.labelId === action.id) {
+      return state
+    }
+
     return {
       ...state,
       labelId: action.id,
     }
   },
   [ActionTypes.SetActivationTrigger]: (state, action) => {
+    if (state.activationTrigger === action.trigger) {
+      return state
+    }
+
     return {
       ...state,
       activationTrigger: action.trigger,
+    }
+  },
+  [ActionTypes.UpdateVirtualOptions]: (state, action) => {
+    if (state.virtual?.options === action.options) {
+      return state
+    }
+
+    let adjustedActiveOptionIndex = state.activeOptionIndex
+    if (state.activeOptionIndex !== null) {
+      let idx = action.options.indexOf(state.virtual!.options[state.activeOptionIndex])
+      if (idx !== -1) {
+        adjustedActiveOptionIndex = idx
+      } else {
+        adjustedActiveOptionIndex = null
+      }
+    }
+
+    return {
+      ...state,
+      activeOptionIndex: adjustedActiveOptionIndex,
+      virtual: Object.assign({}, state.virtual, { options: action.options }),
     }
   },
 }
@@ -283,9 +374,8 @@ let ComboboxActionsContext = createContext<{
   closeCombobox(): void
   registerOption(id: string, dataRef: ComboboxOptionDataRef<unknown>): () => void
   registerLabel(id: string): () => void
-  goToOption(focus: Focus.Specific, id: string, trigger?: ActivationTrigger): void
-  goToOption(focus: Focus, id?: string, trigger?: ActivationTrigger): void
-  selectOption(id: string): void
+  goToOption(focus: Focus.Specific, idx: number, trigger?: ActivationTrigger): void
+  goToOption(focus: Focus, idx?: number, trigger?: ActivationTrigger): void
   selectActiveOption(): void
   setActivationTrigger(trigger: ActivationTrigger): void
   onChange(value: unknown): void
@@ -305,15 +395,10 @@ type _Actions = ReturnType<typeof useActions>
 
 let VirtualContext = createContext<Virtualizer<any, any> | null>(null)
 
-function VirtualProvider(props: React.PropsWithChildren<{}>) {
+function VirtualProvider(props: {
+  children: (data: { option: unknown; open: boolean }) => React.ReactElement
+}) {
   let data = useData('VirtualProvider')
-
-  let firstAvailableOption = data.options.find((option) => option.dataRef.current.domRef.current)
-  let measuredHeight = useMemo(() => {
-    let height =
-      firstAvailableOption?.dataRef.current.domRef.current?.getBoundingClientRect().height
-    return height ?? 40
-  }, [firstAvailableOption])
 
   let [paddingStart, paddingEnd] = useMemo(() => {
     let el = data.optionsRef.current
@@ -330,26 +415,20 @@ function VirtualProvider(props: React.PropsWithChildren<{}>) {
   let virtualizer = useVirtualizer({
     scrollPaddingStart: paddingStart,
     scrollPaddingEnd: paddingEnd,
-    count: data.options.length,
+    count: data.virtual!.options.length,
     estimateSize() {
-      return measuredHeight
+      return 40
     },
     getScrollElement() {
       return (data.optionsRef.current ?? null) as HTMLElement | null
     },
     overscan: 12,
-    onChange(event) {
-      let list = event.getVirtualItems()
-      if (list.length === 0) return
-
-      let min = list[0].index
-      let max = list[list.length - 1].index + 1
-
-      for (let option of data.options.slice(min, max)) {
-        option.dataRef.current.onVirtualRangeUpdate(event)
-      }
-    },
   })
+
+  let [baseKey, setBaseKey] = useState(0)
+  useIsoMorphicEffect(() => {
+    setBaseKey((v) => v + 1)
+  }, [data.virtual?.options])
 
   return (
     <VirtualContext.Provider value={virtualizer}>
@@ -359,8 +438,57 @@ function VirtualProvider(props: React.PropsWithChildren<{}>) {
           width: '100%',
           height: `${virtualizer.getTotalSize()}px`,
         }}
+        ref={(el) => {
+          if (!el) {
+            return
+          }
+
+          // Scroll to the active index
+          {
+            // Ignore this when we are in a test environment
+            if (typeof process !== 'undefined' && process.env.JEST_WORKER_ID !== undefined) {
+              return
+            }
+
+            // Do not scroll when the mouse/pointer is being used
+            if (data.activationTrigger === ActivationTrigger.Pointer) {
+              return
+            }
+
+            if (
+              data.activeOptionIndex !== null &&
+              data.virtual!.options.length > data.activeOptionIndex
+            ) {
+              virtualizer.scrollToIndex(data.activeOptionIndex)
+            }
+          }
+        }}
       >
-        {props.children}
+        {virtualizer.getVirtualItems().map((item) => {
+          return (
+            <Fragment key={item.key}>
+              {React.cloneElement(
+                props.children?.({
+                  option: data.virtual!.options[item.index],
+                  open: data.comboboxState === ComboboxState.Open,
+                }),
+                {
+                  key: `${baseKey}-${item.key}`,
+                  'data-index': item.index,
+                  'aria-setsize': data.virtual!.options.length,
+                  'aria-posinset': item.index + 1,
+                  style: {
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    transform: `translateY(${item.start}px)`,
+                    overflowAnchor: 'none',
+                  },
+                }
+              )}
+            </Fragment>
+          )
+        })}
       </div>
     </VirtualContext.Provider>
   )
@@ -375,11 +503,14 @@ let ComboboxDataContext = createContext<
       activeOptionIndex: number | null
       nullable: boolean
       immediate: boolean
+
+      virtual: { options: unknown[]; disabled: (value: unknown) => boolean } | null
+      calculateIndex(value: unknown): number
       compare(a: unknown, z: unknown): boolean
       isSelected(value: unknown): boolean
-      __demoMode: boolean
+      isActive(value: unknown): boolean
 
-      virtual: boolean
+      __demoMode: boolean
 
       optionsPropsRef: MutableRefObject<{
         static: boolean
@@ -475,7 +606,10 @@ export type ComboboxProps<
   form?: string
   name?: string
   immediate?: boolean
-  virtual?: boolean
+  virtual?: {
+    options: TValue[]
+    disabled?: (value: TValue) => boolean
+  } | null
 }
 
 function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG>(
@@ -505,13 +639,13 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
     onChange: controlledOnChange,
     form: formName,
     name,
-    by = (a: TValue, z: TValue) => a === z,
+    by = null,
     disabled = false,
     __demoMode = false,
     nullable = false,
     multiple = false,
     immediate = false,
-    virtual = false,
+    virtual = null,
     ...theirProps
   } = props
   let [value = multiple ? [] : undefined, theirOnChange] = useControllable<any>(
@@ -524,6 +658,9 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
     dataRef: createRef(),
     comboboxState: __demoMode ? ComboboxState.Open : ComboboxState.Closed,
     options: [],
+    virtual: virtual
+      ? { options: virtual.options, disabled: virtual.disabled ?? (() => false) }
+      : null,
     activeOptionIndex: null,
     activationTrigger: ActivationTrigger.Other,
     labelId: null,
@@ -546,18 +683,36 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
           let property = by as unknown as keyof TActualValue
           return a?.[property] === z?.[property]
         }
-      : by
+      : by ?? ((a: TValue, z: TValue) => a === z)
   )
 
+  let calculateIndex = useEvent((value: TValue) => {
+    if (virtual) {
+      if (by === null) {
+        return virtual.options.indexOf(value)
+      } else {
+        return virtual.options.findIndex((other) => compare(other, value))
+      }
+    } else {
+      // @ts-expect-error
+      return state.options.findIndex((other) => compare(other.dataRef.current.value, value))
+    }
+  })
+
   let isSelected: (value: TValue) => boolean = useCallback(
-    (compareValue) =>
+    (other) =>
       match(data.mode, {
         [ValueMode.Multi]: () =>
-          (value as EnsureArray<TValue>).some((option) => compare(option, compareValue)),
-        [ValueMode.Single]: () => compare(value as TValue, compareValue),
+          (value as EnsureArray<TValue>).some((option) => compare(option, other)),
+        [ValueMode.Single]: () => compare(value as TValue, other),
       }),
     [value]
   )
+
+  let isActive = useEvent((other: TValue) => {
+    return state.activeOptionIndex === calculateIndex(other)
+  })
+
   let data = useMemo<_Data>(
     () => ({
       ...state,
@@ -571,16 +726,26 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
       defaultValue,
       disabled,
       mode: multiple ? ValueMode.Multi : ValueMode.Single,
-      virtual,
+      virtual: state.virtual,
       get activeOptionIndex() {
         if (
           defaultToFirstOption.current &&
           state.activeOptionIndex === null &&
-          state.options.length > 0
+          (virtual ? virtual.options.length > 0 : state.options.length > 0)
         ) {
-          let localActiveOptionIndex = state.options.findIndex(
-            (option) => !option.dataRef.current.disabled
-          )
+          if (virtual) {
+            let localActiveOptionIndex = virtual.options.findIndex(
+              (option) => !(virtual?.disabled?.(option) ?? false)
+            )
+
+            if (localActiveOptionIndex !== -1) {
+              return localActiveOptionIndex
+            }
+          }
+
+          let localActiveOptionIndex = state.options.findIndex((option) => {
+            return !option.dataRef.current.disabled
+          })
 
           if (localActiveOptionIndex !== -1) {
             return localActiveOptionIndex
@@ -589,24 +754,20 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
 
         return state.activeOptionIndex
       },
+      calculateIndex,
       compare,
       isSelected,
+      isActive,
       nullable,
       __demoMode,
     }),
     [value, defaultValue, disabled, multiple, nullable, __demoMode, state, virtual]
   )
 
-  let lastActiveOption = useRef(
-    data.activeOptionIndex !== null ? data.options[data.activeOptionIndex] : null
-  )
-  useEffect(() => {
-    let currentActiveOption =
-      data.activeOptionIndex !== null ? data.options[data.activeOptionIndex] : null
-    if (lastActiveOption.current !== currentActiveOption) {
-      lastActiveOption.current = currentActiveOption
-    }
-  })
+  useIsoMorphicEffect(() => {
+    if (!virtual) return
+    dispatch({ type: ActionTypes.UpdateVirtualOptions, options: virtual.options })
+  }, [virtual, virtual?.options])
 
   useIsoMorphicEffect(() => {
     state.dataRef.current = data
@@ -627,28 +788,27 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
       activeOption:
         data.activeOptionIndex === null
           ? null
-          : (data.options[data.activeOptionIndex].dataRef.current.value as TValue),
+          : data.virtual
+          ? data.virtual.options[data.activeOptionIndex ?? 0]
+          : (data.options[data.activeOptionIndex]?.dataRef.current.value as TValue) ?? null,
       value,
     }),
     [data, disabled, value]
   )
 
-  let selectOption = useEvent((id: string) => {
-    let option = data.options.find((item) => item.id === id)
-    if (!option) return
-
-    onChange(option.dataRef.current.value)
-  })
-
   let selectActiveOption = useEvent(() => {
-    if (data.activeOptionIndex !== null) {
-      let { dataRef, id } = data.options[data.activeOptionIndex]
-      onChange(dataRef.current.value)
+    if (data.activeOptionIndex === null) return
 
-      // It could happen that the `activeOptionIndex` stored in state is actually null,
-      // but we are getting the fallback active option back instead.
-      actions.goToOption(Focus.Specific, id)
+    if (data.virtual) {
+      onChange(data.virtual.options[data.activeOptionIndex])
+    } else {
+      let { dataRef } = data.options[data.activeOptionIndex]
+      onChange(dataRef.current.value)
     }
+
+    // It could happen that the `activeOptionIndex` stored in state is actually null, but we are
+    // getting the fallback active option back instead.
+    actions.goToOption(Focus.Specific, data.activeOptionIndex)
   })
 
   let openCombobox = useEvent(() => {
@@ -661,18 +821,18 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
     defaultToFirstOption.current = false
   })
 
-  let goToOption = useEvent((focus, id, trigger) => {
+  let goToOption = useEvent((focus, idx, trigger) => {
     defaultToFirstOption.current = false
 
     if (focus === Focus.Specific) {
-      return dispatch({ type: ActionTypes.GoToOption, focus: Focus.Specific, id: id!, trigger })
+      return dispatch({ type: ActionTypes.GoToOption, focus: Focus.Specific, idx: idx!, trigger })
     }
 
     return dispatch({ type: ActionTypes.GoToOption, focus, trigger })
   })
 
   let registerOption = useEvent((id, dataRef) => {
-    dispatch({ type: ActionTypes.RegisterOption, id, dataRef })
+    dispatch({ type: ActionTypes.RegisterOption, payload: { id, dataRef } })
     return () => {
       // When we are unregistering the currently active option, then we also have to make sure to
       // reset the `defaultToFirstOption` flag, so that visually something is selected and the next
@@ -683,7 +843,7 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
       // the very first option seems like a fine default. We _could_ be smarter about this by going
       // to the previous / next item in list if we know the direction of the keyboard navigation,
       // but that might be too complex/confusing from an end users perspective.
-      if (lastActiveOption.current?.id === id) {
+      if (data.isActive(dataRef.current.value)) {
         defaultToFirstOption.current = true
       }
 
@@ -730,7 +890,6 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
       openCombobox,
       setActivationTrigger,
       selectActiveOption,
-      selectOption,
     }),
     []
   )
@@ -1008,12 +1167,8 @@ function InputFn<
         event.preventDefault()
         event.stopPropagation()
         return match(data.comboboxState, {
-          [ComboboxState.Open]: () => {
-            actions.goToOption(Focus.Next)
-          },
-          [ComboboxState.Closed]: () => {
-            actions.openCombobox()
-          },
+          [ComboboxState.Open]: () => actions.goToOption(Focus.Next),
+          [ComboboxState.Closed]: () => actions.openCombobox(),
         })
 
       case Keys.ArrowUp:
@@ -1021,9 +1176,7 @@ function InputFn<
         event.preventDefault()
         event.stopPropagation()
         return match(data.comboboxState, {
-          [ComboboxState.Open]: () => {
-            actions.goToOption(Focus.Previous)
-          },
+          [ComboboxState.Open]: () => actions.goToOption(Focus.Previous),
           [ComboboxState.Closed]: () => {
             actions.openCombobox()
             d.nextFrame(() => {
@@ -1199,7 +1352,18 @@ function InputFn<
     'aria-controls': data.optionsRef.current?.id,
     'aria-expanded': data.comboboxState === ComboboxState.Open,
     'aria-activedescendant':
-      data.activeOptionIndex === null ? undefined : data.options[data.activeOptionIndex]?.id,
+      data.activeOptionIndex === null
+        ? undefined
+        : data.virtual
+        ? data.options.find(
+            (option) =>
+              !data.virtual?.disabled(option.dataRef.current.value) &&
+              data.compare(
+                option.dataRef.current.value,
+                data.virtual!.options[data.activeOptionIndex!]
+              )
+          )?.id
+        : data.options[data.activeOptionIndex]?.id,
     'aria-labelledby': labelledby,
     'aria-autocomplete': 'list',
     defaultValue:
@@ -1392,6 +1556,7 @@ function LabelFn<TTag extends ElementType = typeof DEFAULT_LABEL_TAG>(
 let DEFAULT_OPTIONS_TAG = 'ul' as const
 interface OptionsRenderPropArg {
   open: boolean
+  option: unknown
 }
 type OptionsPropsWeControl = 'aria-labelledby' | 'aria-multiselectable' | 'role' | 'tabIndex'
 
@@ -1451,7 +1616,7 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
   )
 
   let slot = useMemo<OptionsRenderPropArg>(
-    () => ({ open: data.comboboxState === ComboboxState.Open }),
+    () => ({ open: data.comboboxState === ComboboxState.Open, option: undefined }),
     [data]
   )
   let ourProps = {
@@ -1465,6 +1630,7 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
   // Map the children in a scrollable container when virtualization is enabled
   if (data.virtual && data.comboboxState === ComboboxState.Open) {
     Object.assign(theirProps, {
+      // @ts-expect-error The `children` prop now is a callback function that receives `{ option }`.
       children: <VirtualProvider>{theirProps.children}</VirtualProvider>,
     })
   }
@@ -1519,25 +1685,22 @@ function OptionFn<
   let data = useData('Combobox.Option')
   let actions = useActions('Combobox.Option')
 
-  let active =
-    data.activeOptionIndex !== null ? data.options[data.activeOptionIndex].id === id : false
+  let active = data.virtual
+    ? data.activeOptionIndex === data.calculateIndex(value)
+    : data.activeOptionIndex === null
+    ? false
+    : data.options[data.activeOptionIndex]?.id === id
 
-  if (order === null && data.virtual) {
-    throw new Error(
-      `The \`order\` prop on <Combobox.Option /> is required when using <Combobox virtual />.`
-    )
-  }
-
-  let [, rerender] = useReducer((v) => !v, true)
   let selected = data.isSelected(value)
   let internalOptionRef = useRef<HTMLLIElement | null>(null)
+
   let bag = useLatestValue<ComboboxOptionDataRef<TType>['current']>({
     disabled,
     value,
     domRef: internalOptionRef,
     order,
-    onVirtualRangeUpdate: rerender,
   })
+
   let virtualizer = useContext(VirtualContext)
   let optionRef = useSyncRefs(
     ref,
@@ -1545,7 +1708,7 @@ function OptionFn<
     virtualizer ? virtualizer.measureElement : null
   )
 
-  let select = useEvent(() => actions.selectOption(id))
+  let select = useEvent(() => actions.onChange(value))
   useIsoMorphicEffect(() => actions.registerOption(id, bag), [bag, id])
 
   let enableScrollIntoView = useRef(data.virtual || data.__demoMode ? false : true)
@@ -1578,7 +1741,7 @@ function OptionFn<
   ])
 
   let handleClick = useEvent((event: { preventDefault: Function }) => {
-    if (disabled) return event.preventDefault()
+    if (disabled || data.virtual?.disabled(value)) return event.preventDefault()
     select()
 
     // We want to make sure that we don't accidentally trigger the virtual keyboard.
@@ -1603,8 +1766,11 @@ function OptionFn<
   })
 
   let handleFocus = useEvent(() => {
-    if (disabled) return actions.goToOption(Focus.Nothing)
-    actions.goToOption(Focus.Specific, id)
+    if (disabled || data.virtual?.disabled(value)) {
+      return actions.goToOption(Focus.Nothing)
+    }
+    let idx = data.calculateIndex(value)
+    actions.goToOption(Focus.Specific, idx)
   })
 
   let pointer = useTrackedPointer()
@@ -1613,14 +1779,15 @@ function OptionFn<
 
   let handleMove = useEvent((evt) => {
     if (!pointer.wasMoved(evt)) return
-    if (disabled) return
+    if (disabled || data.virtual?.disabled(value)) return
     if (active) return
-    actions.goToOption(Focus.Specific, id, ActivationTrigger.Pointer)
+    let idx = data.calculateIndex(value)
+    actions.goToOption(Focus.Specific, idx, ActivationTrigger.Pointer)
   })
 
   let handleLeave = useEvent((evt) => {
     if (!pointer.wasMoved(evt)) return
-    if (disabled) return
+    if (disabled || data.virtual?.disabled(value)) return
     if (!active) return
     if (data.optionsPropsRef.current.hold) return
     actions.goToOption(Focus.Nothing)
@@ -1630,43 +1797,6 @@ function OptionFn<
     () => ({ active, selected, disabled }),
     [active, selected, disabled]
   )
-
-  let virtualIdx = useMemo(() => {
-    if (!data.virtual) return -1
-    return data.options.findIndex((o) => o.id === id) ?? 0
-  }, [virtualizer, data.options, id])
-
-  let virtualItem =
-    virtualIdx === -1
-      ? undefined
-      : (virtualizer?.getVirtualItems() ?? []).find((item) => item.index === virtualIdx)
-
-  let d = useDisposables()
-  let shouldScroll =
-    virtualizer && data.activationTrigger !== ActivationTrigger.Pointer && data.virtual && active
-
-  useEffect(() => {
-    if (!shouldScroll) return
-
-    // Try scrolling to the item
-    virtualizer!.scrollToIndex(virtualIdx)
-
-    // Ensure we scrolled to the correct location
-    ;(function ensureScrolledCorrectly() {
-      if (virtualizer?.isScrolling) {
-        d.requestAnimationFrame(ensureScrolledCorrectly)
-        return
-      }
-
-      virtualizer!.scrollToIndex(virtualIdx)
-    })()
-
-    return d.dispose
-  }, [active, virtualizer, virtualIdx, shouldScroll])
-
-  if (data.virtual && !virtualItem) {
-    return null
-  }
 
   let ourProps = {
     id,
@@ -1678,9 +1808,6 @@ function OptionFn<
     // multi-select,but Voice-Over disagrees. So we use aria-checked instead for
     // both single and multi-select.
     'aria-selected': selected,
-    'data-index': virtualizer && virtualIdx !== -1 ? virtualIdx : undefined,
-    'aria-setsize': virtualizer ? data.options.length : undefined,
-    'aria-posinset': virtualizer && virtualIdx !== -1 ? virtualIdx + 1 : undefined,
     disabled: undefined, // Never forward the `disabled` prop
     onClick: handleClick,
     onFocus: handleFocus,
@@ -1690,21 +1817,6 @@ function OptionFn<
     onMouseMove: handleMove,
     onPointerLeave: handleLeave,
     onMouseLeave: handleLeave,
-  }
-
-  if (virtualItem) {
-    let localOurProps = ourProps as typeof ourProps & { style: CSSProperties }
-
-    localOurProps.style = {
-      ...localOurProps.style,
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      transform: `translateY(${virtualItem.start}px)`,
-    }
-
-    // Technically unnecessary
-    ourProps = localOurProps
   }
 
   return render({

--- a/packages/@headlessui-react/src/utils/calculate-active-index.ts
+++ b/packages/@headlessui-react/src/utils/calculate-active-index.ts
@@ -37,48 +37,56 @@ export function calculateActiveIndex<TItem>(
   let currentActiveIndex = resolvers.resolveActiveIndex()
   let activeIndex = currentActiveIndex ?? -1
 
-  let nextActiveIndex = (() => {
-    switch (action.focus) {
-      case Focus.First:
-        return items.findIndex((item) => !resolvers.resolveDisabled(item))
-
-      case Focus.Previous: {
-        let idx = items
-          .slice()
-          .reverse()
-          .findIndex((item, idx, all) => {
-            if (activeIndex !== -1 && all.length - idx - 1 >= activeIndex) return false
-            return !resolvers.resolveDisabled(item)
-          })
-        if (idx === -1) return idx
-        return items.length - 1 - idx
+  switch (action.focus) {
+    case Focus.First: {
+      for (let i = 0; i < items.length; ++i) {
+        if (!resolvers.resolveDisabled(items[i])) {
+          return i
+        }
       }
-
-      case Focus.Next:
-        return items.findIndex((item, idx) => {
-          if (idx <= activeIndex) return false
-          return !resolvers.resolveDisabled(item)
-        })
-
-      case Focus.Last: {
-        let idx = items
-          .slice()
-          .reverse()
-          .findIndex((item) => !resolvers.resolveDisabled(item))
-        if (idx === -1) return idx
-        return items.length - 1 - idx
-      }
-
-      case Focus.Specific:
-        return items.findIndex((item) => resolvers.resolveId(item) === action.id)
-
-      case Focus.Nothing:
-        return null
-
-      default:
-        assertNever(action)
+      return currentActiveIndex
     }
-  })()
 
-  return nextActiveIndex === -1 ? currentActiveIndex : nextActiveIndex
+    case Focus.Previous: {
+      for (let i = activeIndex - 1; i >= 0; --i) {
+        if (!resolvers.resolveDisabled(items[i])) {
+          return i
+        }
+      }
+      return currentActiveIndex
+    }
+
+    case Focus.Next: {
+      for (let i = activeIndex + 1; i < items.length; ++i) {
+        if (!resolvers.resolveDisabled(items[i])) {
+          return i
+        }
+      }
+      return currentActiveIndex
+    }
+
+    case Focus.Last: {
+      for (let i = items.length - 1; i >= 0; --i) {
+        if (!resolvers.resolveDisabled(items[i])) {
+          return i
+        }
+      }
+      return currentActiveIndex
+    }
+
+    case Focus.Specific: {
+      for (let i = 0; i < items.length; ++i) {
+        if (resolvers.resolveId(items[i]) === action.id) {
+          return i
+        }
+      }
+      return currentActiveIndex
+    }
+
+    case Focus.Nothing:
+      return null
+
+    default:
+      assertNever(action)
+  }
 }

--- a/packages/@headlessui-react/src/utils/calculate-active-index.ts
+++ b/packages/@headlessui-react/src/utils/calculate-active-index.ts
@@ -27,8 +27,8 @@ export function calculateActiveIndex<TItem>(
   resolvers: {
     resolveItems(): TItem[]
     resolveActiveIndex(): number | null
-    resolveId(item: TItem): string
-    resolveDisabled(item: TItem): boolean
+    resolveId(item: TItem, index: number, items: TItem[]): string
+    resolveDisabled(item: TItem, index: number, items: TItem[]): boolean
   }
 ) {
   let items = resolvers.resolveItems()
@@ -40,7 +40,7 @@ export function calculateActiveIndex<TItem>(
   switch (action.focus) {
     case Focus.First: {
       for (let i = 0; i < items.length; ++i) {
-        if (!resolvers.resolveDisabled(items[i])) {
+        if (!resolvers.resolveDisabled(items[i], i, items)) {
           return i
         }
       }
@@ -49,7 +49,7 @@ export function calculateActiveIndex<TItem>(
 
     case Focus.Previous: {
       for (let i = activeIndex - 1; i >= 0; --i) {
-        if (!resolvers.resolveDisabled(items[i])) {
+        if (!resolvers.resolveDisabled(items[i], i, items)) {
           return i
         }
       }
@@ -58,7 +58,7 @@ export function calculateActiveIndex<TItem>(
 
     case Focus.Next: {
       for (let i = activeIndex + 1; i < items.length; ++i) {
-        if (!resolvers.resolveDisabled(items[i])) {
+        if (!resolvers.resolveDisabled(items[i], i, items)) {
           return i
         }
       }
@@ -67,7 +67,7 @@ export function calculateActiveIndex<TItem>(
 
     case Focus.Last: {
       for (let i = items.length - 1; i >= 0; --i) {
-        if (!resolvers.resolveDisabled(items[i])) {
+        if (!resolvers.resolveDisabled(items[i], i, items)) {
           return i
         }
       }
@@ -76,7 +76,7 @@ export function calculateActiveIndex<TItem>(
 
     case Focus.Specific: {
       for (let i = 0; i < items.length; ++i) {
-        if (resolvers.resolveId(items[i]) === action.id) {
+        if (resolvers.resolveId(items[i], i, items) === action.id) {
           return i
         }
       }

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `immediate` prop to `<Combobox />` for immediately opening the Combobox when the `input` receives focus ([#2686](https://github.com/tailwindlabs/headlessui/pull/2686))
-- Add `virtual` prop to `Combobox` component ([#2740](https://github.com/tailwindlabs/headlessui/pull/2740))
+- Add `virtual` prop to `Combobox` component ([#2779](https://github.com/tailwindlabs/headlessui/pull/2779))
 
 ## [1.7.16] - 2023-08-17
 

--- a/packages/playground-react/next.config.js
+++ b/packages/playground-react/next.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  reactStrictMode: true,
+  reactStrictMode: false,
   devIndicators: {
     autoPrerender: false,
   },

--- a/packages/playground-react/pages/_app.tsx
+++ b/packages/playground-react/pages/_app.tsx
@@ -150,6 +150,7 @@ function MyApp({ Component, pageProps }) {
           <NextLink href="/">
             <Logo className="h-6" />
           </NextLink>
+          <span className="font-bold text-white">(React)</span>
         </header>
 
         <KeyCaster />

--- a/packages/playground-react/pages/combobox/combobox-virtualized.tsx
+++ b/packages/playground-react/pages/combobox/combobox-virtualized.tsx
@@ -39,7 +39,7 @@ function Example({ virtual = true, initial }: { virtual?: boolean; initial: stri
             as="div"
           >
             <Combobox.Label className="block text-sm font-medium leading-5 text-gray-700">
-              Timezone {virtual ? `(virtual)` : ''}
+              Timezone {virtual ? `(virtual ${timezones.length})` : `(${timezones.length})`}
             </Combobox.Label>
 
             <div className="relative">

--- a/packages/playground-react/pages/combobox/combobox-virtualized.tsx
+++ b/packages/playground-react/pages/combobox/combobox-virtualized.tsx
@@ -1,27 +1,61 @@
 import { Combobox } from '@headlessui/react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { Button } from '../../components/button'
-import { timezones as allTimezones } from '../../data'
+import { timezones as _allTimezones } from '../../data'
 import { classNames } from '../../utils/class-names'
 
 export default function Home() {
+  let [count, setCount] = useState(1_000)
+
+  let list = useMemo(() => {
+    console.time('Generating list')
+    let result = []
+
+    while (result.length < count) {
+      let batch = Math.floor(result.length / _allTimezones.length) + 1
+      result.push(`${_allTimezones[result.length % _allTimezones.length]} #${batch}`)
+    }
+    console.timeEnd('Generating list')
+
+    return result
+  }, [count])
+
   return (
-    <div className="flex">
-      <Example virtual={true} initial="Europe/Brussels" />
-      <Example virtual={false} initial="Europe/Brussels" />
+    <div className="flex flex-col p-12">
+      <label className="mx-auto flex w-24 items-center gap-2">
+        <span>Items:</span>
+        <select
+          defaultValue={count}
+          className="mx-auto"
+          onChange={(e) => {
+            setCount(Number(e.target.value))
+          }}
+        >
+          <option value={100}>100</option>
+          <option value={1_000}>1000</option>
+          <option value={10_000}>10k</option>
+          <option value={100_000}>100k</option>
+        </select>
+      </label>
+
+      <div className="flex">
+        <Example data={list} virtual={true} initial="Europe/Brussels #1" />
+        <Example data={list} virtual={false} initial="Europe/Brussels #1" />
+      </div>
     </div>
   )
 }
 
-function Example({ virtual = true, initial }: { virtual?: boolean; initial: string }) {
+let nf = new Intl.NumberFormat('en-US')
+function Example({ virtual = true, data, initial }: { virtual?: boolean; data; initial: string }) {
   let [query, setQuery] = useState('')
   let [activeTimezone, setActiveTimezone] = useState(initial)
 
   let timezones =
     query === ''
-      ? allTimezones
-      : allTimezones.filter((timezone) => timezone.toLowerCase().includes(query.toLowerCase()))
+      ? data
+      : data.filter((timezone) => timezone.toLowerCase().includes(query.toLowerCase()))
 
   return (
     <div className="flex h-full w-screen justify-center bg-gray-50 p-12">
@@ -29,7 +63,7 @@ function Example({ virtual = true, initial }: { virtual?: boolean; initial: stri
         <div className="py-8 font-mono text-xs">Selected timezone: {activeTimezone}</div>
         <div className="space-y-1">
           <Combobox
-            virtual={virtual}
+            virtual={virtual ? { options: timezones } : undefined}
             value={activeTimezone}
             nullable
             onChange={(value) => {
@@ -39,7 +73,10 @@ function Example({ virtual = true, initial }: { virtual?: boolean; initial: stri
             as="div"
           >
             <Combobox.Label className="block text-sm font-medium leading-5 text-gray-700">
-              Timezone {virtual ? `(virtual ${timezones.length})` : `(${timezones.length})`}
+              Timezone{' '}
+              {virtual
+                ? `(virtual — ${nf.format(timezones.length)} items)`
+                : `(${nf.format(timezones.length)} items)`}
             </Combobox.Label>
 
             <div className="relative">
@@ -68,52 +105,106 @@ function Example({ virtual = true, initial }: { virtual?: boolean; initial: stri
               </span>
 
               <div className="absolute mt-1 w-full rounded-md bg-white shadow-lg">
-                <Combobox.Options className="shadow-xs max-h-60 overflow-auto rounded-md py-1 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5">
-                  {timezones.map((timezone, idx) => {
-                    return (
-                      <Combobox.Option
-                        key={timezone}
-                        order={virtual ? idx : undefined}
-                        value={timezone}
-                        className={({ active }) => {
-                          return classNames(
-                            'relative w-full cursor-default select-none py-2 pl-3 pr-9 focus:outline-none',
-                            active ? 'bg-indigo-600 text-white' : 'text-gray-900'
-                          )
-                        }}
-                      >
-                        {({ active, selected }) => (
-                          <>
-                            <span
-                              className={classNames(
-                                'block truncate',
-                                selected ? 'font-semibold' : 'font-normal'
-                              )}
-                            >
-                              {timezone}
-                            </span>
-                            {selected && (
+                {virtual ? (
+                  <Combobox.Options className="shadow-xs max-h-60 overflow-auto rounded-md py-1 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5">
+                    {
+                      // @ts-expect-error TODO
+                      ({ option, idx }) => {
+                        return (
+                          <Combobox.Option
+                            value={option}
+                            className={({ active }) => {
+                              return classNames(
+                                'relative w-full cursor-default select-none py-2 pl-3 pr-9 focus:outline-none',
+                                active ? 'bg-indigo-600 text-white' : 'text-gray-900'
+                              )
+                            }}
+                          >
+                            {({ active, selected }) => (
+                              <>
+                                <span
+                                  className={classNames(
+                                    'block truncate',
+                                    selected ? 'font-semibold' : 'font-normal'
+                                  )}
+                                >
+                                  {option}
+                                </span>
+                                {selected && (
+                                  <span
+                                    className={classNames(
+                                      'absolute inset-y-0 right-0 flex items-center pr-4',
+                                      active ? 'text-white' : 'text-indigo-600'
+                                    )}
+                                  >
+                                    <svg
+                                      className="h-5 w-5"
+                                      viewBox="0 0 20 20"
+                                      fill="currentColor"
+                                    >
+                                      <path
+                                        fillRule="evenodd"
+                                        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                                        clipRule="evenodd"
+                                      />
+                                    </svg>
+                                  </span>
+                                )}
+                              </>
+                            )}
+                          </Combobox.Option>
+                        )
+                      }
+                    }
+                  </Combobox.Options>
+                ) : (
+                  <Combobox.Options className="shadow-xs max-h-60 overflow-auto rounded-md py-1 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5">
+                    {timezones.map((timezone, idx) => {
+                      return (
+                        <Combobox.Option
+                          key={timezone}
+                          order={virtual ? idx : undefined}
+                          value={timezone}
+                          className={({ active }) => {
+                            return classNames(
+                              'relative w-full cursor-default select-none py-2 pl-3 pr-9 focus:outline-none',
+                              active ? 'bg-indigo-600 text-white' : 'text-gray-900'
+                            )
+                          }}
+                        >
+                          {({ active, selected }) => (
+                            <>
                               <span
                                 className={classNames(
-                                  'absolute inset-y-0 right-0 flex items-center pr-4',
-                                  active ? 'text-white' : 'text-indigo-600'
+                                  'block truncate',
+                                  selected ? 'font-semibold' : 'font-normal'
                                 )}
                               >
-                                <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                                  <path
-                                    fillRule="evenodd"
-                                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                                    clipRule="evenodd"
-                                  />
-                                </svg>
+                                {timezone}
                               </span>
-                            )}
-                          </>
-                        )}
-                      </Combobox.Option>
-                    )
-                  })}
-                </Combobox.Options>
+                              {selected && (
+                                <span
+                                  className={classNames(
+                                    'absolute inset-y-0 right-0 flex items-center pr-4',
+                                    active ? 'text-white' : 'text-indigo-600'
+                                  )}
+                                >
+                                  <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                                    <path
+                                      fillRule="evenodd"
+                                      d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                                      clipRule="evenodd"
+                                    />
+                                  </svg>
+                                </span>
+                              )}
+                            </>
+                          )}
+                        </Combobox.Option>
+                      )
+                    })}
+                  </Combobox.Options>
+                )}
               </div>
             </div>
           </Combobox>

--- a/packages/playground-vue/src/Layout.vue
+++ b/packages/playground-vue/src/Layout.vue
@@ -59,6 +59,7 @@
           </defs>
         </svg>
       </router-link>
+      <span class="font-bold text-white">(Vue)</span>
     </header>
     <main class="flex-1 overflow-auto bg-gray-50">
       <slot></slot>

--- a/packages/playground-vue/src/components/combobox/_virtual-example.vue
+++ b/packages/playground-vue/src/components/combobox/_virtual-example.vue
@@ -5,7 +5,7 @@
       <div class="space-y-1">
         <Combobox nullable v-model="activeTimezone" as="div" :virtual="virtual">
           <ComboboxLabel class="block text-sm font-medium leading-5 text-gray-700">
-            Timezone {{ virtual ? '(virtual)' : '' }}
+            Timezone {{ virtual ? `(virtual ${timezones.length})` : `(${timezones.length})` }}
           </ComboboxLabel>
 
           <div class="relative">

--- a/packages/playground-vue/src/components/combobox/_virtual-example.vue
+++ b/packages/playground-vue/src/components/combobox/_virtual-example.vue
@@ -5,7 +5,12 @@
       <div class="space-y-1">
         <Combobox nullable v-model="activeTimezone" as="div" :virtual="virtual">
           <ComboboxLabel class="block text-sm font-medium leading-5 text-gray-700">
-            Timezone {{ virtual ? `(virtual ${timezones.length})` : `(${timezones.length})` }}
+            Timezone
+            {{
+              virtual
+                ? `(virtual — ${nf.format(timezones.length)} items)`
+                : `(${nf.format(timezones.length)} items)`
+            }}
           </ComboboxLabel>
 
           <div class="relative">
@@ -37,6 +42,7 @@
 
             <div class="absolute mt-1 w-full rounded-md bg-white shadow-lg">
               <ComboboxOptions
+                v-if="!virtual"
                 class="shadow-xs max-h-60 overflow-auto rounded-md py-1 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5"
               >
                 <ComboboxOption
@@ -74,6 +80,39 @@
                   </li>
                 </ComboboxOption>
               </ComboboxOptions>
+              <ComboboxOptions
+                v-if="virtual"
+                class="shadow-xs max-h-60 overflow-auto rounded-md py-1 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5"
+                v-slot="{ option: timezone }"
+              >
+                <ComboboxOption :value="timezone" v-slot="{ active, selected }" as="template">
+                  <li
+                    :class="[
+                      'relative w-full cursor-default select-none py-2 pl-3 pr-9 focus:outline-none',
+                      active ? 'bg-indigo-600 text-white' : 'text-gray-900',
+                    ]"
+                  >
+                    <span :class="['block truncate', selected ? 'font-semibold' : 'font-normal']">
+                      {{ timezone }}
+                    </span>
+                    <span
+                      v-if="selected"
+                      :class="[
+                        'absolute inset-y-0 right-0 flex items-center pr-4',
+                        active ? 'text-white' : 'text-indigo-600',
+                      ]"
+                    >
+                      <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                        <path
+                          fillRule="evenodd"
+                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
+                    </span>
+                  </li>
+                </ComboboxOption>
+              </ComboboxOptions>
             </div>
           </div>
         </Combobox>
@@ -83,7 +122,7 @@
 </template>
 
 <script setup>
-import { timezones as allTimezones } from '../../data'
+let nf = new Intl.NumberFormat('en-US')
 import { ref, computed } from 'vue'
 import {
   Combobox,
@@ -94,18 +133,17 @@ import {
   ComboboxOptions,
 } from '@headlessui/vue'
 
-defineProps({
-  virtual: {
-    type: Boolean,
-    default: false,
-  },
-})
+let props = defineProps(['data', 'initial', 'virtual'])
 
 let query = ref('')
-let activeTimezone = ref('Europe/Brussels')
+let activeTimezone = ref(props.initial)
 let timezones = computed(() => {
   return query.value === ''
-    ? allTimezones
-    : allTimezones.filter((timezone) => timezone.toLowerCase().includes(query.value.toLowerCase()))
+    ? props.data
+    : props.data.filter((timezone) => timezone.toLowerCase().includes(query.value.toLowerCase()))
+})
+
+let virtual = computed(() => {
+  return props.virtual ? { options: timezones.value } : null
 })
 </script>

--- a/packages/playground-vue/src/components/combobox/combobox-virtualized.vue
+++ b/packages/playground-vue/src/components/combobox/combobox-virtualized.vue
@@ -1,10 +1,37 @@
 <template>
-  <div class="flex">
-    <Example :virtual="true" />
-    <Example :virtual="false" />
+  <div className="flex flex-col p-12">
+    <label class="mx-auto flex w-24 items-center gap-2">
+      <span>Items:</span>
+      <select v-model="count" class="mx-auto">
+        <option :value="100">100</option>
+        <option :value="1_000">1000</option>
+        <option :value="10_000">10k</option>
+        <option :value="100_000">100k</option>
+      </select>
+    </label>
+    <div class="flex">
+      <Example :data="list" initial="Europe/Brussels #1" :virtual="true" />
+      <Example :data="list" initial="Europe/Brussels #1" :virtual="false" />
+    </div>
   </div>
 </template>
 
 <script setup>
+import { ref, computed } from 'vue'
+import { timezones as _allTimezones } from '../../data'
 import Example from './_virtual-example.vue'
+
+let count = ref(1_000)
+let list = computed(() => {
+  console.time('Generating list')
+  let result = []
+
+  while (result.length < Number(count.value)) {
+    let batch = Math.floor(result.length / _allTimezones.length) + 1
+    result.push(`${_allTimezones[result.length % _allTimezones.length]} #${batch}`)
+  }
+  console.timeEnd('Generating list')
+
+  return result
+})
 </script>


### PR DESCRIPTION
This PR is an improvement on the [previous PR](https://github.com/tailwindlabs/headlessui/pull/2740) where we introduced a new `virtual` prop to the `Combobox` component.

This new API requires you to pass in a list of options, and provide a template to the `Combobox.Options` such that we can _only_ render the visible options (+ overscan).

**React:**

```tsx
<Combobox
  virtual={{
    options: ["Foo", "Bar", "Baz"],
    disabled: (option) => option === "Bar",
  }}
>
  <Combobox.Input />
  <Combobox.Options>
    {({ option }) => <Combobox.Option value={option}>{option}</Combobox.Option>}
  </Combobox.Options>
</Combobox>
```

**Vue:**

```vue
<template>
  <Combobox :virtual="virtual">
    <ComboboxInput />
    <ComboboxOptions v-slot="{ option }">
      <ComboboxOption :value="option">{{ option }}</ComboboxOption>
    </ComboboxOptions>
  </Combobox>
</template>

<script setup>
import { ref } from "vue";
let virtual = ref({
  options: ["Foo", "Bar", "Baz"],
  disabled: (option) => option === "Bar",
});
</script>
```

The `disabled` function in the `virtual` object is optional, but this is used to determine whether an option is disabled or not. In a non-virtual `Combobox`, we can check the `disabled` prop on the `Combobox.Option`, but since we are not rendering all of those, we don't have access to that information anymore.

The API we exposed in #2740 is now deprecated and won't be supported in future version.

Further fixes: #2441

Playground:
- React: https://headlessui-react-git-feat-virtual-list-tailwindlabs.vercel.app/combobox/combobox-virtualized
- Vue: https://headlessui-vue-git-feat-virtual-list-tailwindlabs.vercel.app/combobox/combobox-virtualized

---

_Some background:_

- **Why things are slow:**

  Our default `Combobox` component requires you to render (and mount) all the available options so that we know which options are available and what the next and previous options are based on the current active option to ensure that using arrow keys work as expected.

- **Initial approach:**

  To ensure that we always go to the correct next / previous option, we have to make sure that everything is sorted. React doesn't expose an "index" or other information about where a certain element is within the React tree (at least not as a public API). Instead, we sorted the options by the DOM node position. When you have a lot of items then this is very slow.

  A first approach, is that we introduced and `order` prop on the
  `Combobox.Option` to sort based on this instead of the DOM node, which is much
  much faster.

  **React:**

  ```diff
    <Combobox>
      <Combobox.Input />
      <Combobox.Options>
        {countries.map((country, idx) => (
  -       <Combobox.Option key={country} value={country}>
  +       <Combobox.Option key={country} value={country} order={idx}>
            {country}
          </Combobox.Option>
        ))}
      </Combobox.Options>
    </Combobox>
  ```

  **Vue:**

  ```diff
    <Combobox>
      <ComboboxInput />
      <ComboboxOptions
        <ComboboxOption
  -       v-for="country in countries"
  +       v-for="(country, idx) in countries"
  +       :order="idx"
          :key="country"
          :value="country"
        >
          {country}
        </ComboboxOption>
      </ComboboxOptions>
    </Combobox>
  ```

- **Next approach:**

  This was still too slow, especially when you have a lot of items. Instead, to keep the API clean, there is another approach we can use, which is only _mount_ the items that are necessary, but still have them in the React/Vue tree.

  This was a huge improvement for React, but it was still a bit too slow for Vue. This approach also required us to still **register** each individial option in memory. This was especially noticeable when you open the `Combobox` component.

  From an API perspective, this looks very clean, and it's easy to change a non-virtual Combobox to a virtual one.

  **React:**

  ```diff
  - <Combobox>
  + <Combobox virtual>
      <Combobox.Input />
      <Combobox.Options>
        {countries.map((country, idx) => (
          <Combobox.Option key={country} value={country} order={idx}>
            {country}
          </Combobox.Option>
        ))}
      </Combobox.Options>
    </Combobox>
  ```

  **Vue:**

  ```diff
  - <Combobox>
  + <Combobox virtual>
      <ComboboxInput />
      <ComboboxOptions>
        <ComboboxOption
          v-for="(country, idx) in countries"
          :order="idx"
          :key="country"
          :value="country"
        >
          {country}
        </ComboboxOption>
      </ComboboxOptions>
    </Combobox>
  ```

- **This PR:**

  Next, the goal is to get rid of all the pre-registering of options. Instead, let's pass in all the available options. Then, we will make sure that only the visible options are being rendered. To do this, you have to provide a "template":

  **React:**

  ```tsx
  <Combobox
    virtual={{
      options: ["Foo", "Bar", "Baz"],
      disabled: (option) => option === "Bar",
    }}
  >
    <Combobox.Input />
    <Combobox.Options>
      {({ option }) => (
        <Combobox.Option value={option}>{option}</Combobox.Option>
      )}
    </Combobox.Options>
  </Combobox>
  ```

  **Vue:**

  ```vue
  <template>
    <Combobox :virtual="virtual">
      <ComboboxInput />
      <ComboboxOptions v-slot="{ option }">
        <ComboboxOption :value="option">{{ option }}</ComboboxOption>
      </ComboboxOptions>
    </Combobox>
  </template>

  <script setup>
  import { ref } from "vue";
  let virtual = ref({
    options: ["Foo", "Bar", "Baz"],
    disabled: (option) => option === "Bar",
  });
  </script>
  ```

