### PR TITLE
Ensure import actions use the correct paths

### DIFF
--- a/packages/@headlessui-react/tsconfig.json
+++ b/packages/@headlessui-react/tsconfig.json
@@ -6,7 +6,6 @@
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,
-    "rootDir": "./src",
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
@@ -14,11 +13,6 @@
     "noFallthroughCasesInSwitch": true,
     "downlevelIteration": true,
     "moduleResolution": "node",
-    "baseUrl": "./",
-    "paths": {
-      "@headlessui/react": ["src"],
-      "*": ["src/*", "node_modules/*"]
-    },
     "jsx": "react",
     "esModuleInterop": true,
     "target": "ESNext",

--- a/packages/@headlessui-vue/tsconfig.json
+++ b/packages/@headlessui-vue/tsconfig.json
@@ -6,7 +6,6 @@
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,
-    "rootDir": "./src",
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
@@ -14,11 +13,6 @@
     "noFallthroughCasesInSwitch": true,
     "downlevelIteration": true,
     "moduleResolution": "node",
-    "baseUrl": "./",
-    "paths": {
-      "@headlessui/vue": ["src"],
-      "*": ["src/*", "node_modules/*"]
-    },
     "esModuleInterop": true,
     "target": "ESNext",
     "allowJs": true,


### PR DESCRIPTION
This PR is a fix for internal usage while developing Headless UI itself. Until this PR, code actions in your editor for importing paths typically imported the wrong path.

It used absolute paths instead of relative paths. This did fail when building.
```diff
- import foo from 'utils/foo';
+ import foo from '../utils/foo';
```

This should now be fixed.
