### PR TITLE
Fix outside click detection when component is mounted in the Shadow DOM

### DIFF
--- a/packages/@headlessui-react/src/hooks/use-root-containers.tsx
+++ b/packages/@headlessui-react/src/hooks/use-root-containers.tsx
@@ -43,6 +43,7 @@ export function useRootContainers({
       if (!(container instanceof HTMLElement)) continue // Skip non-HTMLElements
       if (container.id === 'headlessui-portal-root') continue // Skip the Headless UI portal root
       if (container.contains(mainTreeNodeRef.current)) continue // Skip if it is the main app
+      if (container.contains((mainTreeNodeRef.current?.getRootNode() as ShadowRoot)?.host)) continue // Skip if it is the main app (and the component is inside a shadow root)
       if (containers.some((defaultContainer) => container.contains(defaultContainer))) continue // Skip if the current container is part of a container we've already seen (e.g.: default container / portal)
 
       containers.push(container)


### PR DESCRIPTION
If a component (like a `<Popover>`) was mounted inside the Shadow DOM we wouldn't handle outside clicks correctly. Our outside click handling has to detect "3rd-party" elements in the DOM to make sure interacting with things like Grammarly still work. In Next.js the app is wrapped in a div (in non RSC situations) and, when a component was mounted inside the Shadow DOM, we'd detect this wrapping element as a valid 3rd-party element.

This PR fixes this my detecting if the component is mounted inside the shadow DOM, and if so, looking for the corresponding host element instead of the hidden node element we normally use.

Fixes #2856