### PR TITLE
fix(Popover): tabindex at 0

### DIFF
--- a/packages/@headlessui-vue/src/components/popover/popover.ts
+++ b/packages/@headlessui-vue/src/components/popover/popover.ts
@@ -700,7 +700,7 @@ export let PopoverPanel = defineComponent({
         id,
         onKeydown: handleKeyDown,
         onFocusout: focus && api.popoverState.value === PopoverStates.Open ? handleBlur : undefined,
-        tabIndex: -1,
+        tabIndex: 0,
       }
 
       return render({


### PR DESCRIPTION
This PR would be fix the issue (#2951) when the popover is open the user can't focus button, inputs or others stuff inside the popover content with "tab". 