### PR TITLE
Remove the `anchor.strategy` option

### DIFF
--- a/packages/@headlessui-react/src/internal/floating.tsx
+++ b/packages/@headlessui-react/src/internal/floating.tsx
@@ -22,11 +22,6 @@ type Placement = 'top' | 'right' | 'bottom' | 'left'
 
 type BaseAnchorProps = {
   /**
-   * The strategy to use when positioning the panel. Defaults to `absolute`.
-   */
-  strategy: 'absolute' | 'fixed'
-
-  /**
    * The `gap` is the space between the trigger and the panel.
    */
   gap: number | string // For `var()` support
@@ -171,7 +166,6 @@ export function FloatingProvider({
     offset = 0,
     padding = 0,
     inner,
-    strategy = 'absolute',
   } = useResolvedConfig(config, floatingEl)
   let [to, align = 'center'] = placement.split(' ') as [Placement | 'selection', Align | 'center']
 
@@ -195,7 +189,7 @@ export function FloatingProvider({
 
     // This component will be used in combination with a `Portal`, which means the floating
     // element will be rendered outside of the current DOM tree.
-    strategy,
+    strategy: 'absolute',
 
     // We use the panel in a `Dialog` which is making the page inert, therefore no re-positioning is
     // needed when scrolling changes.


### PR DESCRIPTION
This PR removes the `anchor.strategy` option because we use the default strategy of `absolute`.

All places where we use the `anchor` prop, we also portal the element at the end of the page, therefore we don't need a `fixed` strategy because there is no relative parent to worry about.
