### PR TITLE
Ensure `Input`, `Select` and `Textarea` expose `Ref` related types

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Ensure `Input`, `Select` and `Textarea` expose `Ref` related types ([#2902](https://github.com/tailwindlabs/headlessui/pull/2902))
 
 ## [2.0.0-alpha.3] - 2023-12-20
 

--- a/packages/@headlessui-react/src/components/input/input.tsx
+++ b/packages/@headlessui-react/src/components/input/input.tsx
@@ -7,7 +7,13 @@ import { useId } from '../../hooks/use-id'
 import { useDisabled } from '../../internal/disabled'
 import { useProvidedId } from '../../internal/id'
 import type { Props } from '../../types'
-import { forwardRefWithAs, mergeProps, render, type HasDisplayName } from '../../utils/render'
+import {
+  forwardRefWithAs,
+  mergeProps,
+  render,
+  type HasDisplayName,
+  type RefProp,
+} from '../../utils/render'
 import { useDescribedBy } from '../description/description'
 import { useLabelledBy } from '../label/label'
 
@@ -91,7 +97,9 @@ function InputFn<TTag extends ElementType = typeof DEFAULT_INPUT_TAG>(
 }
 
 export interface _internal_ComponentInput extends HasDisplayName {
-  <TTag extends ElementType = typeof DEFAULT_INPUT_TAG>(props: InputProps<TTag>): JSX.Element
+  <TTag extends ElementType = typeof DEFAULT_INPUT_TAG>(
+    props: InputProps<TTag> & RefProp<typeof InputFn>
+  ): JSX.Element
 }
 
 export let Input = forwardRefWithAs(InputFn) as unknown as _internal_ComponentInput

--- a/packages/@headlessui-react/src/components/select/select.tsx
+++ b/packages/@headlessui-react/src/components/select/select.tsx
@@ -8,7 +8,13 @@ import { useId } from '../../hooks/use-id'
 import { useDisabled } from '../../internal/disabled'
 import { useProvidedId } from '../../internal/id'
 import type { Props } from '../../types'
-import { forwardRefWithAs, mergeProps, render, type HasDisplayName } from '../../utils/render'
+import {
+  forwardRefWithAs,
+  mergeProps,
+  render,
+  type HasDisplayName,
+  type RefProp,
+} from '../../utils/render'
 import { useDescribedBy } from '../description/description'
 import { useLabelledBy } from '../label/label'
 
@@ -93,7 +99,9 @@ function SelectFn<TTag extends ElementType = typeof DEFAULT_SELECT_TAG>(
 }
 
 export interface _internal_ComponentSelect extends HasDisplayName {
-  <TTag extends ElementType = typeof DEFAULT_SELECT_TAG>(props: SelectProps<TTag>): JSX.Element
+  <TTag extends ElementType = typeof DEFAULT_SELECT_TAG>(
+    props: SelectProps<TTag> & RefProp<typeof SelectFn>
+  ): JSX.Element
 }
 
 export let Select = forwardRefWithAs(SelectFn) as unknown as _internal_ComponentSelect

--- a/packages/@headlessui-react/src/components/textarea/textarea.tsx
+++ b/packages/@headlessui-react/src/components/textarea/textarea.tsx
@@ -7,7 +7,13 @@ import { useId } from '../../hooks/use-id'
 import { useDisabled } from '../../internal/disabled'
 import { useProvidedId } from '../../internal/id'
 import type { Props } from '../../types'
-import { forwardRefWithAs, mergeProps, render, type HasDisplayName } from '../../utils/render'
+import {
+  forwardRefWithAs,
+  mergeProps,
+  render,
+  type HasDisplayName,
+  type RefProp,
+} from '../../utils/render'
 import { useDescribedBy } from '../description/description'
 import { useLabelledBy } from '../label/label'
 
@@ -88,7 +94,9 @@ function TextareaFn<TTag extends ElementType = typeof DEFAULT_TEXTAREA_TAG>(
 }
 
 export interface _internal_ComponentTextarea extends HasDisplayName {
-  <TTag extends ElementType = typeof DEFAULT_TEXTAREA_TAG>(props: TextareaProps<TTag>): JSX.Element
+  <TTag extends ElementType = typeof DEFAULT_TEXTAREA_TAG>(
+    props: TextareaProps<TTag> & RefProp<typeof TextareaFn>
+  ): JSX.Element
 }
 
 export let Textarea = forwardRefWithAs(TextareaFn) as unknown as _internal_ComponentTextarea


### PR DESCRIPTION
This PR ensures that the types for `Input`, `Select` and `Textarea` expose information about the
`ref`.

Right now, these components do accept a ref and forward them to the correct underlying DOM element,
but the types aren't in sync.

