### PR TITLE
Change react to wildcard @types/react(-dom) deps

### DIFF
--- a/packages/@headlessui-react/package.json
+++ b/packages/@headlessui-react/package.json
@@ -43,8 +43,8 @@
   },
   "devDependencies": {
     "@testing-library/react": "^13.0.0",
-    "@types/react": "^17.0.43",
-    "@types/react-dom": "^17.0.14",
+    "@types/react": "*",
+    "@types/react-dom": "*",
     "esbuild": "^0.11.18",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1128,14 +1128,14 @@
   resolved "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
 
-"@types/react-dom@*", "@types/react-dom@^17.0.14":
+"@types/react-dom@*":
   version "17.0.14"
   resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.14.tgz"
   integrity sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.43":
+"@types/react@*":
   version "17.0.43"
   resolved "https://registry.npmjs.org/@types/react/-/react-17.0.43.tgz"
   integrity sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==


### PR DESCRIPTION
Changing @types/react from previous 17.0.x version to allow any react types.

This is a similar approach to shopify polaris [here](https://github.com/Shopify/polaris/blob/bb310cd3abf18b272583afa6e732ce6b422b0b97/polaris-react/package.json#L61).

This allows flexibility on the user end to use whichever @types/react they have. This takes care of bazel build issues as noted in #2775 .

Other options:
* Update them to 18.x to align with react dev dependency
* Change to "^16 || ^17 || ^18" same with react peer dependency