### PR TITLE
Add `overflow: auto` when using the `anchor` prop

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure anchored components are always rendered in a stacking context ([#3115](https://github.com/tailwindlabs/headlessui/pull/3115))
 - Add optional `onClose` callback to `Combobox` component ([#3122](https://github.com/tailwindlabs/headlessui/pull/3122))
 - Make sure `data-disabled` is available on virtualized options in the `Combobox` component ([#3128](https://github.com/tailwindlabs/headlessui/pull/3128))
+- Add `overflow: auto` when using the `anchor` prop ([#3138](https://github.com/tailwindlabs/headlessui/pull/3138))
 
 ### Changed
 

--- a/packages/@headlessui-react/src/internal/floating.tsx
+++ b/packages/@headlessui-react/src/internal/floating.tsx
@@ -314,6 +314,7 @@ export function FloatingProvider({
       sizeMiddleware({
         apply({ availableWidth, availableHeight, elements }) {
           Object.assign(elements.floating.style, {
+            overflow: 'auto',
             maxWidth: `${availableWidth - padding}px`,
             maxHeight: `${availableHeight - padding}px`,
           })


### PR DESCRIPTION
We want to constrain the anchored element within the viewport (minus the padding if there is some). But without an `overflow: auto`, it would overflow and the `maxWidth` / `maxHeight` are a bit pointless.

Once you opt-in to `anchor`, then we have to provide styles anyway. This improves the UX.
