### PR TITLE
Attempt form submission when pressing `Enter` on `Checkbox` component

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `isFocused` instead of `isFocusVisible` for `Input` and `Textarea` components ([#2940](https://github.com/tailwindlabs/headlessui/pull/2940))
 - Ensure `children` prop of `Field` component can be a render prop ([#2941](https://github.com/tailwindlabs/headlessui/pull/2941))
 - Add `hidden` attribute to internal `<Hidden />` component when the `Features.Hidden` feature is used ([#2955](https://github.com/tailwindlabs/headlessui/pull/2955))
+- Attempt form submission when pressing `Enter` on `Checkbox` component ([#2962](https://github.com/tailwindlabs/headlessui/pull/2962))
 
 ## [2.0.0-alpha.4] - 2024-01-03
 

--- a/packages/@headlessui-react/src/components/checkbox/checkbox.test.tsx
+++ b/packages/@headlessui-react/src/components/checkbox/checkbox.test.tsx
@@ -119,3 +119,47 @@ describe.each([
     })
   )
 })
+
+describe('Form submissions', () => {
+  it('should be possible to use in an uncontrolled way', async () => {
+    let handleSubmission = jest.fn()
+
+    render(
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          handleSubmission(Object.fromEntries(new FormData(e.target as HTMLFormElement)))
+        }}
+      >
+        <Checkbox name="notifications" />
+      </form>
+    )
+
+    // Focus the checkbox
+    await focus(getCheckbox())
+
+    // Submit
+    await press(Keys.Enter)
+
+    // No values
+    expect(handleSubmission).toHaveBeenLastCalledWith({})
+
+    // Toggle
+    await click(getCheckbox())
+
+    // Submit
+    await press(Keys.Enter)
+
+    // Notifications should be on
+    expect(handleSubmission).toHaveBeenLastCalledWith({ notifications: 'on' })
+
+    // Toggle
+    await click(getCheckbox())
+
+    // Submit
+    await press(Keys.Enter)
+
+    // Notifications should be off (or in this case, non-existant)
+    expect(handleSubmission).toHaveBeenLastCalledWith({})
+  })
+})


### PR DESCRIPTION
This PR fixes an issue where pressing `Enter` on a `<Checkbox />` component didn't attempt to submit the form. This PR solves that.

The `Checkbox` component is a `span` to make it stylable which means that it doesn't have the native capabilities to submit a form (we do render a hidden input field for exposing the data to the parent `form` but it doesn't retrieve any events directly).

This now implements the same logic as the `<Switch />` component where it attempts to submit the form. 

Fixes: #2958
