### PR TITLE
Use user aria-describedby attr in case of our undefined

### DIFF
--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -823,7 +823,7 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
       'aria-controls': data.optionsRef.current?.id,
       'aria-expanded': data.listboxState === ListboxStates.Open,
       'aria-labelledby': labelledBy,
-      'aria-describedby': describedBy,
+      'aria-describedby': describedBy ?? theirProps['aria-describedby'],
       disabled: disabled || undefined,
       autoFocus,
       onKeyDown: handleKeyDown,


### PR DESCRIPTION
If a user manually adds the aria-describedby attribute to the ListBox component, it is not displayed in the DOM button element.

This issue was reported here: https://github.com/tailwindlabs/headlessui/issues/3114.

Problem: The aria-describedby property of ourProps object overwrites the property of theirProps object, even if our value is undefined.

Solution: If our value is undefined, use the user's value.