### PR TITLE
Add open and close events to popover

### DIFF
--- a/packages/@headlessui-vue/src/components/popover/popover.test.ts
+++ b/packages/@headlessui-vue/src/components/popover/popover.test.ts
@@ -249,6 +249,42 @@ describe('Rendering', () => {
         assertActiveElement(getByText('restoreable'))
       })
     )
+
+    it(
+      'should emit events on opening and closing the popover',
+      suppressConsoleLogs(async () => {
+        const { wrapper } = renderTemplate({
+          template: html`
+            <Popover v-slot="{ close }">
+              <PopoverButton>Trigger</PopoverButton>
+              <PopoverPanel> <button @click="close(elementRef)">Close me</button>} </PopoverPanel>
+            </Popover>
+          `,
+          setup: () => ({ elementRef: ref() }),
+        })
+
+        const popoverWrapper = wrapper.getComponent(Popover)
+
+        // Focus the button
+        getPopoverButton()?.focus()
+
+        // Ensure the button is focused
+        assertActiveElement(getPopoverButton())
+
+        // Open the popover
+        await click(getPopoverButton())
+
+        expect(popoverWrapper.emitted()).toHaveProperty('open')
+
+        // Ensure we can click the close button
+        await click(getByText('Close me'))
+
+        expect(popoverWrapper.emitted()).toHaveProperty('close')
+
+        // Ensure the popover is closed
+        assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
+      })
+    )
   })
 
   describe('PopoverButton', () => {

--- a/packages/@headlessui-vue/src/components/popover/popover.ts
+++ b/packages/@headlessui-vue/src/components/popover/popover.ts
@@ -9,6 +9,7 @@ import {
   provide,
   ref,
   shallowRef,
+  watch,
   watchEffect,
   type ComponentPublicInstance,
   type InjectionKey,
@@ -106,7 +107,8 @@ export let Popover = defineComponent({
   props: {
     as: { type: [Object, String], default: 'div' },
   },
-  setup(props, { slots, attrs, expose }) {
+  emits: ['open', 'close'],
+  setup(props, { slots, attrs, expose, emit }) {
     let internalPopoverRef = ref<HTMLElement | null>(null)
 
     expose({ el: internalPopoverRef, $el: internalPopoverRef })
@@ -257,6 +259,20 @@ export let Popover = defineComponent({
       },
       computed(() => popoverState.value === PopoverStates.Open)
     )
+
+    //Emit events on state change
+    watch(popoverState, (value) => {
+      const isOpen = match(value, {
+        [PopoverStates.Open]: true,
+        [PopoverStates.Closed]: false,
+      })
+
+      if (isOpen) {
+        emit('open')
+      } else {
+        emit('close')
+      }
+    })
 
     return () => {
       let slot = { open: popoverState.value === PopoverStates.Open, close: api.close }

--- a/packages/@headlessui-vue/src/components/popover/popover.ts
+++ b/packages/@headlessui-vue/src/components/popover/popover.ts
@@ -9,7 +9,6 @@ import {
   provide,
   ref,
   shallowRef,
-  watch,
   watchEffect,
   type ComponentPublicInstance,
   type InjectionKey,
@@ -261,8 +260,8 @@ export let Popover = defineComponent({
     )
 
     //Emit events on state change
-    watch(popoverState, (value) => {
-      const isOpen = match(value, {
+    watchEffect(() => {
+      const isOpen = match(popoverState.value, {
         [PopoverStates.Open]: true,
         [PopoverStates.Closed]: false,
       })

--- a/packages/@headlessui-vue/src/test-utils/vue-testing-library.ts
+++ b/packages/@headlessui-vue/src/test-utils/vue-testing-library.ts
@@ -55,6 +55,7 @@ export function render(TestComponent: any, options?: Parameters<typeof mount>[1]
       template.innerHTML = wrapper.element.parentElement!.innerHTML
       return template.content
     },
+    wrapper,
   }
 }
 


### PR DESCRIPTION
As a user of this library i want to run some side effects when the popover is opened or closed, without these events, its very hacky and easy to miss some accessible ways of opening the popover.