### PR TITLE
Remove unnecessary `as unknown` type casts

### DIFF
--- a/packages/@headlessui-react/src/components/button/button.tsx
+++ b/packages/@headlessui-react/src/components/button/button.tsx
@@ -78,4 +78,4 @@ export interface _internal_ComponentButton extends HasDisplayName {
   ): JSX.Element
 }
 
-export let Button = forwardRefWithAs(ButtonFn) as unknown as _internal_ComponentButton
+export let Button = forwardRefWithAs(ButtonFn) as _internal_ComponentButton

--- a/packages/@headlessui-react/src/components/checkbox/checkbox.tsx
+++ b/packages/@headlessui-react/src/components/checkbox/checkbox.tsx
@@ -198,4 +198,4 @@ export interface _internal_ComponentCheckbox extends HasDisplayName {
   ): JSX.Element
 }
 
-export let Checkbox = forwardRefWithAs(CheckboxFn) as unknown as _internal_ComponentCheckbox
+export let Checkbox = forwardRefWithAs(CheckboxFn) as _internal_ComponentCheckbox

--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -2015,7 +2015,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
               options,
               disabled: isDisabled,
             }}
-            value={'test' as unknown as T}
+            value={'test' as T}
             onChange={NOOP}
             {...comboboxProps}
           >
@@ -4456,7 +4456,7 @@ describe.each([{ virtual: true }, { virtual: false }])('Mouse interactions %s', 
       return typeof option === 'string'
         ? false
         : typeof option === 'object' && option !== null && 'disabled' in option
-          ? (option?.disabled as unknown as boolean | undefined) ?? false
+          ? (option?.disabled as boolean | undefined) ?? false
           : false
     }
     if (virtual) {
@@ -4466,7 +4466,7 @@ describe.each([{ virtual: true }, { virtual: false }])('Mouse interactions %s', 
             options,
             disabled: isDisabled,
           }}
-          value={'test' as unknown as T}
+          value={'test' as T}
           onChange={NOOP}
           {...comboboxProps}
         >

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -814,7 +814,7 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
           copy.splice(idx, 1)
         }
 
-        return theirOnChange?.(copy as unknown as TValue[])
+        return theirOnChange?.(copy as TValue[])
       },
     })
   })
