### PR TITLE
Keep focus inside of the `<ComboboxInput />` component

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent unnecessary execution of the `displayValue` callback in the `ComboboxInput` component ([#3048](https://github.com/tailwindlabs/headlessui/pull/3048))
 - Expose missing `data-disabled` and `data-focus` attributes on the `TabsPanel`, `MenuButton`, `PopoverButton` and `DisclosureButton` components ([#3061](https://github.com/tailwindlabs/headlessui/pull/3061))
 - Fix cursor position when re-focusing the `ComboboxInput` component ([#3065](https://github.com/tailwindlabs/headlessui/pull/3065))
+- Keep focus inside of the `<ComboboxInput />` component ([#3073](https://github.com/tailwindlabs/headlessui/pull/3073))
 
 ### Changed
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -5194,7 +5194,7 @@ describe.each([{ virtual: true }, { virtual: false }])('Mouse interactions %s', 
             options={[
               { value: 'alice', children: 'Alice', disabled: false },
               { value: 'bob', children: 'Bob', disabled: true },
-              { value: 'charile', children: 'Charlie', disabled: false },
+              { value: 'charlie', children: 'Charlie', disabled: false },
             ]}
           />
         )

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1454,12 +1454,10 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
   })
 
   let handleMouseDown = useEvent((event: ReactMouseEvent<HTMLButtonElement>) => {
-    // We use the `mousedown` event because this will fire before the `focus`
-    // event. When we use `event.preventDefault()` here, the
-    // `document.activeElement` will stay on the current element.
-    //
-    // Typically that means that the `ComboboxInput` will stay focused, and thus
-    // the selection / cursor position will be preserved.
+    // We use the `mousedown` event here since it fires before the focus
+    // event, allowing us to cancel the event before focus is moved from
+    // the `ComboboxInput` to the `ComboboxButton`. This keeps the input
+    // focused, preserving the cursor position and any text selection.
     event.preventDefault()
 
     if (isDisabledReactIssue7711(event.currentTarget)) return

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1454,17 +1454,17 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
   })
 
   let handleMouseDown = useEvent((event: ReactMouseEvent<HTMLButtonElement>) => {
-    // We use the `mousedown` event here since it fires before the focus
-    // event, allowing us to cancel the event before focus is moved from
-    // the `ComboboxInput` to the `ComboboxButton`. This keeps the input
-    // focused, preserving the cursor position and any text selection.
+    // We use the `mousedown` event here since it fires before the focus event,
+    // allowing us to cancel the event before focus is moved from the
+    // `ComboboxInput` to the `ComboboxButton`. This keeps the input focused,
+    // preserving the cursor position and any text selection.
     event.preventDefault()
 
     if (isDisabledReactIssue7711(event.currentTarget)) return
 
-    // Since we're using the `mousedown` event instead of a `click` event
-    // here to preserve the focus of the `ComboboxInput`, we need to also
-    // check that the `left` mouse button was clicked.
+    // Since we're using the `mousedown` event instead of a `click` event here
+    // to preserve the focus of the `ComboboxInput`, we need to also check
+    // that the `left` mouse button was clicked.
     if (event.button === MouseButton.Left) {
       if (data.comboboxState === ComboboxState.Open) {
         actions.closeCombobox()
@@ -1731,18 +1731,15 @@ function OptionFn<
   ])
 
   let handleMouseDown = useEvent((event: ReactMouseEvent<HTMLButtonElement>) => {
-    // We use the `mousedown` event because this will fire before the `focus`
-    // event. When we use `event.preventDefault()` here, the
-    // `document.activeElement` will stay on the current element.
-    //
-    // Typically that means that the `ComboboxInput` will stay focused, and thus
-    // the selection / cursor position will be preserved.
+    // We use the `mousedown` event here since it fires before the focus event,
+    // allowing us to cancel the event before focus is moved from the
+    // `ComboboxInput` to the `ComboboxOption`. This keeps the input focused,
+    // preserving the cursor position and any text selection.
     event.preventDefault()
 
-    // When we used the `click` event we didn't have to worry about this because
-    // that only fires if you use the `left` mouse button. However, now that we
-    // use the `mousedown` event, we do have to worry about which button is
-    // pressed.
+    // Since we're using the `mousedown` event instead of a `click` event here
+    // to preserve the focus of the `ComboboxInput`, we need to also check
+    // that the `left` mouse button was clicked.
     if (event.button !== MouseButton.Left) {
       return
     }

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -3,7 +3,6 @@
 import { useFocusRing } from '@react-aria/focus'
 import { useHover } from '@react-aria/interactions'
 import { Virtualizer, useVirtualizer } from '@tanstack/react-virtual'
-import { useFrameDebounce } from 'hooks/use-frame-debounce'
 import React, {
   Fragment,
   createContext,
@@ -28,6 +27,7 @@ import { useControllable } from '../../hooks/use-controllable'
 import { useDisposables } from '../../hooks/use-disposables'
 import { useElementSize } from '../../hooks/use-element-size'
 import { useEvent } from '../../hooks/use-event'
+import { useFrameDebounce } from '../../hooks/use-frame-debounce'
 import { useId } from '../../hooks/use-id'
 import { useIsoMorphicEffect } from '../../hooks/use-iso-morphic-effect'
 import { useLatestValue } from '../../hooks/use-latest-value'

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1424,12 +1424,13 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
     }
   })
 
-  let handleClick = useEvent((event: ReactMouseEvent<HTMLButtonElement>) => {
-    if (isDisabledReactIssue7711(event.currentTarget)) return event.preventDefault()
+  let handleMouseDown = useEvent((event: ReactMouseEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+
+    if (isDisabledReactIssue7711(event.currentTarget)) return
     if (data.comboboxState === ComboboxState.Open) {
       actions.closeCombobox()
     } else {
-      event.preventDefault()
       actions.openCombobox()
     }
 
@@ -1464,7 +1465,7 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
       'aria-labelledby': labelledBy,
       disabled: disabled || undefined,
       autoFocus,
-      onClick: handleClick,
+      onMouseDown: handleMouseDown,
       onKeyDown: handleKeyDown,
     },
     focusProps,
@@ -1689,8 +1690,10 @@ function OptionFn<
     /* We also want to trigger this when the position of the active item changes so that we can re-trigger the scrollIntoView */ data.activeOptionIndex,
   ])
 
-  let handleClick = useEvent((event: { preventDefault: Function }) => {
-    if (disabled || data.virtual?.disabled(value)) return event.preventDefault()
+  let handleMouseDown = useEvent((event: { preventDefault: Function }) => {
+    event.preventDefault()
+
+    if (disabled || data.virtual?.disabled(value)) return
     select()
 
     // We want to make sure that we don't accidentally trigger the virtual keyboard.
@@ -1758,7 +1761,7 @@ function OptionFn<
     // both single and multi-select.
     'aria-selected': selected,
     disabled: undefined, // Never forward the `disabled` prop
-    onClick: handleClick,
+    onMouseDown: handleMouseDown,
     onFocus: handleFocus,
     onPointerEnter: handleEnter,
     onMouseEnter: handleEnter,

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1425,6 +1425,12 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
   })
 
   let handleMouseDown = useEvent((event: ReactMouseEvent<HTMLButtonElement>) => {
+    // We use the `mousedown` event because this will fire before the `focus`
+    // event. When we use `event.preventDefault()` here, the
+    // `document.activeElement` will stay on the current element.
+    //
+    // Typically that means that the `ComboboxInput` will stay focused, and thus
+    // the selection / cursor position will be preserved.
     event.preventDefault()
 
     if (isDisabledReactIssue7711(event.currentTarget)) return
@@ -1691,6 +1697,12 @@ function OptionFn<
   ])
 
   let handleMouseDown = useEvent((event: { preventDefault: Function }) => {
+    // We use the `mousedown` event because this will fire before the `focus`
+    // event. When we use `event.preventDefault()` here, the
+    // `document.activeElement` will stay on the current element.
+    //
+    // Typically that means that the `ComboboxInput` will stay focused, and thus
+    // the selection / cursor position will be preserved.
     event.preventDefault()
 
     if (disabled || data.virtual?.disabled(value)) return

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1462,10 +1462,9 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
 
     if (isDisabledReactIssue7711(event.currentTarget)) return
 
-    // When we used the `click` event we didn't have to worry about this because
-    // that only fires if you use the `left` mouse button. However, now that
-    // we use the `mousedown` event, we do have to worry about which button is
-    // pressed.
+    // Since we're using the `mousedown` event instead of a `click` event
+    // here to preserve the focus of the `ComboboxInput`, we need to also
+    // check that the `left` mouse button was clicked.
     if (event.button === MouseButton.Left) {
       if (data.comboboxState === ComboboxState.Open) {
         actions.closeCombobox()

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1078,8 +1078,21 @@ function InputFn<
     })
   })
 
+  let dd = useDisposables()
   let handleKeyDown = useEvent((event: ReactKeyboardEvent<HTMLInputElement>) => {
     isTyping.current = true
+
+    // Re-set the typing flag, this behaves as a debounce-like implementation,
+    // so as long as we are typing we will not reset the `isTyping` flag, but
+    // once we stop typing we will reset it.
+    {
+      d.add(dd.dispose) // Ensure we cleanup when `d` is disposed
+      dd.dispose() // Cleanup previous disposables
+      dd.nextFrame(() => {
+        isTyping.current = false
+      })
+    }
+
     switch (event.key) {
       // Ref: https://www.w3.org/WAI/ARIA/apg/patterns/menu/#keyboard-interaction-12
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1389,6 +1389,16 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
     switch (event.key) {
       // Ref: https://www.w3.org/WAI/ARIA/apg/patterns/menu/#keyboard-interaction-12
 
+      case Keys.Space:
+      case Keys.Enter:
+        event.preventDefault()
+        event.stopPropagation()
+        if (data.comboboxState === ComboboxState.Closed) {
+          actions.openCombobox()
+        }
+
+        return d.nextFrame(() => refocusInput())
+
       case Keys.ArrowDown:
         event.preventDefault()
         event.stopPropagation()

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -3,6 +3,7 @@
 import { useFocusRing } from '@react-aria/focus'
 import { useHover } from '@react-aria/interactions'
 import { Virtualizer, useVirtualizer } from '@tanstack/react-virtual'
+import { useFrameDebounce } from 'hooks/use-frame-debounce'
 import React, {
   Fragment,
   createContext,
@@ -1078,20 +1079,12 @@ function InputFn<
     })
   })
 
-  let dd = useDisposables()
+  let debounce = useFrameDebounce()
   let handleKeyDown = useEvent((event: ReactKeyboardEvent<HTMLInputElement>) => {
     isTyping.current = true
-
-    // Re-set the typing flag, this behaves as a debounce-like implementation,
-    // so as long as we are typing we will not reset the `isTyping` flag, but
-    // once we stop typing we will reset it.
-    {
-      d.add(dd.dispose) // Ensure we cleanup when `d` is disposed
-      dd.dispose() // Cleanup previous disposables
-      dd.nextFrame(() => {
-        isTyping.current = false
-      })
-    }
+    debounce(() => {
+      isTyping.current = false
+    })
 
     switch (event.key) {
       // Ref: https://www.w3.org/WAI/ARIA/apg/patterns/menu/#keyboard-interaction-12

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1404,6 +1404,11 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
         event.stopPropagation()
         if (data.comboboxState === ComboboxState.Closed) {
           actions.openCombobox()
+          d.nextFrame(() => {
+            if (!data.value) {
+              actions.goToOption(Focus.First)
+            }
+          })
         }
 
         return d.nextFrame(() => refocusInput())

--- a/packages/@headlessui-react/src/components/mouse.ts
+++ b/packages/@headlessui-react/src/components/mouse.ts
@@ -1,0 +1,4 @@
+export enum MouseButton {
+  Left = 0,
+  Right = 2,
+}

--- a/packages/@headlessui-react/src/hooks/use-frame-debounce.ts
+++ b/packages/@headlessui-react/src/hooks/use-frame-debounce.ts
@@ -1,0 +1,18 @@
+import { useDisposables } from './use-disposables'
+import { useEvent } from './use-event'
+
+/**
+ * Schedule some task in the next frame.
+ *
+ * - If you call the returned function multiple times, only the last task will
+ *   be executed.
+ * - If the component is unmounted, the task will be cancelled.
+ */
+export function useFrameDebounce() {
+  let d = useDisposables()
+
+  return useEvent((cb: () => void) => {
+    d.dispose()
+    d.nextFrame(() => cb())
+  })
+}

--- a/packages/@headlessui-react/src/hooks/use-refocusable-input.ts
+++ b/packages/@headlessui-react/src/hooks/use-refocusable-input.ts
@@ -32,6 +32,7 @@ export function useRefocusableInput(ref: MutableRefObject<HTMLInputElement | nul
 
     // If the input is already focused, we don't need to do anything
     if (document.activeElement === input) return
+
     if (!(input instanceof HTMLInputElement)) return
     if (!input.isConnected) return
 

--- a/packages/@headlessui-react/src/hooks/use-refocusable-input.ts
+++ b/packages/@headlessui-react/src/hooks/use-refocusable-input.ts
@@ -29,6 +29,9 @@ export function useRefocusableInput(ref: MutableRefObject<HTMLInputElement | nul
 
   return useEvent(() => {
     let input = ref.current
+
+    // If the input is already focused, we don't need to do anything
+    if (document.activeElement === input) return
     if (!(input instanceof HTMLInputElement)) return
     if (!input.isConnected) return
 

--- a/packages/@headlessui-react/src/utils/disposables.ts
+++ b/packages/@headlessui-react/src/utils/disposables.ts
@@ -59,6 +59,10 @@ export function disposables() {
     },
 
     add(cb: () => void) {
+      if (_disposables.includes(cb)) {
+        return
+      }
+
       _disposables.push(cb)
       return () => {
         let idx = _disposables.indexOf(cb)


### PR DESCRIPTION
This PR improves the UX of the `Combobox` component. 

When you open the combobox via the button or when you select an option from the list, then the focus is briefly moved to the button or the option respectively and then we restore the focus to the input itself.

We improved this behaviour in #3065 where we ensure that the selection and cursor position inside of the input will be preserved when the focus is moved around as-if nothing happened.

However, this can result in a tiny selection flicker (because when the focus is moved to the button or the option, the selection is removed).

This PR improves on that behaviour by using the `mousedown` event instead of the `click` event. If we use `event.preventDefault()` in the `mousedown` event, then the focus will not be moved to the button or the option and the focus remains in the input. This also means that the selection remains in the input.

We now use the `mousedown` event, which means that we have to do a tiny bit more work compared to the `click` event. For example:
- We have to check that the left mouse button was used. The `mousedown` event will also be triggered when using the right mouse button (the click event doesn't do this)
- We have to manually check for `space` or `enter` keydown events on the button — this was previously handled by the `click` event as well.


https://github.com/tailwindlabs/headlessui/assets/1834413/6b30420f-f658-4308-a1aa-7fd7644a3a13

