### PR TITLE
fix DOMException when remove class with '\n' character in 'transition' component

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix infinite render-loop for `<Disclosure.Panel>` and `<Popover.Panel>` when `as={Fragment}` ([#2760](https://github.com/tailwindlabs/headlessui/pull/2760))
 - Fix VoiceOver bug for `Listbox` component in Chrome ([#2824](https://github.com/tailwindlabs/headlessui/pull/2824))
 - Fix outside click detection when component is mounted in the Shadow DOM ([#2866](https://github.com/tailwindlabs/headlessui/pull/2866))
+- Fix error when transition classes contain new lines ([#2871](https://github.com/tailwindlabs/headlessui/pull/2871))
 
 ### Added
 

--- a/packages/@headlessui-react/src/components/transitions/transition.test.tsx
+++ b/packages/@headlessui-react/src/components/transitions/transition.test.tsx
@@ -1,11 +1,11 @@
 import { act as _act, fireEvent, render } from '@testing-library/react'
 import React, { Fragment, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { getByText } from '../../test-utils/accessibility-assertions'
 import { executeTimeline } from '../../test-utils/execute-timeline'
+import { click } from '../../test-utils/interactions'
 import { createSnapshot } from '../../test-utils/snapshot'
 import { suppressConsoleLogs } from '../../test-utils/suppress-console-logs'
 import { Transition } from './transition'
-import { click } from '../../test-utils/interactions'
-import { getByText } from '../../test-utils/accessibility-assertions'
 
 let act = _act as unknown as <T>(fn: () => T) => PromiseLike<T>
 

--- a/packages/@headlessui-react/src/components/transitions/transition.tsx
+++ b/packages/@headlessui-react/src/components/transitions/transition.tsx
@@ -335,7 +335,7 @@ function TransitionChildFn<TTag extends ElementType = typeof DEFAULT_TRANSITION_
   }, [state, container, register, unregister, show, strategy])
 
   let classes = useLatestValue({
-    base: Array.from(rest.classList),
+    base: splitClasses(rest.className),
     enter: splitClasses(enter),
     enterFrom: splitClasses(enterFrom),
     enterTo: splitClasses(enterTo),

--- a/packages/@headlessui-react/src/components/transitions/transition.tsx
+++ b/packages/@headlessui-react/src/components/transitions/transition.tsx
@@ -40,7 +40,7 @@ type TransitionDirection = 'enter' | 'leave' | 'idle'
 /**
  * Split class lists by whitespace
  *
- * We can't check for just spaces as all whitespace characters is
+ * We can't check for just spaces as all whitespace characters are
  * invalid in a class name, so we have to split on ANY whitespace.
  */
 function splitClasses(classes: string = '') {

--- a/packages/@headlessui-react/src/components/transitions/transition.tsx
+++ b/packages/@headlessui-react/src/components/transitions/transition.tsx
@@ -37,8 +37,14 @@ type ContainerElement = MutableRefObject<HTMLElement | null>
 
 type TransitionDirection = 'enter' | 'leave' | 'idle'
 
+/**
+ * Split class lists by whitespace
+ *
+ * We can't check for just spaces as all whitespace characters is
+ * invalid in a class name, so we have to split on ANY whitespace.
+ */
 function splitClasses(classes: string = '') {
-  return classes.split(' ').filter((className) => className.trim().length > 1)
+  return classes.split(/\s+/).filter((className) => className.length > 1)
 }
 
 interface TransitionContextValues {

--- a/packages/@headlessui-react/src/components/transitions/transition.tsx
+++ b/packages/@headlessui-react/src/components/transitions/transition.tsx
@@ -329,7 +329,7 @@ function TransitionChildFn<TTag extends ElementType = typeof DEFAULT_TRANSITION_
   }, [state, container, register, unregister, show, strategy])
 
   let classes = useLatestValue({
-    base: splitClasses(rest.className),
+    base: Array.from(rest.classList),
     enter: splitClasses(enter),
     enterFrom: splitClasses(enterFrom),
     enterTo: splitClasses(enterTo),

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix missing `data-headlessui-state` attribute when `as="template"` ([#2787](https://github.com/tailwindlabs/headlessui/pull/2787))
 - Fix VoiceOver bug for `Listbox` component in Chrome ([#2824](https://github.com/tailwindlabs/headlessui/pull/2824))
 - Fix outside click detection when component is mounted in the Shadow DOM ([6846231](https://github.com/tailwindlabs/headlessui/commit/684623131b99d9e75dfc1c1f6d27244c334a95d9))
+- Fix error when transition classes contain new lines ([#2871](https://github.com/tailwindlabs/headlessui/pull/2871))
 
 ### Added
 

--- a/packages/@headlessui-vue/src/components/transitions/transition.ts
+++ b/packages/@headlessui-vue/src/components/transitions/transition.ts
@@ -29,8 +29,14 @@ import { Reason, transition } from './utils/transition'
 
 type ID = ReturnType<typeof useId>
 
+/**
+ * Split class lists by whitespace
+ *
+ * We can't check for just spaces as all whitespace characters is
+ * invalid in a class name, so we have to split on ANY whitespace.
+ */
 function splitClasses(classes: string = '') {
-  return classes.split(' ').filter((className) => className.trim().length > 1)
+  return classes.split(/\s+/).filter((className) => className.length > 1)
 }
 
 interface TransitionContextValues {

--- a/packages/@headlessui-vue/src/components/transitions/transition.ts
+++ b/packages/@headlessui-vue/src/components/transitions/transition.ts
@@ -32,7 +32,7 @@ type ID = ReturnType<typeof useId>
 /**
  * Split class lists by whitespace
  *
- * We can't check for just spaces as all whitespace characters is
+ * We can't check for just spaces as all whitespace characters are
  * invalid in a class name, so we have to split on ANY whitespace.
  */
 function splitClasses(classes: string = '') {


### PR DESCRIPTION
![image](https://github.com/tailwindlabs/headlessui/assets/3191925/fbcebd34-57a4-4dd3-a5ce-a8833304cbdb)
![image](https://github.com/tailwindlabs/headlessui/assets/3191925/5b841a28-65c6-45e1-9203-3d30248aef25)
![image](https://github.com/tailwindlabs/headlessui/assets/3191925/8f95cd32-018c-4c7d-b8e0-7270298c8829)
