### PR TITLE
Add optional `onClose` callback to `Combobox` component

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -588,6 +588,8 @@ export type ComboboxProps<
       disabled?: (value: NoInfer<TValue>) => boolean
     } | null
 
+    onClose?(): void
+
     __demoMode?: boolean
   }
 >
@@ -605,6 +607,7 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
     name,
     by,
     disabled = providedDisabled || false,
+    onClose,
     __demoMode = false,
     multiple = false,
     immediate = false,
@@ -771,6 +774,7 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
   let closeCombobox = useEvent(() => {
     dispatch({ type: ActionTypes.CloseCombobox })
     defaultToFirstOption.current = false
+    onClose?.()
   })
 
   let goToOption = useEvent((focus, idx, trigger) => {


### PR DESCRIPTION
This PR adds a new optional `onClose` prop to the `Combobox` component and it will be called when the `Combobox` closes.

Right now, we don't provide any information about _why_ the `Combobox` closes, but that could be a future improvement.