@@ -970,7 +970,7 @@ function InputFn<
   // yourself using the selected option(s).
   let currentDisplayValue = useMemo(() => {
     if (typeof displayValue === 'function' && data.value !== undefined) {
-      return displayValue(data.value as unknown as TType) ?? ''
+      return displayValue(data.value as TType) ?? ''
     } else if (typeof data.value === 'string') {
       return data.value
     } else {
@@ -1319,9 +1319,7 @@ function InputFn<
       'aria-autocomplete': 'list',
       defaultValue:
         props.defaultValue ??
-        (data.defaultValue !== undefined
-          ? displayValue?.(data.defaultValue as unknown as TType)
-          : null) ??
+        (data.defaultValue !== undefined ? displayValue?.(data.defaultValue as TType) : null) ??
         data.defaultValue,
       disabled: disabled || undefined,
       autoFocus,
@@ -1869,19 +1867,13 @@ export interface _internal_ComponentComboboxOption extends HasDisplayName {
   ): JSX.Element
 }
 
-let ComboboxRoot = forwardRefWithAs(ComboboxFn) as unknown as _internal_ComponentCombobox
-export let ComboboxButton = forwardRefWithAs(
-  ButtonFn
-) as unknown as _internal_ComponentComboboxButton
-export let ComboboxInput = forwardRefWithAs(InputFn) as unknown as _internal_ComponentComboboxInput
+let ComboboxRoot = forwardRefWithAs(ComboboxFn) as _internal_ComponentCombobox
+export let ComboboxButton = forwardRefWithAs(ButtonFn) as _internal_ComponentComboboxButton
+export let ComboboxInput = forwardRefWithAs(InputFn) as _internal_ComponentComboboxInput
 /** @deprecated use `<Label>` instead of `<ComboboxLabel>` */
 export let ComboboxLabel = Label as _internal_ComponentComboboxLabel
-export let ComboboxOptions = forwardRefWithAs(
-  OptionsFn
-) as unknown as _internal_ComponentComboboxOptions
-export let ComboboxOption = forwardRefWithAs(
-  OptionFn
-) as unknown as _internal_ComponentComboboxOption
+export let ComboboxOptions = forwardRefWithAs(OptionsFn) as _internal_ComponentComboboxOptions
+export let ComboboxOption = forwardRefWithAs(OptionFn) as _internal_ComponentComboboxOption
 
 export let Combobox = Object.assign(ComboboxRoot, {
   Input: ComboboxInput,

--- a/packages/@headlessui-react/src/components/data-interactive/data-interactive.tsx
+++ b/packages/@headlessui-react/src/components/data-interactive/data-interactive.tsx
@@ -64,4 +64,4 @@ export interface _internal_ComponentDataInteractive extends HasDisplayName {
 
 export let DataInteractive = forwardRefWithAs(
   DataInteractiveFn
-) as unknown as _internal_ComponentDataInteractive
+) as _internal_ComponentDataInteractive

--- a/packages/@headlessui-react/src/components/description/description.tsx
+++ b/packages/@headlessui-react/src/components/description/description.tsx
@@ -137,7 +137,7 @@ export interface _internal_ComponentDescription extends HasDisplayName {
   ): JSX.Element
 }
 
-let DescriptionRoot = forwardRefWithAs(DescriptionFn) as unknown as _internal_ComponentDescription
+let DescriptionRoot = forwardRefWithAs(DescriptionFn) as _internal_ComponentDescription
 
 export let Description = Object.assign(DescriptionRoot, {
   //

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -667,15 +667,11 @@ export interface _internal_ComponentDialogTitle extends HasDisplayName {
 
 export interface _internal_ComponentDialogDescription extends _internal_ComponentDescription {}
 
-let DialogRoot = forwardRefWithAs(DialogFn) as unknown as _internal_ComponentDialog
-export let DialogBackdrop = forwardRefWithAs(
-  BackdropFn
-) as unknown as _internal_ComponentDialogBackdrop
-export let DialogPanel = forwardRefWithAs(PanelFn) as unknown as _internal_ComponentDialogPanel
-export let DialogOverlay = forwardRefWithAs(
-  OverlayFn
-) as unknown as _internal_ComponentDialogOverlay
-export let DialogTitle = forwardRefWithAs(TitleFn) as unknown as _internal_ComponentDialogTitle
+let DialogRoot = forwardRefWithAs(DialogFn) as _internal_ComponentDialog
+export let DialogBackdrop = forwardRefWithAs(BackdropFn) as _internal_ComponentDialogBackdrop
+export let DialogPanel = forwardRefWithAs(PanelFn) as _internal_ComponentDialogPanel
+export let DialogOverlay = forwardRefWithAs(OverlayFn) as _internal_ComponentDialogOverlay
+export let DialogTitle = forwardRefWithAs(TitleFn) as _internal_ComponentDialogTitle
 /** @deprecated use `<Description>` instead of `<DialogDescription>` */
 export let DialogDescription = Description as _internal_ComponentDialogDescription
 

--- a/packages/@headlessui-react/src/components/disclosure/disclosure.tsx
+++ b/packages/@headlessui-react/src/components/disclosure/disclosure.tsx
@@ -180,7 +180,7 @@ function DisclosureFn<TTag extends ElementType = typeof DEFAULT_DISCLOSURE_TAG>(
     ref,
     optionalRef(
       (ref) => {
-        internalDisclosureRef.current = ref as unknown as HTMLElement | null
+        internalDisclosureRef.current = ref as HTMLElement | null
       },
       props.as === undefined ||
         // @ts-expect-error The `as` prop _can_ be a Fragment
@@ -506,13 +506,9 @@ export interface _internal_ComponentDisclosurePanel extends HasDisplayName {
   ): JSX.Element
 }
 
-let DisclosureRoot = forwardRefWithAs(DisclosureFn) as unknown as _internal_ComponentDisclosure
-export let DisclosureButton = forwardRefWithAs(
-  ButtonFn
-) as unknown as _internal_ComponentDisclosureButton
-export let DisclosurePanel = forwardRefWithAs(
-  PanelFn
-) as unknown as _internal_ComponentDisclosurePanel
+let DisclosureRoot = forwardRefWithAs(DisclosureFn) as _internal_ComponentDisclosure
+export let DisclosureButton = forwardRefWithAs(ButtonFn) as _internal_ComponentDisclosureButton
+export let DisclosurePanel = forwardRefWithAs(PanelFn) as _internal_ComponentDisclosurePanel
 
 export let Disclosure = Object.assign(DisclosureRoot, {
   Button: DisclosureButton,

--- a/packages/@headlessui-react/src/components/field/field.tsx
+++ b/packages/@headlessui-react/src/components/field/field.tsx
@@ -76,4 +76,4 @@ export interface _internal_ComponentField extends HasDisplayName {
   <TTag extends ElementType = typeof DEFAULT_FIELD_TAG>(props: FieldProps<TTag>): JSX.Element
 }
 
-export let Field = forwardRefWithAs(FieldFn) as unknown as _internal_ComponentField
+export let Field = forwardRefWithAs(FieldFn) as _internal_ComponentField

--- a/packages/@headlessui-react/src/components/fieldset/fieldset.tsx
+++ b/packages/@headlessui-react/src/components/fieldset/fieldset.tsx
@@ -58,4 +58,4 @@ export interface _internal_ComponentFieldset extends HasDisplayName {
   <TTag extends ElementType = typeof DEFAULT_FIELDSET_TAG>(props: FieldsetProps<TTag>): JSX.Element
 }
 
-export let Fieldset = forwardRefWithAs(FieldsetFn) as unknown as _internal_ComponentFieldset
+export let Fieldset = forwardRefWithAs(FieldsetFn) as _internal_ComponentFieldset

--- a/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
+++ b/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
@@ -230,7 +230,7 @@ export interface _internal_ComponentFocusTrap extends HasDisplayName {
   ): JSX.Element
 }
 
-let FocusTrapRoot = forwardRefWithAs(FocusTrapFn) as unknown as _internal_ComponentFocusTrap
+let FocusTrapRoot = forwardRefWithAs(FocusTrapFn) as _internal_ComponentFocusTrap
 
 export let FocusTrap = Object.assign(FocusTrapRoot, {
   features: FocusTrapFeatures,

--- a/packages/@headlessui-react/src/components/input/input.tsx
+++ b/packages/@headlessui-react/src/components/input/input.tsx
@@ -93,4 +93,4 @@ export interface _internal_ComponentInput extends HasDisplayName {
   ): JSX.Element
 }
 
-export let Input = forwardRefWithAs(InputFn) as unknown as _internal_ComponentInput
+export let Input = forwardRefWithAs(InputFn) as _internal_ComponentInput

--- a/packages/@headlessui-react/src/components/label/label.tsx
+++ b/packages/@headlessui-react/src/components/label/label.tsx
@@ -220,7 +220,7 @@ export interface _internal_ComponentLabel extends HasDisplayName {
   ): JSX.Element
 }
 
-let LabelRoot = forwardRefWithAs(LabelFn) as unknown as _internal_ComponentLabel
+let LabelRoot = forwardRefWithAs(LabelFn) as _internal_ComponentLabel
 
 export let Label = Object.assign(LabelRoot, {
   //

--- a/packages/@headlessui-react/src/components/legend/legend.tsx
+++ b/packages/@headlessui-react/src/components/legend/legend.tsx
@@ -31,4 +31,4 @@ export interface _internal_ComponentLegend extends HasDisplayName {
   <TTag extends ElementType = typeof DEFAULT_LEGEND_TAG>(props: LegendProps<TTag>): JSX.Element
 }
 
-export let Legend = forwardRefWithAs(LegendFn) as unknown as _internal_ComponentLegend
+export let Legend = forwardRefWithAs(LegendFn) as _internal_ComponentLegend

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -510,9 +510,7 @@ function ListboxFn<
     (compareValue) =>
       match(data.mode, {
         [ValueMode.Multi]: () => {
-          return (value as unknown as EnsureArray<TType>).some((option) =>
-            compare(option, compareValue)
-          )
+          return (value as EnsureArray<TType>).some((option) => compare(option, compareValue))
         },
         [ValueMode.Single]: () => {
           return compare(value as TActualType, compareValue)
@@ -1362,17 +1360,15 @@ export interface _internal_ComponentListboxSelectedOption extends HasDisplayName
   ): JSX.Element
 }
 
-let ListboxRoot = forwardRefWithAs(ListboxFn) as unknown as _internal_ComponentListbox
-export let ListboxButton = forwardRefWithAs(ButtonFn) as unknown as _internal_ComponentListboxButton
+let ListboxRoot = forwardRefWithAs(ListboxFn) as _internal_ComponentListbox
+export let ListboxButton = forwardRefWithAs(ButtonFn) as _internal_ComponentListboxButton
 /** @deprecated use `<Label>` instead of `<ListboxLabel>` */
 export let ListboxLabel = Label as _internal_ComponentListboxLabel
-export let ListboxOptions = forwardRefWithAs(
-  OptionsFn
-) as unknown as _internal_ComponentListboxOptions
-export let ListboxOption = forwardRefWithAs(OptionFn) as unknown as _internal_ComponentListboxOption
+export let ListboxOptions = forwardRefWithAs(OptionsFn) as _internal_ComponentListboxOptions
+export let ListboxOption = forwardRefWithAs(OptionFn) as _internal_ComponentListboxOption
 export let ListboxSelectedOption = forwardRefWithAs(
   SelectedFn
-) as unknown as _internal_ComponentListboxSelectedOption
+) as _internal_ComponentListboxSelectedOption
 
 export let Listbox = Object.assign(ListboxRoot, {
   Button: ListboxButton,

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -1087,15 +1087,13 @@ export interface _internal_ComponentMenuSeparator extends HasDisplayName {
   ): JSX.Element
 }
 
-let MenuRoot = forwardRefWithAs(MenuFn) as unknown as _internal_ComponentMenu
-export let MenuButton = forwardRefWithAs(ButtonFn) as unknown as _internal_ComponentMenuButton
-export let MenuItems = forwardRefWithAs(ItemsFn) as unknown as _internal_ComponentMenuItems
-export let MenuItem = forwardRefWithAs(ItemFn) as unknown as _internal_ComponentMenuItem
-export let MenuSection = forwardRefWithAs(SectionFn) as unknown as _internal_ComponentMenuSection
-export let MenuHeading = forwardRefWithAs(HeadingFn) as unknown as _internal_ComponentMenuHeading
-export let MenuSeparator = forwardRefWithAs(
-  SeparatorFn
-) as unknown as _internal_ComponentMenuSeparator
+let MenuRoot = forwardRefWithAs(MenuFn) as _internal_ComponentMenu
+export let MenuButton = forwardRefWithAs(ButtonFn) as _internal_ComponentMenuButton
+export let MenuItems = forwardRefWithAs(ItemsFn) as _internal_ComponentMenuItems
+export let MenuItem = forwardRefWithAs(ItemFn) as _internal_ComponentMenuItem
+export let MenuSection = forwardRefWithAs(SectionFn) as _internal_ComponentMenuSection
+export let MenuHeading = forwardRefWithAs(HeadingFn) as _internal_ComponentMenuHeading
+export let MenuSeparator = forwardRefWithAs(SeparatorFn) as _internal_ComponentMenuSeparator
 
 export let Menu = Object.assign(MenuRoot, {
   Button: MenuButton,

--- a/packages/@headlessui-react/src/components/popover/popover.test.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.test.tsx
@@ -18,7 +18,7 @@ import { Portal } from '../portal/portal'
 import { Transition } from '../transition/transition'
 import { Popover } from './popover'
 
-let act = _act as unknown as <T>(fn: () => T) => PromiseLike<T>
+let act = _act as <T>(fn: () => T) => PromiseLike<T>
 
 jest.mock('../../hooks/use-id')
 

--- a/packages/@headlessui-react/src/components/popover/popover.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.tsx
@@ -1194,13 +1194,11 @@ export interface _internal_ComponentPopoverGroup extends HasDisplayName {
   ): JSX.Element
 }
 
-let PopoverRoot = forwardRefWithAs(PopoverFn) as unknown as _internal_ComponentPopover
-export let PopoverButton = forwardRefWithAs(ButtonFn) as unknown as _internal_ComponentPopoverButton
-export let PopoverOverlay = forwardRefWithAs(
-  OverlayFn
-) as unknown as _internal_ComponentPopoverOverlay
-export let PopoverPanel = forwardRefWithAs(PanelFn) as unknown as _internal_ComponentPopoverPanel
-export let PopoverGroup = forwardRefWithAs(GroupFn) as unknown as _internal_ComponentPopoverGroup
+let PopoverRoot = forwardRefWithAs(PopoverFn) as _internal_ComponentPopover
+export let PopoverButton = forwardRefWithAs(ButtonFn) as _internal_ComponentPopoverButton
+export let PopoverOverlay = forwardRefWithAs(OverlayFn) as _internal_ComponentPopoverOverlay
+export let PopoverPanel = forwardRefWithAs(PanelFn) as _internal_ComponentPopoverPanel
+export let PopoverGroup = forwardRefWithAs(GroupFn) as _internal_ComponentPopoverGroup
 
 export let Popover = Object.assign(PopoverRoot, {
   Button: PopoverButton,

--- a/packages/@headlessui-react/src/components/portal/portal.tsx
+++ b/packages/@headlessui-react/src/components/portal/portal.tsx
@@ -237,6 +237,6 @@ export interface _internal_ComponentPortalGroup extends HasDisplayName {
 }
 
 let PortalRoot = forwardRefWithAs(PortalFn) as unknown as _internal_ComponentPortal
-export let PortalGroup = forwardRefWithAs(GroupFn) as unknown as _internal_ComponentPortalGroup
+export let PortalGroup = forwardRefWithAs(GroupFn) as _internal_ComponentPortalGroup
 
 export let Portal = Object.assign(PortalRoot, { Group: PortalGroup })

--- a/packages/@headlessui-react/src/components/radio-group/radio-group.tsx
+++ b/packages/@headlessui-react/src/components/radio-group/radio-group.tsx
@@ -182,7 +182,7 @@ function RadioGroupFn<TTag extends ElementType = typeof DEFAULT_RADIO_GROUP_TAG,
 
   let compare = useByComparator(by)
   let [state, dispatch] = useReducer(stateReducer, { options: [] } as StateDefinition<TType>)
-  let options = state.options as unknown as Option<TType>[]
+  let options = state.options as Option<TType>[]
   let [labelledby, LabelProvider] = useLabels()
   let [describedby, DescriptionProvider] = useDescriptions()
   let internalRadioGroupRef = useRef<HTMLElement | null>(null)
@@ -586,11 +586,9 @@ export interface _internal_ComponentRadio extends HasDisplayName {
 export interface _internal_ComponentRadioLabel extends _internal_ComponentLabel {}
 export interface _internal_ComponentRadioDescription extends _internal_ComponentDescription {}
 
-let RadioGroupRoot = forwardRefWithAs(RadioGroupFn) as unknown as _internal_ComponentRadioGroup
-export let RadioGroupOption = forwardRefWithAs(
-  OptionFn
-) as unknown as _internal_ComponentRadioOption
-export let Radio = forwardRefWithAs(RadioFn) as unknown as _internal_ComponentRadio
+let RadioGroupRoot = forwardRefWithAs(RadioGroupFn) as _internal_ComponentRadioGroup
+export let RadioGroupOption = forwardRefWithAs(OptionFn) as _internal_ComponentRadioOption
+export let Radio = forwardRefWithAs(RadioFn) as _internal_ComponentRadio
 /** @deprecated use `<Label>` instead of `<RadioGroupLabel>` */
 export let RadioGroupLabel = Label as _internal_ComponentRadioLabel
 /** @deprecated use `<Description>` instead of `<RadioGroupDescription>` */

--- a/packages/@headlessui-react/src/components/select/select.tsx
+++ b/packages/@headlessui-react/src/components/select/select.tsx
@@ -104,4 +104,4 @@ export interface _internal_ComponentSelect extends HasDisplayName {
   ): JSX.Element
 }
 
-export let Select = forwardRefWithAs(SelectFn) as unknown as _internal_ComponentSelect
+export let Select = forwardRefWithAs(SelectFn) as _internal_ComponentSelect

--- a/packages/@headlessui-react/src/components/switch/switch.tsx
+++ b/packages/@headlessui-react/src/components/switch/switch.tsx
@@ -267,8 +267,8 @@ export interface _internal_ComponentSwitchGroup extends HasDisplayName {
 export interface _internal_ComponentSwitchLabel extends _internal_ComponentLabel {}
 export interface _internal_ComponentSwitchDescription extends _internal_ComponentDescription {}
 
-let SwitchRoot = forwardRefWithAs(SwitchFn) as unknown as _internal_ComponentSwitch
-export let SwitchGroup = GroupFn as unknown as _internal_ComponentSwitchGroup
+let SwitchRoot = forwardRefWithAs(SwitchFn) as _internal_ComponentSwitch
+export let SwitchGroup = GroupFn as _internal_ComponentSwitchGroup
 /** @deprecated use `<Label>` instead of `<SwitchLabel>` */
 export let SwitchLabel = Label as _internal_ComponentSwitchLabel
 /** @deprecated use `<Description>` instead of `<SwitchDescription>` */

--- a/packages/@headlessui-react/src/components/tabs/tabs.tsx
+++ b/packages/@headlessui-react/src/components/tabs/tabs.tsx
@@ -696,11 +696,11 @@ export interface _internal_ComponentTabPanel extends HasDisplayName {
   ): JSX.Element
 }
 
-let TabRoot = forwardRefWithAs(TabFn) as unknown as _internal_ComponentTab
-export let TabGroup = forwardRefWithAs(GroupFn) as unknown as _internal_ComponentTabGroup
-export let TabList = forwardRefWithAs(ListFn) as unknown as _internal_ComponentTabList
-export let TabPanels = forwardRefWithAs(PanelsFn) as unknown as _internal_ComponentTabPanels
-export let TabPanel = forwardRefWithAs(PanelFn) as unknown as _internal_ComponentTabPanel
+let TabRoot = forwardRefWithAs(TabFn) as _internal_ComponentTab
+export let TabGroup = forwardRefWithAs(GroupFn) as _internal_ComponentTabGroup
+export let TabList = forwardRefWithAs(ListFn) as _internal_ComponentTabList
+export let TabPanels = forwardRefWithAs(PanelsFn) as _internal_ComponentTabPanels
+export let TabPanel = forwardRefWithAs(PanelFn) as _internal_ComponentTabPanel
 
 export let Tab = Object.assign(TabRoot, {
   Group: TabGroup,

--- a/packages/@headlessui-react/src/components/textarea/textarea.tsx
+++ b/packages/@headlessui-react/src/components/textarea/textarea.tsx
@@ -93,4 +93,4 @@ export interface _internal_ComponentTextarea extends HasDisplayName {
   ): JSX.Element
 }
 
-export let Textarea = forwardRefWithAs(TextareaFn) as unknown as _internal_ComponentTextarea
+export let Textarea = forwardRefWithAs(TextareaFn) as _internal_ComponentTextarea

--- a/packages/@headlessui-react/src/components/tooltip/tooltip.tsx
+++ b/packages/@headlessui-react/src/components/tooltip/tooltip.tsx
@@ -494,6 +494,6 @@ export interface _internal_ComponentPanel extends HasDisplayName {
   ): JSX.Element
 }
 
-export let Tooltip = forwardRefWithAs(TooltipFn) as unknown as _internal_ComponentTooltip
-export let TooltipTrigger = forwardRefWithAs(TriggerFn) as unknown as _internal_ComponentTrigger
-export let TooltipPanel = forwardRefWithAs(PanelFn) as unknown as _internal_ComponentPanel
+export let Tooltip = forwardRefWithAs(TooltipFn) as _internal_ComponentTooltip
+export let TooltipTrigger = forwardRefWithAs(TriggerFn) as _internal_ComponentTrigger
+export let TooltipPanel = forwardRefWithAs(PanelFn) as _internal_ComponentPanel

--- a/packages/@headlessui-react/src/components/transition/transition.test.tsx
+++ b/packages/@headlessui-react/src/components/transition/transition.test.tsx
@@ -7,7 +7,7 @@ import { createSnapshot } from '../../test-utils/snapshot'
 import { suppressConsoleLogs } from '../../test-utils/suppress-console-logs'
 import { Transition } from './transition'
 
-let act = _act as unknown as <T>(fn: () => T) => PromiseLike<T>
+let act = _act as <T>(fn: () => T) => PromiseLike<T>
 
 function nextFrame() {
   return new Promise<void>((resolve) => {

--- a/packages/@headlessui-react/src/components/transition/transition.tsx
+++ b/packages/@headlessui-react/src/components/transition/transition.tsx
@@ -618,15 +618,11 @@ export interface _internal_ComponentTransitionChild extends HasDisplayName {
   ): JSX.Element
 }
 
-let TransitionRoot = forwardRefWithAs(
-  TransitionRootFn
-) as unknown as _internal_ComponentTransitionRoot
+let TransitionRoot = forwardRefWithAs(TransitionRootFn) as _internal_ComponentTransitionRoot
 let InternalTransitionChild = forwardRefWithAs(
   TransitionChildFn
-) as unknown as _internal_ComponentTransitionChild
-export let TransitionChild = forwardRefWithAs(
-  ChildFn
-) as unknown as _internal_ComponentTransitionChild
+) as _internal_ComponentTransitionChild
+export let TransitionChild = forwardRefWithAs(ChildFn) as _internal_ComponentTransitionChild
 
 export let Transition = Object.assign(TransitionRoot, {
   Child: TransitionChild,

--- a/packages/@headlessui-react/src/hooks/use-by-comparator.ts
+++ b/packages/@headlessui-react/src/hooks/use-by-comparator.ts
@@ -23,7 +23,7 @@ export function useByComparator<T>(by: ByComparator<T> = defaultBy) {
   return useCallback(
     (a: T, z: T) => {
       if (typeof by === 'string') {
-        let property = by as unknown as keyof T
+        let property = by as keyof T
         return a?.[property] === z?.[property]
       }
 

--- a/packages/@headlessui-react/src/hooks/use-watch.ts
+++ b/packages/@headlessui-react/src/hooks/use-watch.ts
@@ -5,11 +5,11 @@ export function useWatch<T extends any[]>(
   cb: (newValues: [...T], oldValues: [...T]) => void | (() => void),
   dependencies: [...T]
 ) {
-  let track = useRef<typeof dependencies>([] as unknown as [...T])
+  let track = useRef([] as unknown as typeof dependencies)
   let action = useEvent(cb)
 
   useEffect(() => {
-    let oldValues = [...track.current] as unknown as [...T]
+    let oldValues = [...track.current] as [...T]
 
     for (let [idx, value] of dependencies.entries()) {
       if (track.current[idx] !== value) {

--- a/packages/@headlessui-react/src/internal/hidden.tsx
+++ b/packages/@headlessui-react/src/internal/hidden.tsx
@@ -70,4 +70,4 @@ interface ComponentHidden extends HasDisplayName {
   ): JSX.Element
 }
 
-export let Hidden = forwardRefWithAs(VisuallyHidden) as unknown as ComponentHidden
+export let Hidden = forwardRefWithAs(VisuallyHidden) as ComponentHidden

--- a/packages/@headlessui-react/src/internal/modal.tsx
+++ b/packages/@headlessui-react/src/internal/modal.tsx
@@ -213,6 +213,6 @@ export interface _internal_ComponentModal extends HasDisplayName {
   ): JSX.Element
 }
 
-let ModalRoot = forwardRefWithAs(ModalFn) as unknown as _internal_ComponentModal
+let ModalRoot = forwardRefWithAs(ModalFn) as _internal_ComponentModal
 
 export let Modal = Object.assign(ModalRoot, {})

--- a/packages/@headlessui-react/src/utils/focus-management.ts
+++ b/packages/@headlessui-react/src/utils/focus-management.ts
@@ -198,7 +198,7 @@ function isSelectableElement(
 
 export function sortByDomNode<T>(
   nodes: T[],
-  resolveKey: (item: T) => HTMLElement | null = (i) => i as unknown as HTMLElement | null
+  resolveKey: (item: T) => HTMLElement | null = (i) => i as HTMLElement | null
 ): T[] {
   return nodes.slice().sort((aItem, zItem) => {
     let a = resolveKey(aItem)

--- a/packages/@headlessui-react/src/utils/render.ts
+++ b/packages/@headlessui-react/src/utils/render.ts
@@ -427,7 +427,7 @@ export function mergeProps<T extends Props<any, any>[]>(...listOfProps: T) {
 export function forwardRefWithAs<T extends { name: string; displayName?: string }>(
   component: T
 ): T & { displayName: string } {
-  return Object.assign(forwardRef(component as unknown as any) as any, {
+  return Object.assign(forwardRef(component as any) as any, {
     displayName: component.displayName ?? component.name,
   })
 }


### PR DESCRIPTION
This PR cleans up internal `as unknown` usages in the codebase that are not necessary anymore.

