### PR TITLE
Add gitattributes to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# git
+.gitattributes

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -823,7 +823,7 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
       'aria-controls': data.optionsRef.current?.id,
       'aria-expanded': data.listboxState === ListboxStates.Open,
       'aria-labelledby': labelledBy,
-      'aria-describedby': describedBy,
+      'aria-describedby': describedBy ?? theirProps['aria-describedby'],
       disabled: disabled || undefined,
       autoFocus,
       onKeyDown: handleKeyDown,


### PR DESCRIPTION
It's good change for developers in case of handling EOF git tracking and for implement more advanced local git strategies.
Discussion: https://github.com/tailwindlabs/headlessui/discussions/3117.