### PR TITLE
Ensure anchored components are always rendered in a stacking context

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Omit `nullable` prop from `Combobox` component ([#3100](https://github.com/tailwindlabs/headlessui/pull/3100))
 - Ensure anchored components are properly stacked on top of `Dialog` components ([#3111](https://github.com/tailwindlabs/headlessui/pull/3111))
 - Move focus to `ListboxOptions` and `MenuItems` when they are rendered later ([#3112](https://github.com/tailwindlabs/headlessui/pull/3112))
+- Ensure anchored components are always rendered in a stacking context ([#3115](https://github.com/tailwindlabs/headlessui/pull/3115))
 
 ### Changed
 

--- a/packages/@headlessui-react/src/internal/floating.tsx
+++ b/packages/@headlessui-react/src/internal/floating.tsx
@@ -139,8 +139,8 @@ export function useFloatingPanel(
   let context = useContext(FloatingContext)
 
   return useMemo(
-    () => [context.setFloating, context.styles] as const,
-    [context.setFloating, context.styles]
+    () => [context.setFloating, placement ? context.styles : {}] as const,
+    [context.setFloating, placement, context.styles]
   )
 }
 
@@ -343,7 +343,7 @@ export function FloatingProvider({
         value={{
           setFloating: setFloatingRef,
           setReference: refs.setReference,
-          styles: !isEnabled ? {} : floatingStyles,
+          styles: floatingStyles,
           getReferenceProps,
           getFloatingProps,
           slot: data,


### PR DESCRIPTION
This PR ensures that components with the `anchor` prop always use the `floatingStyles` from Floating UI (which contains `position: absolute`).

This is important, otherwise there is a brief moment where the `<ListboxOptions anchor={…} />` (in case of a `Listbox`) is rendered at the end of the page.

One side effect of this is that this could cause a scrollbar to appear for a moment. But the `anchor` prop also renders the component in a `Modal` which does scroll locking (by applying `overflow: hidden;` to the body).

A side effect of adding `overflow: hidden` is that the scrollbar is removed. This is nice, but this causes a visual jump when the scrollbar is removed. To counteract this, we also add a `padding-right` based on the width of the scrollbar to the body to prevent the visual jump.

But because of the brief moment where the scrollbar is visible, we also add a `padding-right` to the body to prevent the visual jump actually which now causes a visual glitch now. Head scratcher...

Long story short, no more accidental scrollbar appearing for a brief moment.
