### PR TITLE
Replace deprecated Jest methods with the new methods

### DIFF
--- a/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
@@ -6079,7 +6079,7 @@ describe('Form compatibility', () => {
     // Submit the form
     await click(getByText('Submit'))
 
-    expect(submits).lastCalledWith([['delivery', 'pickup']])
+    expect(submits).toHaveBeenLastCalledWith([['delivery', 'pickup']])
   })
 
   it('should be possible to submit a form with a value', async () => {
@@ -6119,7 +6119,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([]) // no data
+    expect(submits).toHaveBeenLastCalledWith([]) // no data
 
     // Open combobox again
     await click(getComboboxButton())
@@ -6131,7 +6131,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([['delivery', 'home-delivery']])
+    expect(submits).toHaveBeenLastCalledWith([['delivery', 'home-delivery']])
 
     // Open combobox again
     await click(getComboboxButton())
@@ -6143,7 +6143,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([['delivery', 'pickup']])
+    expect(submits).toHaveBeenLastCalledWith([['delivery', 'pickup']])
   })
 
   it('should not submit the data if the Combobox is disabled', async () => {
@@ -6248,7 +6248,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([
+    expect(submits).toHaveBeenLastCalledWith([
       ['delivery[id]', '1'],
       ['delivery[value]', 'pickup'],
       ['delivery[label]', 'Pickup'],
@@ -6265,7 +6265,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([
+    expect(submits).toHaveBeenLastCalledWith([
       ['delivery[id]', '2'],
       ['delivery[value]', 'home-delivery'],
       ['delivery[label]', 'Home delivery'],
@@ -6282,7 +6282,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([
+    expect(submits).toHaveBeenLastCalledWith([
       ['delivery[id]', '1'],
       ['delivery[value]', 'pickup'],
       ['delivery[label]', 'Pickup'],

--- a/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
@@ -98,7 +98,7 @@ describe('safeguards', () => {
   ])(
     'should error when we are using a <%s /> without a parent <Combobox />',
     suppressConsoleLogs((name, Component) => {
-      expect(() => render(Component)).toThrowError(
+      expect(() => render(Component)).toThrow(
         `<${name} /> is missing a parent <Combobox /> component.`
       )
     })

--- a/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
@@ -92,7 +92,7 @@ describe('Safe guards', () => {
   ])(
     'should error when we are using a <%s /> without a parent <Dialog />',
     suppressConsoleLogs((name, Component) => {
-      expect(() => render(Component)).toThrowError(
+      expect(() => render(Component)).toThrow(
         `<${name} /> is missing a parent <Dialog /> component.`
       )
       expect.hasAssertions()

--- a/packages/@headlessui-vue/src/components/disclosure/disclosure.test.ts
+++ b/packages/@headlessui-vue/src/components/disclosure/disclosure.test.ts
@@ -32,7 +32,7 @@ describe('Safe guards', () => {
   ])(
     'should error when we are using a <%s /> without a parent <Disclosure />',
     suppressConsoleLogs((name, Component) => {
-      expect(() => render(Component)).toThrowError(
+      expect(() => render(Component)).toThrow(
         `<${name} /> is missing a parent <Disclosure /> component.`
       )
     })

--- a/packages/@headlessui-vue/src/components/listbox/listbox.test.tsx
+++ b/packages/@headlessui-vue/src/components/listbox/listbox.test.tsx
@@ -5005,7 +5005,7 @@ describe('Form compatibility', () => {
     // Submit the form
     await click(getByText('Submit'))
 
-    expect(submits).lastCalledWith([['delivery', 'pickup']])
+    expect(submits).toHaveBeenLastCalledWith([['delivery', 'pickup']])
   })
 
   it('should be possible to submit a form with a value', async () => {
@@ -5044,7 +5044,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([]) // no data
+    expect(submits).toHaveBeenLastCalledWith([]) // no data
 
     // Open listbox again
     await click(getListboxButton())
@@ -5056,7 +5056,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([['delivery', 'home-delivery']])
+    expect(submits).toHaveBeenLastCalledWith([['delivery', 'home-delivery']])
 
     // Open listbox again
     await click(getListboxButton())
@@ -5068,7 +5068,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([['delivery', 'pickup']])
+    expect(submits).toHaveBeenLastCalledWith([['delivery', 'pickup']])
   })
 
   it('should not submit the data if the Listbox is disabled', async () => {
@@ -5171,7 +5171,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([
+    expect(submits).toHaveBeenLastCalledWith([
       ['delivery[id]', '1'],
       ['delivery[value]', 'pickup'],
       ['delivery[label]', 'Pickup'],
@@ -5188,7 +5188,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([
+    expect(submits).toHaveBeenLastCalledWith([
       ['delivery[id]', '2'],
       ['delivery[value]', 'home-delivery'],
       ['delivery[label]', 'Home delivery'],
@@ -5205,7 +5205,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([
+    expect(submits).toHaveBeenLastCalledWith([
       ['delivery[id]', '1'],
       ['delivery[value]', 'pickup'],
       ['delivery[label]', 'Pickup'],

--- a/packages/@headlessui-vue/src/components/listbox/listbox.test.tsx
+++ b/packages/@headlessui-vue/src/components/listbox/listbox.test.tsx
@@ -74,7 +74,7 @@ describe('safeguards', () => {
   ])(
     'should error when we are using a <%s /> without a parent <Listbox />',
     suppressConsoleLogs((name, Component) => {
-      expect(() => render(Component)).toThrowError(
+      expect(() => render(Component)).toThrow(
         `<${name} /> is missing a parent <Listbox /> component.`
       )
     })

--- a/packages/@headlessui-vue/src/components/menu/menu.test.tsx
+++ b/packages/@headlessui-vue/src/components/menu/menu.test.tsx
@@ -63,9 +63,7 @@ describe('Safe guards', () => {
   ])(
     'should error when we are using a <%s /> without a parent <Menu />',
     suppressConsoleLogs((name, component) => {
-      expect(() => render(component)).toThrowError(
-        `<${name} /> is missing a parent <Menu /> component.`
-      )
+      expect(() => render(component)).toThrow(`<${name} /> is missing a parent <Menu /> component.`)
     })
   )
 

--- a/packages/@headlessui-vue/src/components/popover/popover.test.ts
+++ b/packages/@headlessui-vue/src/components/popover/popover.test.ts
@@ -45,7 +45,7 @@ describe('Safe guards', () => {
   ])(
     'should error when we are using a <%s /> without a parent <Popover />',
     suppressConsoleLogs((name, Component) => {
-      expect(() => render(Component)).toThrowError(
+      expect(() => render(Component)).toThrow(
         `<${name} /> is missing a parent <Popover /> component.`
       )
     })

--- a/packages/@headlessui-vue/src/components/radio-group/radio-group.test.ts
+++ b/packages/@headlessui-vue/src/components/radio-group/radio-group.test.ts
@@ -43,7 +43,7 @@ describe('Safe guards', () => {
   it.each([['RadioGroupOption', RadioGroupOption]])(
     'should error when we are using a <%s /> without a parent <RadioGroup />',
     suppressConsoleLogs((name, Component) => {
-      expect(() => render(Component)).toThrowError(
+      expect(() => render(Component)).toThrow(
         `<${name} /> is missing a parent <RadioGroup /> component.`
       )
     })

--- a/packages/@headlessui-vue/src/components/radio-group/radio-group.test.ts
+++ b/packages/@headlessui-vue/src/components/radio-group/radio-group.test.ts
@@ -1623,7 +1623,7 @@ describe('Form compatibility', () => {
       // Submit the form
       await click(getByText('Submit'))
 
-      expect(submits).lastCalledWith([['delivery', 'pickup']])
+      expect(submits).toHaveBeenLastCalledWith([['delivery', 'pickup']])
     })
   )
 
@@ -1659,7 +1659,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([]) // no data
+    expect(submits).toHaveBeenLastCalledWith([]) // no data
 
     // Choose home delivery
     await click(getByText('Home delivery'))
@@ -1668,7 +1668,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([['delivery', 'home-delivery']])
+    expect(submits).toHaveBeenLastCalledWith([['delivery', 'home-delivery']])
 
     // Choose pickup
     await click(getByText('Pickup'))
@@ -1677,7 +1677,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([['delivery', 'pickup']])
+    expect(submits).toHaveBeenLastCalledWith([['delivery', 'pickup']])
   })
 
   it('should not submit the data if the RadioGroup is disabled', async () => {
@@ -1771,7 +1771,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([
+    expect(submits).toHaveBeenLastCalledWith([
       ['delivery[id]', '1'],
       ['delivery[value]', 'pickup'],
       ['delivery[label]', 'Pickup'],
@@ -1785,7 +1785,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([
+    expect(submits).toHaveBeenLastCalledWith([
       ['delivery[id]', '2'],
       ['delivery[value]', 'home-delivery'],
       ['delivery[label]', 'Home delivery'],
@@ -1799,7 +1799,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([
+    expect(submits).toHaveBeenLastCalledWith([
       ['delivery[id]', '1'],
       ['delivery[value]', 'pickup'],
       ['delivery[label]', 'Pickup'],

--- a/packages/@headlessui-vue/src/components/switch/switch.test.tsx
+++ b/packages/@headlessui-vue/src/components/switch/switch.test.tsx
@@ -845,7 +845,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([['notifications', 'on']])
+    expect(submits).toHaveBeenLastCalledWith([['notifications', 'on']])
   })
 
   it('should be possible to submit a form with an boolean value', async () => {
@@ -877,7 +877,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([]) // no data
+    expect(submits).toHaveBeenLastCalledWith([]) // no data
 
     // Toggle
     await click(getSwitchLabel())
@@ -886,7 +886,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([['notifications', 'on']])
+    expect(submits).toHaveBeenLastCalledWith([['notifications', 'on']])
   })
 
   it('should be possible to submit a form with a provided string value', async () => {
@@ -918,7 +918,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([]) // no data
+    expect(submits).toHaveBeenLastCalledWith([]) // no data
 
     // Toggle
     await click(getSwitchLabel())
@@ -927,7 +927,7 @@ describe('Form compatibility', () => {
     await click(getByText('Submit'))
 
     // Verify that the form has been submitted
-    expect(submits).lastCalledWith([['fruit', 'apple']])
+    expect(submits).toHaveBeenLastCalledWith([['fruit', 'apple']])
   })
 
   it('should not submit the data if the Switch is disabled', async () => {

--- a/packages/@headlessui-vue/src/components/tabs/tabs.test.ts
+++ b/packages/@headlessui-vue/src/components/tabs/tabs.test.ts
@@ -32,7 +32,7 @@ describe('safeguards', () => {
   ])(
     'should error when we are using a <%s /> without a parent <TabGroup /> component',
     suppressConsoleLogs((name, Component) => {
-      expect(() => render(Component)).toThrowError(
+      expect(() => render(Component)).toThrow(
         `<${name} /> is missing a parent <TabGroup /> component.`
       )
     })


### PR DESCRIPTION
Something I noticed while working on another issue, some of the test methods have been deprecated. This PR fixes that by using the new methods they expect.