### PR TITLE
Remove empty line in the middle of enum in menu under react package

### DIFF
--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -80,7 +80,6 @@ interface StateDefinition {
 enum ActionTypes {
   OpenMenu,
   CloseMenu,
-
   GoToItem,
   Search,
   ClearSearch,


### PR DESCRIPTION
I happen to have noticed what I judged to be an unwanted empty line in the middle of an Enum definition in the `menu.tsx` file under the React package, this PR removes it.

Documentation on contributing say "Please ask first before starting work on any significant new features", since this is not a major change, I thought it'd be ok to create this PR.