### PR TITLE
Make sure data-disabled is available on virtualized options

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move focus to `ListboxOptions` and `MenuItems` when they are rendered later ([#3112](https://github.com/tailwindlabs/headlessui/pull/3112))
 - Ensure anchored components are always rendered in a stacking context ([#3115](https://github.com/tailwindlabs/headlessui/pull/3115))
 - Add optional `onClose` callback to `Combobox` component ([#3122](https://github.com/tailwindlabs/headlessui/pull/3122))
+- Make sure `data-disabled` is available on virtualized options in the `Combobox` component ([#3128](https://github.com/tailwindlabs/headlessui/pull/3128))
 
 ### Changed
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1315,7 +1315,7 @@ function InputFn<
           : data.virtual
             ? data.options.find(
                 (option) =>
-                  !data.virtual?.disabled(option.dataRef.current.value) &&
+                  !option.dataRef.current.disabled &&
                   data.compare(
                     option.dataRef.current.value,
                     data.virtual!.options[data.activeOptionIndex!]
@@ -1666,17 +1666,17 @@ function OptionFn<
   // But today is not that day..
   TType = Parameters<typeof ComboboxRoot>[0]['value'],
 >(props: ComboboxOptionProps<TTag, TType>, ref: Ref<HTMLLIElement>) {
+  let data = useData('Combobox.Option')
+  let actions = useActions('Combobox.Option')
+
   let internalId = useId()
   let {
     id = `headlessui-combobox-option-${internalId}`,
-    disabled = false,
     value,
+    disabled = data.virtual?.disabled(value) ?? false,
     order = null,
     ...theirProps
   } = props
-
-  let data = useData('Combobox.Option')
-  let actions = useActions('Combobox.Option')
 
   let refocusInput = useRefocusableInput(data.inputRef)
 
@@ -1749,7 +1749,7 @@ function OptionFn<
       return
     }
 
-    if (disabled || data.virtual?.disabled(value)) return
+    if (disabled) return
     select()
 
     // We want to make sure that we don't accidentally trigger the virtual keyboard.
@@ -1774,7 +1774,7 @@ function OptionFn<
   })
 
   let handleFocus = useEvent(() => {
-    if (disabled || data.virtual?.disabled(value)) {
+    if (disabled) {
       return actions.goToOption(Focus.Nothing)
     }
     let idx = data.calculateIndex(value)
@@ -1787,7 +1787,7 @@ function OptionFn<
 
   let handleMove = useEvent((evt) => {
     if (!pointer.wasMoved(evt)) return
-    if (disabled || data.virtual?.disabled(value)) return
+    if (disabled) return
     if (active) return
     let idx = data.calculateIndex(value)
     actions.goToOption(Focus.Specific, idx, ActivationTrigger.Pointer)
@@ -1795,22 +1795,20 @@ function OptionFn<
 
   let handleLeave = useEvent((evt) => {
     if (!pointer.wasMoved(evt)) return
-    if (disabled || data.virtual?.disabled(value)) return
+    if (disabled) return
     if (!active) return
     if (data.optionsPropsRef.current.hold) return
     actions.goToOption(Focus.Nothing)
   })
 
-  let slot = useMemo(
-    () =>
-      ({
-        active,
-        focus: active,
-        selected,
-        disabled: Boolean(disabled || data.virtual?.disabled(value)),
-      }) satisfies OptionRenderPropArg,
-    [active, selected, disabled]
-  )
+  let slot = useMemo(() => {
+    return {
+      active,
+      focus: active,
+      selected,
+      disabled,
+    } satisfies OptionRenderPropArg
+  }, [active, selected, disabled])
 
   let ourProps = {
     id,

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1802,7 +1802,13 @@ function OptionFn<
   })
 
   let slot = useMemo(
-    () => ({ active, focus: active, selected, disabled }) satisfies OptionRenderPropArg,
+    () =>
+      ({
+        active,
+        focus: active,
+        selected,
+        disabled: Boolean(disabled || data.virtual?.disabled(value)),
+      }) satisfies OptionRenderPropArg,
     [active, selected, disabled]
   )
 


### PR DESCRIPTION
When using a combobox disabled options get a `data-disabled` attribute that can be used for styling. However, when the combobox was virtualized we were not. This happened because we were only looking at the disabled prop on the option itself but a virtual combobox uses a disabled function in the `virtual` options to determine whether or not an option is enabled.

This fixes that 👍 

@RobinMalfait you have an idea on how this should be tested?