### PR TITLE
Add frozen value to `ComboboxOptions` component

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add new `CloseButton` component and `useClose` hook ([#3096](https://github.com/tailwindlabs/headlessui/pull/3096))
 - Allow passing a boolean to the `anchor` prop ([#3121](https://github.com/tailwindlabs/headlessui/pull/3121))
 - Add `portal` prop to `Combobox`, `Listbox`, `Menu` and `Popover` components ([#3124](https://github.com/tailwindlabs/headlessui/pull/3124))
-- Add frozen value to `ComboboxOption` component ([#3126](https://github.com/tailwindlabs/headlessui/pull/3126))
+- Add frozen value to `ComboboxOptions` component ([#3126](https://github.com/tailwindlabs/headlessui/pull/3126))
 
 ## [1.7.19] - 2024-04-15
 

--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add new `CloseButton` component and `useClose` hook ([#3096](https://github.com/tailwindlabs/headlessui/pull/3096))
 - Allow passing a boolean to the `anchor` prop ([#3121](https://github.com/tailwindlabs/headlessui/pull/3121))
 - Add `portal` prop to `Combobox`, `Listbox`, `Menu` and `Popover` components ([#3124](https://github.com/tailwindlabs/headlessui/pull/3124))
+- Add frozen value to `ComboboxOption` component ([#3126](https://github.com/tailwindlabs/headlessui/pull/3126))
 
 ## [1.7.19] - 2024-04-15
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -4289,7 +4289,6 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             // Verify that we don't have an selected option anymore
             assertNotActiveComboboxOption(options[1])
-            assertNoSelectedComboboxOption()
 
             // Verify that we saw the `null` change coming in
             expect(handleChange).toHaveBeenCalledTimes(1)

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1646,17 +1646,35 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
     })
   }
 
+  // Frozen state, the selected value will only update visually when the user re-opens the <Combobox />
+  let [frozenValue, setFrozenValue] = useState(data.value)
+  if (
+    data.value !== frozenValue &&
+    data.comboboxState === ComboboxState.Open &&
+    data.mode !== ValueMode.Multi
+  ) {
+    setFrozenValue(data.value)
+  }
+
+  let isSelected = useEvent((compareValue: unknown) => {
+    return data.compare(frozenValue, compareValue)
+  })
+
   return (
     <Portal enabled={visible && portal}>
-      {render({
-        ourProps,
-        theirProps,
-        slot,
-        defaultTag: DEFAULT_OPTIONS_TAG,
-        features: OptionsRenderFeatures,
-        visible,
-        name: 'Combobox.Options',
-      })}
+      <ComboboxDataContext.Provider
+        value={data.mode === ValueMode.Multi ? data : { ...data, isSelected }}
+      >
+        {render({
+          ourProps,
+          theirProps,
+          slot,
+          defaultTag: DEFAULT_OPTIONS_TAG,
+          features: OptionsRenderFeatures,
+          visible,
+          name: 'Combobox.Options',
+        })}
+      </ComboboxDataContext.Provider>
     </Portal>
   )
 }
@@ -1796,7 +1814,7 @@ function OptionFn<
     }
 
     if (data.mode === ValueMode.Single) {
-      requestAnimationFrame(() => actions.closeCombobox())
+      actions.closeCombobox()
     }
   })
 


### PR DESCRIPTION
This PR introduces a frozen value, similar to the `Listbox` component. This allows us to keep the visual state of the "old" value when selecting a new value.

The reason for this is that when you select a value, the combobox will close and in a lot of cases a (fade out) transition is happening. If we change the selected state to the new value, then the UI will flicker (or at least changes visual state) when the transition is happening. This PR prevents that. This is also how the native `<select>` works. 

Note: the `Combobox` and `ComboboxInput` still know about the correct newly selected value and will update `aria-activedescendant` information correctly.

Also note that this only happens in "single value mode", if you use the `multiple` prop, then the selected value will be updated immediately.
