### PR TITLE
Render hidden form input fields for `Checkbox`, `Switch` and `RadioGroup` components

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix cursor position when re-focusing the `ComboboxInput` component ([#3065](https://github.com/tailwindlabs/headlessui/pull/3065))
 - Keep focus inside of the `<ComboboxInput />` component ([#3073](https://github.com/tailwindlabs/headlessui/pull/3073))
 - Fix enter transitions for the `Transition` component ([#3074](https://github.com/tailwindlabs/headlessui/pull/3074))
+- Render hidden form input fields for `Checkbox`, `Switch` and `RadioGroup` components ([#3095](https://github.com/tailwindlabs/headlessui/pull/3095))
 
 ### Changed
 

--- a/packages/@headlessui-react/src/components/checkbox/checkbox.test.tsx
+++ b/packages/@headlessui-react/src/components/checkbox/checkbox.test.tsx
@@ -135,8 +135,10 @@ describe('Form submissions', () => {
       </form>
     )
 
+    let checkbox = document.querySelector('[id^="headlessui-checkbox-"]') as HTMLInputElement
+
     // Focus the checkbox
-    await focus(getCheckbox())
+    await focus(checkbox)
 
     // Submit
     await press(Keys.Enter)
@@ -145,7 +147,7 @@ describe('Form submissions', () => {
     expect(handleSubmission).toHaveBeenLastCalledWith({})
 
     // Toggle
-    await click(getCheckbox())
+    await click(checkbox)
 
     // Submit
     await press(Keys.Enter)
@@ -154,7 +156,7 @@ describe('Form submissions', () => {
     expect(handleSubmission).toHaveBeenLastCalledWith({ notifications: 'on' })
 
     // Toggle
-    await click(getCheckbox())
+    await click(checkbox)
 
     // Submit
     await press(Keys.Enter)

--- a/packages/@headlessui-react/src/components/checkbox/checkbox.tsx
+++ b/packages/@headlessui-react/src/components/checkbox/checkbox.tsx
@@ -174,7 +174,8 @@ function CheckboxFn<TTag extends ElementType = typeof DEFAULT_CHECKBOX_TAG, TTyp
       {name != null && (
         <FormFields
           disabled={disabled}
-          data={checked ? { [name]: value || 'on' } : {}}
+          data={{ [name]: value || 'on' }}
+          overrides={{ type: 'checkbox', checked }}
           form={form}
           onReset={reset}
         />

--- a/packages/@headlessui-react/src/components/radio-group/radio-group.tsx
+++ b/packages/@headlessui-react/src/components/radio-group/radio-group.tsx
@@ -315,7 +315,8 @@ function RadioGroupFn<TTag extends ElementType = typeof DEFAULT_RADIO_GROUP_TAG,
             {name != null && (
               <FormFields
                 disabled={disabled}
-                data={value != null ? { [name]: value || 'on' } : {}}
+                data={{ [name]: value || 'on' }}
+                overrides={{ type: 'radio', checked: value != null }}
                 form={form}
                 onReset={reset}
               />

--- a/packages/@headlessui-react/src/components/switch/switch.tsx
+++ b/packages/@headlessui-react/src/components/switch/switch.tsx
@@ -240,7 +240,8 @@ function SwitchFn<TTag extends ElementType = typeof DEFAULT_SWITCH_TAG>(
       {name != null && (
         <FormFields
           disabled={disabled}
-          data={checked ? { [name]: value || 'on' } : {}}
+          data={{ [name]: value || 'on' }}
+          overrides={{ type: 'checkbox', checked }}
           form={form}
           onReset={reset}
         />

--- a/packages/@headlessui-react/src/internal/form-fields.tsx
+++ b/packages/@headlessui-react/src/internal/form-fields.tsx
@@ -33,8 +33,10 @@ export function FormFields({
   form: formId,
   disabled,
   onReset,
+  overrides,
 }: {
   data: Record<string, any>
+  overrides?: Record<string, any>
   form?: string
   disabled?: boolean
   onReset?: (e: Event) => void
@@ -66,6 +68,7 @@ export function FormFields({
               disabled,
               name,
               value,
+              ...overrides,
             })}
           />
         )


### PR DESCRIPTION
This PR ensures that we always render the hidden form input elements for the `Checkbox`, `Switch` and `RadioGroup` components.

The reason why we didn't render them was because they weren't included in the `FormData` anyway as long as they are not "checked". However, this makes it harder if you want to get access to the elements if you use some form library that uses the inputs in the form. Additionally, this also means that we were adding and removing elements from the DOM.

Now with this change, they will always be there and the `checked` attribute will be updated behind the scenes instead. Now, the hidden inputs will always be available in the form data.

Note: if you don't pass the `name` prop, the hidden form inputs won't be rendered (same behavior as before).

Fixes: #2977
