### PR TITLE
Deprecate the `entered` prop on the `Transition` component

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Attempt form submission when pressing `Enter` on the `<Listbox.Button />` component ([#2972](https://github.com/tailwindlabs/headlessui/pull/2972))
 - Make the `Combobox` component `nullable` by default ([#3064](https://github.com/tailwindlabs/headlessui/pull/3064))
+- Deprecate the `entered` prop on the `Transition` component ([#3089](https://github.com/tailwindlabs/headlessui/pull/3089))
 
 ### Added
 

--- a/packages/@headlessui-react/src/components/transition/transition.tsx
+++ b/packages/@headlessui-react/src/components/transition/transition.tsx
@@ -66,6 +66,9 @@ export interface TransitionClasses {
   enter?: string
   enterFrom?: string
   enterTo?: string
+  /**
+   * @deprecated The `enterTo` and `leaveTo` classes stay applied after the transition has finished.
+   */
   entered?: string
   leave?: string
   leaveFrom?: string


### PR DESCRIPTION
This PR marks the `entered` prop on the `Transition` component as deprecated. This prop was used to ensure that some classes stay after the transition finishes.

However, it makes more sense to use the `enterTo` and `leaveTo` classes to achieve the same effect. This was already implemented, so there is no need for the `entered` prop at all. We keep it for backwards compatibility reasons, but marking it as deprecated such that you can drop it from your own codebase if you want.

Quick summary:

- We keep the `enterTo` classes once the `enter` transition finishes
- We keep the `leaveTo` classes once the `leave` transition finishes
