### PR TITLE
Accept optional `strategy` for the `anchor` prop

### DIFF
--- a/packages/@headlessui-react/src/internal/floating.tsx
+++ b/packages/@headlessui-react/src/internal/floating.tsx
@@ -22,6 +22,11 @@ type Placement = 'top' | 'right' | 'bottom' | 'left'
 
 type BaseAnchorProps = {
   /**
+   * The strategy to use when positioning the panel. Defaults to `fixed`.
+   */
+  strategy: 'absolute' | 'fixed'
+
+  /**
    * The `gap` is the space between the trigger and the panel.
    */
   gap: number | string // For `var()` support
@@ -166,6 +171,7 @@ export function FloatingProvider({
     offset = 0,
     padding = 0,
     inner,
+    strategy = 'fixed',
   } = useResolvedConfig(config, floatingEl)
   let [to, align = 'center'] = placement.split(' ') as [Placement | 'selection', Align | 'center']
 
@@ -189,7 +195,7 @@ export function FloatingProvider({
 
     // This component will be used in combination with a `Portal`, which means the floating
     // element will be rendered outside of the current DOM tree.
-    strategy: 'fixed',
+    strategy,
 
     // We use the panel in a `Dialog` which is making the page inert, therefore no re-positioning is
     // needed when scrolling changes.


### PR DESCRIPTION
This PR allows you to customize the `strategy` when using the `anchor` prop on most of our components.

This defaults to `fixed`, but you can override it to `absolute` if it's needed. Typically you won't need it, but it could improve performance around janky scroll behaviour.
