### PR TITLE
Make the `Combobox` component `nullable` by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "prettier-plugin-tailwindcss": "^0.5.7",
         "rimraf": "^3.0.2",
         "tslib": "^2.3.1",
-        "typescript": "^5.3.2"
+        "typescript": "^5.4.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -98,6 +98,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@arethetypeswrong/core/node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -9653,9 +9666,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
+      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
       "devOptional": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "prettier-plugin-tailwindcss": "^0.5.7",
     "rimraf": "^3.0.2",
     "tslib": "^2.3.1",
-    "typescript": "^5.3.2"
+    "typescript": "^5.4.3"
   }
 }

--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -692,7 +692,7 @@ describe('Rendering', () => {
 
           return (
             <>
-              <Combobox value={value} onChange={setValue} nullable>
+              <Combobox value={value} onChange={setValue}>
                 <Combobox.Input
                   onChange={NOOP}
                   displayValue={(str?: string) =>
@@ -4100,27 +4100,6 @@ describe.each([{ virtual: true }, { virtual: false }])(
               let [value, setValue] = useState<string | null>('bob')
               let [, setQuery] = useState<string>('')
 
-              // return (
-              //   <MyCombobox
-              //     options={[
-              //       { value: 'alice', children: 'Alice' },
-              //       { value: 'bob', children: 'Bob' },
-              //       { value: 'charlie', children: 'Charlie' },
-              //     ]}
-              //     comboboxProps={{
-              //       value,
-              //       onChange: (value: any) => {
-              //         setValue(value)
-              //         handleChange(value)
-              //       },
-              //       nullable: true,
-              //     }}
-              //     inputProps={{
-              //       onChange: (event: any) => setQuery(event.target.value),
-              //     }}
-              //   />
-              // )
-
               return (
                 <Combobox
                   value={value}
@@ -4128,7 +4107,6 @@ describe.each([{ virtual: true }, { virtual: false }])(
                     setValue(value)
                     handleChange(value)
                   }}
-                  nullable
                 >
                   <Combobox.Input onChange={(event) => setQuery(event.target.value)} />
                   <Combobox.Button>Trigger</Combobox.Button>

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1251,32 +1251,28 @@ function InputFn<
     isTyping.current = false
 
     // Focus is moved into the list, we don't want to close yet.
-    if (data.optionsRef.current?.contains(relatedTarget)) {
-      return
-    }
+    if (data.optionsRef.current?.contains(relatedTarget)) return
 
-    if (data.buttonRef.current?.contains(relatedTarget)) {
-      return
-    }
+    // Focus is moved to the button, we don't want to close yet.
+    if (data.buttonRef.current?.contains(relatedTarget)) return
 
+    // Focus is moved, but the combobox is not open. This can mean two things:
+    //
+    // 1. The combobox was never opened, so we don't have to do anything.
+    // 2. The combobox was closed and focus was moved already. At that point we
+    //    don't need to try and select the active option.
     if (data.comboboxState !== ComboboxState.Open) return
+
     event.preventDefault()
 
-    if (data.mode === ValueMode.Single) {
-      // We want to clear the value when the user presses escape if and only if the current
-      // value is not set (aka, they didn't select anything yet, or they cleared the input which
-      // caused the value to be set to `null`). If the current value is set, then we want to
-      // fallback to that value when we press escape (this part is handled in the watcher that
-      // syncs the value with the input field again).
-      if (data.value === null) {
-        clear()
-      }
-
-      // We do have a value, so let's select the active option, unless we were just going through
-      // the form and we opened it due to the focus event.
-      else if (data.activationTrigger !== ActivationTrigger.Focus) {
-        actions.selectActiveOption()
-      }
+    // We want to clear the value when the user presses escape or clicks outside
+    // the combobox if and only if the current value is not set (aka, they
+    // didn't select anything yet, or they cleared the input which caused the
+    // value to be set to `null`). If the current value is set, then we want to
+    // fallback to that value when we press escape (this part is handled in the
+    // watcher that syncs the value with the input field again).
+    if (data.mode === ValueMode.Single && data.value === null) {
+      clear()
     }
 
     return actions.closeCombobox()

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -48,7 +48,7 @@ import {
 import { FormFields } from '../../internal/form-fields'
 import { useProvidedId } from '../../internal/id'
 import { OpenClosedProvider, State, useOpenClosed } from '../../internal/open-closed'
-import type { EnsureArray, Expand, Props } from '../../types'
+import type { EnsureArray, Props } from '../../types'
 import { history } from '../../utils/active-element-history'
 import { isDisabledReactIssue7711 } from '../../utils/bugs'
 import { Focus, calculateActiveIndex } from '../../utils/calculate-active-index'
@@ -551,68 +551,34 @@ type ComboboxRenderPropArg<TValue, TActive = TValue> = {
   value: TValue
 }
 
-type O = 'value' | 'defaultValue' | 'multiple' | 'onChange' | 'by'
-
-type ComboboxValueProps<
-  TValue,
-  TMultiple extends boolean | undefined,
-  TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG,
-> = Extract<
-  | ({
-      value?: EnsureArray<TValue>
-      defaultValue?: EnsureArray<TValue>
-      multiple: true
-      onChange?(value: EnsureArray<TValue>): void
-      by?: ByComparator<TValue>
-    } & Props<TTag, ComboboxRenderPropArg<EnsureArray<TValue>, TValue>, O>)
-  | ({
-      value?: TValue | null
-      defaultValue?: TValue | null
-      multiple?: false
-      onChange?(value: TValue | null): void
-      by?: ByComparator<TValue | null>
-    } & Expand<Props<TTag, ComboboxRenderPropArg<TValue | null>, O>>)
-  | ({
-      value?: EnsureArray<TValue>
-      defaultValue?: EnsureArray<TValue>
-      multiple: true
-      onChange?(value: EnsureArray<TValue>): void
-      by?: ByComparator<TValue extends Array<infer U> ? U : TValue>
-    } & Expand<Props<TTag, ComboboxRenderPropArg<EnsureArray<TValue>, TValue>, O>>)
-  | ({
-      value?: TValue
-      multiple?: false
-      defaultValue?: TValue
-      onChange?(value: TValue): void
-      by?: ByComparator<TValue>
-    } & Props<TTag, ComboboxRenderPropArg<TValue>, O>),
-  { multiple?: TMultiple }
->
-
 export type ComboboxProps<
   TValue,
   TMultiple extends boolean | undefined,
   TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG,
-> = ComboboxValueProps<TValue, TMultiple, TTag> & {
-  disabled?: boolean
-  __demoMode?: boolean
-  form?: string
-  name?: string
-  immediate?: boolean
-  virtual?: {
-    options: TValue[]
-    disabled?: (value: TValue) => boolean
-  } | null
-}
+> = Props<
+  TTag,
+  ComboboxRenderPropArg<NoInfer<TValue>>,
+  'value' | 'defaultValue' | 'multiple' | 'onChange' | 'by',
+  {
+    value?: TMultiple extends true ? EnsureArray<TValue> : TValue
+    defaultValue?: TMultiple extends true ? EnsureArray<NoInfer<TValue>> : NoInfer<TValue>
 
-function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG>(
-  props: ComboboxProps<TValue, true, TTag>,
-  ref: Ref<HTMLElement>
-): JSX.Element
-function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG>(
-  props: ComboboxProps<TValue, false, TTag>,
-  ref: Ref<HTMLElement>
-): JSX.Element
+    onChange?(value: TMultiple extends true ? EnsureArray<NoInfer<TValue>> : NoInfer<TValue>): void
+    by?: ByComparator<NoInfer<TValue>>
+
+    multiple?: TMultiple
+    disabled?: boolean
+    form?: string
+    name?: string
+    immediate?: boolean
+    virtual?: {
+      options: NoInfer<TValue>[]
+      disabled?: (value: NoInfer<TValue>) => boolean
+    } | null
+
+    __demoMode?: boolean
+  }
+>
 
 function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG>(
   props: ComboboxProps<TValue, boolean | undefined, TTag>,

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -502,7 +502,6 @@ let ComboboxDataContext = createContext<
       disabled: boolean
       mode: ValueMode
       activeOptionIndex: number | null
-      nullable: boolean
       immediate: boolean
 
       virtual: { options: unknown[]; disabled: (value: unknown) => boolean } | null
@@ -552,18 +551,16 @@ type ComboboxRenderPropArg<TValue, TActive = TValue> = {
   value: TValue
 }
 
-type O = 'value' | 'defaultValue' | 'nullable' | 'multiple' | 'onChange' | 'by'
+type O = 'value' | 'defaultValue' | 'multiple' | 'onChange' | 'by'
 
 type ComboboxValueProps<
   TValue,
-  TNullable extends boolean | undefined,
   TMultiple extends boolean | undefined,
   TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG,
 > = Extract<
   | ({
       value?: EnsureArray<TValue>
       defaultValue?: EnsureArray<TValue>
-      nullable: true // We ignore `nullable` in multiple mode
       multiple: true
       onChange?(value: EnsureArray<TValue>): void
       by?: ByComparator<TValue>
@@ -571,7 +568,6 @@ type ComboboxValueProps<
   | ({
       value?: TValue | null
       defaultValue?: TValue | null
-      nullable: true
       multiple?: false
       onChange?(value: TValue | null): void
       by?: ByComparator<TValue | null>
@@ -579,28 +575,25 @@ type ComboboxValueProps<
   | ({
       value?: EnsureArray<TValue>
       defaultValue?: EnsureArray<TValue>
-      nullable?: false
       multiple: true
       onChange?(value: EnsureArray<TValue>): void
       by?: ByComparator<TValue extends Array<infer U> ? U : TValue>
     } & Expand<Props<TTag, ComboboxRenderPropArg<EnsureArray<TValue>, TValue>, O>>)
   | ({
       value?: TValue
-      nullable?: false
       multiple?: false
       defaultValue?: TValue
       onChange?(value: TValue): void
       by?: ByComparator<TValue>
     } & Props<TTag, ComboboxRenderPropArg<TValue>, O>),
-  { nullable?: TNullable; multiple?: TMultiple }
+  { multiple?: TMultiple }
 >
 
 export type ComboboxProps<
   TValue,
-  TNullable extends boolean | undefined,
   TMultiple extends boolean | undefined,
   TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG,
-> = ComboboxValueProps<TValue, TNullable, TMultiple, TTag> & {
+> = ComboboxValueProps<TValue, TMultiple, TTag> & {
   disabled?: boolean
   __demoMode?: boolean
   form?: string
@@ -613,24 +606,16 @@ export type ComboboxProps<
 }
 
 function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG>(
-  props: ComboboxProps<TValue, true, true, TTag>,
+  props: ComboboxProps<TValue, true, TTag>,
   ref: Ref<HTMLElement>
 ): JSX.Element
 function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG>(
-  props: ComboboxProps<TValue, true, false, TTag>,
-  ref: Ref<HTMLElement>
-): JSX.Element
-function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG>(
-  props: ComboboxProps<TValue, false, false, TTag>,
-  ref: Ref<HTMLElement>
-): JSX.Element
-function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG>(
-  props: ComboboxProps<TValue, false, true, TTag>,
+  props: ComboboxProps<TValue, false, TTag>,
   ref: Ref<HTMLElement>
 ): JSX.Element
 
 function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG>(
-  props: ComboboxProps<TValue, boolean | undefined, boolean | undefined, TTag>,
+  props: ComboboxProps<TValue, boolean | undefined, TTag>,
   ref: Ref<HTMLElement>
 ) {
   let providedDisabled = useDisabled()
@@ -643,7 +628,6 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
     by,
     disabled = providedDisabled || false,
     __demoMode = false,
-    nullable = false,
     multiple = false,
     immediate = false,
     virtual = null,
@@ -748,10 +732,9 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
       compare,
       isSelected,
       isActive,
-      nullable,
       __demoMode,
     }),
-    [value, defaultValue, disabled, multiple, nullable, __demoMode, state, virtual]
+    [value, defaultValue, disabled, multiple, __demoMode, state, virtual]
   )
 
   useIsoMorphicEffect(() => {
@@ -1214,7 +1197,7 @@ function InputFn<
           event.stopPropagation()
         }
 
-        if (data.nullable && data.mode === ValueMode.Single) {
+        if (data.mode === ValueMode.Single) {
           // We want to clear the value when the user presses escape if and only if the current
           // value is not set (aka, they didn't select anything yet, or they cleared the input which
           // caused the value to be set to `null`). If the current value is set, then we want to
@@ -1252,7 +1235,7 @@ function InputFn<
     //
     // This is can happen when you press backspace, but also when you select all the text and press
     // ctrl/cmd+x.
-    if (data.nullable && data.mode === ValueMode.Single) {
+    if (data.mode === ValueMode.Single) {
       if (event.target.value === '') {
         clear()
       }
@@ -1285,7 +1268,7 @@ function InputFn<
       // caused the value to be set to `null`). If the current value is set, then we want to
       // fallback to that value when we press escape (this part is handled in the watcher that
       // syncs the value with the input field again).
-      if (data.nullable && data.value === null) {
+      if (data.value === null) {
         clear()
       }
 
@@ -1827,16 +1810,10 @@ function OptionFn<
 
 export interface _internal_ComponentCombobox extends HasDisplayName {
   <TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG>(
-    props: ComboboxProps<TValue, true, true, TTag> & RefProp<typeof ComboboxFn>
+    props: ComboboxProps<TValue, true, TTag> & RefProp<typeof ComboboxFn>
   ): JSX.Element
   <TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG>(
-    props: ComboboxProps<TValue, true, false, TTag> & RefProp<typeof ComboboxFn>
-  ): JSX.Element
-  <TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG>(
-    props: ComboboxProps<TValue, false, true, TTag> & RefProp<typeof ComboboxFn>
-  ): JSX.Element
-  <TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG>(
-    props: ComboboxProps<TValue, false, false, TTag> & RefProp<typeof ComboboxFn>
+    props: ComboboxProps<TValue, false, TTag> & RefProp<typeof ComboboxFn>
   ): JSX.Element
 }
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -566,6 +566,9 @@ export type ComboboxProps<
     onChange?(value: TMultiple extends true ? EnsureArray<NoInfer<TValue>> : NoInfer<TValue>): void
     by?: ByComparator<NoInfer<TValue>>
 
+    /** @deprecated The `<Combobox />` is now nullable default */
+    nullable?: boolean
+
     multiple?: TMultiple
     disabled?: boolean
     form?: string

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1230,15 +1230,13 @@ function InputFn<
     // options while typing won't work at all because we are still in "composing" mode.
     onChange?.(event)
 
-    // When the value becomes empty in a single value mode while being nullable then we want to clear
+    // When the value becomes empty in a single value mode then we want to clear
     // the option entirely.
     //
     // This is can happen when you press backspace, but also when you select all the text and press
     // ctrl/cmd+x.
-    if (data.mode === ValueMode.Single) {
-      if (event.target.value === '') {
-        clear()
-      }
+    if (data.mode === ValueMode.Single && event.target.value === '') {
+      clear()
     }
 
     // Open the combobox to show the results based on what the user has typed


### PR DESCRIPTION
This PR makes the `Combobox` nullable by default, this means that it's possible to receive a `null` value in the `onChange` callback.

This PR also improves the behaviour of the component in general.

- If you remove all the text from the `ComboboxInput`, you will receive a `null` value in the `onChange` callback.
- If you click outside of the `Combobox`, the `Combobox` will close and then a few things can happen:

    1. The `Combobox` didn't have a value, so it will remain empty.
    2. The `Combobox` had a value, so it will keep that value.

    It will **not** select the currently `active` value (active means the visually selected value without being selected in the `Combobox` state itself).
- If you press `Escape`, the `Combobox` will close and the same rules as above will apply.
- If you press `<tab>`, the `Combobox` will close but this time the `active` value will be `selected`.

This PR also improves the underlying types, and uses the new TypeScript 5.4 `NoInfer<T>` feature. This way we can cleanup some complex types and make the code more readable.
