### PR TITLE
useOutsideClick hook fail on tests

### DIFF
--- a/packages/@headlessui-react/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-react/src/hooks/use-outside-click.ts
@@ -16,7 +16,7 @@ export function useOutsideClick(
   // TODO: remove this once the React bug has been fixed: https://github.com/facebook/react/issues/24657
   let enabledRef = useRef(false)
   useEffect(
-    process.env.NODE_ENV === 'test'
+    typeof process !== 'undefined' && process.env.JEST_WORKER_ID !== undefined
       ? () => {
           enabledRef.current = enabled
         }


### PR DESCRIPTION
fix logic of detecting test env not only inside module but also for the app use this module