### PR TITLE
Improve cancellation of events when using `disabled` or `aria-disabled` attributes

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Allow horizontal scrolling inside the `Dialog` component ([#2889](https://github.com/tailwindlabs/headlessui/pull/2889))
+- Improve cancellation of events when using `disabled` or `aria-disabled` attributes ([#2890](https://github.com/tailwindlabs/headlessui/pull/2890))
 
 ## [2.0.0-alpha.1] - 2023-12-20
 

--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Allow horizontal scrolling when scroll locking ([bdf4f8e](https://github.com/tailwindlabs/headlessui/commit/bdf4f8e32358485dd9c437c0d631309250ee5624))
+- Allow horizontal scrolling inside the `Dialog` component ([#2889](https://github.com/tailwindlabs/headlessui/pull/2889))
 
 ## [2.0.0-alpha.1] - 2023-12-20
 

--- a/packages/@headlessui-react/src/utils/render.ts
+++ b/packages/@headlessui-react/src/utils/render.ts
@@ -318,16 +318,14 @@ function mergePropsAdvanced(...listOfProps: Props<any, any>[]) {
     }
   }
 
-  // Do not attach any event handlers when there is a `disabled` or `aria-disabled` prop set.
+  // Ensure event listeners are not called if `disabled` or `aria-disabled` is true
   if (target.disabled || target['aria-disabled']) {
-    return Object.assign(
-      target,
-      // Set all event listeners that we collected to `undefined`. This is
-      // important because of the `cloneElement` from above, which merges the
-      // existing and new props, they don't just override therefore we have to
-      // explicitly nullify them.
-      Object.fromEntries(Object.keys(eventHandlers).map((eventName) => [eventName, undefined]))
-    )
+    for (let eventName in eventHandlers) {
+      // Prevent default events for `onClick`, `onMouseDown`, `onKeyDown`, etc.
+      if (/^(on(?:Click|Pointer|Mouse|Key)(?:Down|Up|Press)?)$/.test(eventName)) {
+        eventHandlers[eventName] = [(e: any) => e?.preventDefault?.()]
+      }
+    }
   }
 
   // Merge event handlers


### PR DESCRIPTION
This PR fixes and improves the `disabled` and `aria-disabled` event handling that we introduced in
[#1265](https://github.com/tailwindlabs/headlessui/pull/1265). 

We wrongly assumed that we don't want to attach any event listeners if the `disabled` or
`aria-disabled` props were used. While in most cases this is true, and is even a no-op (the browser
doesn't call `onClick` on a `<button disabled>`) it is not true in other cases. 

For example `<a disabled>` doesn't exist, instead we use `<a aria-hidden="">`. If we now want to
"disabled" the native click behaviour we have to add `onClick={e => e.preventDefault()}`.

In the linked PR, we were removing the `onClick` we could have added. In this PR we make sure to
always add `e => e.preventDefault()` instead of the `onXYZ` handler we or you provided. We only do
this for `onClick`, `onMouseDown`, `onMouseUp`, `onPointerDown`, `onPoiterUp`, `onKeyDown`,
`onKeyUp` and `onKeyPress`. These are typically the events that cause an actual action that we want
to prevent instead.
