### PR TITLE
Update minimal peer dependency version requirements for `react` and `react-dom`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10366,8 +10366,8 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "react": "^16 || ^17 || ^18",
-        "react-dom": "^16 || ^17 || ^18"
+        "react": "^18",
+        "react-dom": "^18"
       }
     },
     "packages/@headlessui-react/node_modules/@floating-ui/react": {

--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `absolute` as the default Floating UI strategy ([#3097](https://github.com/tailwindlabs/headlessui/pull/3097))
 - Change default tags for `ListboxOptions`, `ListboxOption`, `ComboboxOptions`, `ComboboxOption` and `TabGroup` components ([#3109](https://github.com/tailwindlabs/headlessui/pull/3109))
 - Change default tag from `div` to `Fragment` on `Transition` components ([#3110](https://github.com/tailwindlabs/headlessui/pull/3110))
+- Update minimal peer dependency version requirements for `react` and `react-dom` ([#3131](https://github.com/tailwindlabs/headlessui/pull/3131))
 
 ### Added
 

--- a/packages/@headlessui-react/package.json
+++ b/packages/@headlessui-react/package.json
@@ -42,8 +42,8 @@
     "clean": "rimraf ./dist"
   },
   "peerDependencies": {
-    "react": "^16 || ^17 || ^18",
-    "react-dom": "^16 || ^17 || ^18"
+    "react": "^18",
+    "react-dom": "^18"
   },
   "devDependencies": {
     "@testing-library/react": "^13.0.0",


### PR DESCRIPTION
This PR updates the minimal version requirements for `react` and `react-dom` dependencies to React 18 because we are using some React 18 only features in Headless UI v2.
