### PR TITLE
Add `hidden` attribute to internal `<Hidden />` component when the `Features.Hidden` feature is used

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent default behaviour when clicking outside of a `Dialog.Panel` ([#2919](https://github.com/tailwindlabs/headlessui/pull/2919))
 - Use `isFocused` instead of `isFocusVisible` for `Input` and `Textarea` components ([#2940](https://github.com/tailwindlabs/headlessui/pull/2940))
 - Ensure `children` prop of `Field` component can be a render prop ([#2941](https://github.com/tailwindlabs/headlessui/pull/2941))
+- Add `hidden` attribute to internal `<Hidden />` component when the `Features.Hidden` feature is used ([#2955](https://github.com/tailwindlabs/headlessui/pull/2955))
 
 ## [2.0.0-alpha.4] - 2024-01-03
 

--- a/packages/@headlessui-react/src/internal/hidden.tsx
+++ b/packages/@headlessui-react/src/internal/hidden.tsx
@@ -35,6 +35,7 @@ function VisuallyHidden<TTag extends ElementType = typeof DEFAULT_VISUALLY_HIDDE
       (features & HiddenFeatures.Focusable) === HiddenFeatures.Focusable
         ? true
         : theirProps['aria-hidden'] ?? undefined,
+    hidden: (features & HiddenFeatures.Hidden) === HiddenFeatures.Hidden ? true : undefined,
     style: {
       position: 'fixed',
       top: 1,

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose `disabled` state on `<Tab />` component ([#2918](https://github.com/tailwindlabs/headlessui/pull/2918))
 - Prevent default behaviour when clicking outside of a `DialogPanel` ([#2919](https://github.com/tailwindlabs/headlessui/pull/2919))
 - Don’t override explicit `disabled` prop for components inside `<MenuItem>` ([#2929](https://github.com/tailwindlabs/headlessui/pull/2929))
+- Add `hidden` attribute to internal `<Hidden />` component when the `Features.Hidden` feature is used ([#2955](https://github.com/tailwindlabs/headlessui/pull/2955))
 
 ## [1.7.17] - 2024-01-08
 

--- a/packages/@headlessui-vue/src/internal/hidden.ts
+++ b/packages/@headlessui-vue/src/internal/hidden.ts
@@ -27,6 +27,7 @@ export let Hidden = defineComponent({
             ? true
             : // @ts-ignore
               theirProps['aria-hidden'] ?? undefined,
+        hidden: (features & Features.Hidden) === Features.Hidden ? true : undefined,
         style: {
           position: 'fixed',
           top: 1,


### PR DESCRIPTION
This PR adds the `hidden` attribute to the `<Hidden />` component if the `Features.Hidden` is used as a feature.

We used to only add `display: none`, but that's not enough since certain CSS selectors still "see" this DOM node. 

E.g.: `space-x-4` in Tailwind CSS will set the `margin-left` on everything but the first DOM node. It is implemented with an exception for the `hidden` attribute.

Fixes: #2947

