### PR TITLE
Add close emit to Popover

### DIFF
--- a/packages/@headlessui-vue/src/components/popover/popover.ts
+++ b/packages/@headlessui-vue/src/components/popover/popover.ts
@@ -106,7 +106,8 @@ export let Popover = defineComponent({
   props: {
     as: { type: [Object, String], default: 'div' },
   },
-  setup(props, { slots, attrs, expose }) {
+  emits: { close: (_close: boolean) => true },
+  setup(props, { slots, attrs, emit, expose }) {
     let internalPopoverRef = ref<HTMLElement | null>(null)
 
     expose({ el: internalPopoverRef, $el: internalPopoverRef })
@@ -169,6 +170,7 @@ export let Popover = defineComponent({
       closePopover() {
         if (popoverState.value === PopoverStates.Closed) return
         popoverState.value = PopoverStates.Closed
+        emit('close', false)
       },
       close(focusableElement: HTMLElement | Ref<HTMLElement | null>) {
         api.closePopover()


### PR DESCRIPTION
This aligns the popover with the dialog api.
Now, both share the same emit logic.

Reference in dialog.ts: 
https://github.com/tailwindlabs/headlessui/blob/0befd75df52da35ac66dfb1e9b365ab5b87b5b86/packages/%40headlessui-vue/src/components/dialog/dialog.ts#L79