### PR TITLE
Further fine tune scroll locking on iOS

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Further fine tune scroll locking on iOS ([#2891](https://github.com/tailwindlabs/headlessui/pull/2891))
 
 ## [2.0.0-alpha.2] - 2023-12-20
 


### PR DESCRIPTION
This PR fixes an issue that I only noticed in a production build and not in the local development
version (potentially related to strict mode?).

However, we are trying to scroll lock the page on iOS, a way to do this is to add
`overscroll-behavior: contain;` and call `event.preventDefault()` in the `touchmove` event. While
this works great, we have to account for scrollable elements _inside_ the allowed containers (e.g.:
a scrollable table in a dialog).

We did this by checking whether or not the `event.target` or any of its parent were scrollable. The
heuristic we used was two-fold:

1. Does the computed style have `overflow: auto | scroll;`, `overflow-x: auto | scroll;` and `overflow-y: auto | scroll;`
2. Or, is there an overflow happening `element.scrollWidth` > `element.clientWidth` or `element.scrollHeight` > `element.clientHeight`

The issue is the first step, if an `overflow` property exists but there is no overflowing happening
then the `overscroll-behavior` for some reason doesn't have any effect and it will result in the
main page being scrollable.

Purely relying on step 2 seems to fix this issue.
