### PR TITLE
Ensure the `multiple` prop is typed correctly when passing explicit types to the `Combobox` component

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keep focus inside of the `<ComboboxInput />` component ([#3073](https://github.com/tailwindlabs/headlessui/pull/3073))
 - Fix enter transitions for the `Transition` component ([#3074](https://github.com/tailwindlabs/headlessui/pull/3074))
 - Render hidden form input fields for `Checkbox`, `Switch` and `RadioGroup` components ([#3095](https://github.com/tailwindlabs/headlessui/pull/3095))
+- Ensure the `multiple` prop is typed correctly when passing explicit types to the `Combobox` component ([#3099](https://github.com/tailwindlabs/headlessui/pull/3099))
 
 ### Changed
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1830,11 +1830,12 @@ function OptionFn<
 // ---
 
 export interface _internal_ComponentCombobox extends HasDisplayName {
-  <TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG>(
-    props: ComboboxProps<TValue, true, TTag> & RefProp<typeof ComboboxFn>
-  ): JSX.Element
-  <TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG>(
-    props: ComboboxProps<TValue, false, TTag> & RefProp<typeof ComboboxFn>
+  <
+    TValue,
+    TMultiple extends boolean | undefined = false,
+    TTag extends ElementType = typeof DEFAULT_COMBOBOX_TAG,
+  >(
+    props: ComboboxProps<TValue, TMultiple, TTag> & RefProp<typeof ComboboxFn>
   ): JSX.Element
 }
 


### PR DESCRIPTION
This PR fixes an issue where defining the types of the `Combobox` component explicitly made the type of the `multiple` prop incorrect (it defaulted to `true`).

E.g.:


```ts
<Combobox<{ id: number, name: string }> />
```

This eventually became the following type:
```ts
{ id: number, name: string }[]
```

... which is incorrect.
