### PR TITLE
Fix state data attribute in Vue

### DIFF
--- a/packages/@headlessui-vue/src/utils/render.test.ts
+++ b/packages/@headlessui-vue/src/utils/render.test.ts
@@ -148,4 +148,22 @@ describe('State Data Attributes', () => {
       'active selected'
     )
   })
+
+  it('as=template', () => {
+    renderTemplate({
+      template: html`
+        <Dummy as="template" class="abc" :slot="{active: true, selected: true}">
+          <div id="result">test</div>
+        </Dummy>
+      `,
+    })
+
+    expect(document.getElementById('result')).toHaveClass('abc')
+
+    // NOTE: Removing class="abc" causes this assertion to fail
+    expect(document.getElementById('result')).toHaveAttribute(
+      'data-headlessui-state',
+      'active selected'
+    )
+  })
 })

--- a/packages/@headlessui-vue/src/utils/render.test.ts
+++ b/packages/@headlessui-vue/src/utils/render.test.ts
@@ -6,9 +6,21 @@ import { render } from './render'
 let Dummy = defineComponent({
   props: {
     as: { type: [Object, String], default: 'div' },
+    slot: { type: Object, default: () => ({}) },
   },
   setup(props, { attrs, slots }) {
-    return () => render({ theirProps: props, ourProps: {}, slots, attrs, slot: {}, name: 'Dummy' })
+    return () => {
+      let { slot, ...rest } = props
+
+      return render({
+        theirProps: rest,
+        ourProps: {},
+        slots,
+        attrs,
+        slot,
+        name: 'Dummy',
+      })
+    }
   },
 })
 
@@ -118,5 +130,22 @@ describe('Validation', () => {
 
     // TODO: Is this the expected behavior? Should it actually be `345`?
     expect(document.getElementById('result')).toHaveAttribute('data-test', '123')
+  })
+})
+
+describe('State Data Attributes', () => {
+  it('as=element', () => {
+    renderTemplate({
+      template: html`
+        <Dummy id="result" as="div" :slot="{active: true, selected: true}">
+          <div>test</div>
+        </Dummy>
+      `,
+    })
+
+    expect(document.getElementById('result')).toHaveAttribute(
+      'data-headlessui-state',
+      'active selected'
+    )
   })
 })

--- a/packages/@headlessui-vue/src/utils/render.ts
+++ b/packages/@headlessui-vue/src/utils/render.ts
@@ -139,7 +139,7 @@ function _render({
         )
       }
 
-      let mergedProps = mergeProps(firstChild.props ?? {}, incomingProps)
+      let mergedProps = mergeProps(firstChild.props ?? {}, incomingProps, dataAttributes)
       let cloned = cloneVNode(firstChild, mergedProps, true)
       // Explicitly override props starting with `on`. This is for event handlers, but there are
       // scenario's where we set them to `undefined` explicitly (when `aria-disabled="true"` is
@@ -155,6 +155,7 @@ function _render({
     }
 
     if (Array.isArray(children) && children.length === 1) {
+      // TODO: Do we need to cloneVNode + dataAttributes here?
       return children[0]
     }
 


### PR DESCRIPTION
We accidentally broke the `data-headlessui-state="…"` attribute in Vue when using `as="template"`. In this situation the attribute would be omitted when it shouldn't be.

This PR fixes that so the `@headlessui/tailwindcss` plugin works again when using components from Radio Group, Listbox, Combobox, etc… with `as="template"`

Fixes #2786