### PR TITLE
Fix Combobox `activeOption` render prop

### DIFF
--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+- Fix Combobox `activeOption` render prop ([#2973](https://github.com/tailwindlabs/headlessui/pull/2973))
 
 ## [1.7.18] - 2024-02-02
 

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -725,7 +725,7 @@ export let Combobox = defineComponent({
             ? null
             : api.virtual.value
             ? api.virtual.value.options[api.activeOptionIndex.value ?? 0]
-            : api.options.value[api.activeOptionIndex.value]?.dataRef.value.value ?? null,
+            : api.options.value[api.activeOptionIndex.value]?.dataRef.value ?? null,
         value: value.value,
       }
 


### PR DESCRIPTION
Resolves #2963 #2964

This PR fixes an issue with the `Combobox` component's `activeOption` render prop which was always `null` and also causing an error when hovering over an option with a `null` value.