### PR TITLE
Ensure `TransitionRoot` component without props transitions correctly

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add optional `onClose` callback to `Combobox` component ([#3122](https://github.com/tailwindlabs/headlessui/pull/3122))
 - Make sure `data-disabled` is available on virtualized options in the `Combobox` component ([#3128](https://github.com/tailwindlabs/headlessui/pull/3128))
 - Add `overflow: auto` when using the `anchor` prop ([#3138](https://github.com/tailwindlabs/headlessui/pull/3138))
+- Ensure `TransitionRoot` component without props transitions correctly ([#3147](https://github.com/tailwindlabs/headlessui/pull/3147))
 
 ### Changed
 

--- a/packages/@headlessui-react/src/components/transition/transition.tsx
+++ b/packages/@headlessui-react/src/components/transition/transition.tsx
@@ -559,6 +559,7 @@ function TransitionRootFn<TTag extends ElementType = typeof DEFAULT_TRANSITION_C
   let [state, setState] = useState(show ? TreeStates.Visible : TreeStates.Hidden)
 
   let nestingBag = useNesting(() => {
+    if (show) return
     setState(TreeStates.Hidden)
   })
 
@@ -590,7 +591,7 @@ function TransitionRootFn<TTag extends ElementType = typeof DEFAULT_TRANSITION_C
   useIsoMorphicEffect(() => {
     if (show) {
       setState(TreeStates.Visible)
-    } else if (!hasChildren(nestingBag)) {
+    } else if (!hasChildren(nestingBag) && internalTransitionRef.current !== null) {
       setState(TreeStates.Hidden)
     }
   }, [show, nestingBag])

--- a/packages/@headlessui-react/src/hooks/use-transition.ts
+++ b/packages/@headlessui-react/src/hooks/use-transition.ts
@@ -35,23 +35,31 @@ export function useTransition({ container, direction, classes, onStart, onStop }
   let inFlight = useRef(false)
 
   useIsoMorphicEffect(() => {
-    let node = container.current
-    if (!node) return // We don't have a DOM node (yet)
     if (direction === 'idle') return // We don't need to transition
     if (!mounted.current) return
 
     onStart.current(direction)
 
-    d.add(
-      transition(node, {
-        direction,
-        classes: classes.current,
-        inFlight,
-        done() {
-          onStop.current(direction)
-        },
-      })
-    )
+    let node = container.current
+    if (!node) {
+      // No node, so let's skip the transition and call the `onStop` callback
+      // immediately because there is no transition to wait for anyway.
+      onStop.current(direction)
+    }
+
+    // We do have a node, let's transition it!
+    else {
+      d.add(
+        transition(node, {
+          direction,
+          classes: classes.current,
+          inFlight,
+          done() {
+            onStop.current(direction)
+          },
+        })
+      )
+    }
 
     return d.dispose
   }, [direction])


### PR DESCRIPTION
We recently made a change that the `Transition` component renders a `Fragment` by default. We also made sure that a `TransitionRoot` component (which could exist for orchestration purposes for child transitions) doesn't render a DOM node when it doesn't need to. This is the case if it doesn't have any `enter`, `enterFrom`, `enterTo`, `leave`, `leaveFrom`, or `leaveTo` props.

However, this caused a bug where the `Transition` component doesn't properly mount or unmount its children when the `TransitionRoot` component doesn't render a DOM node. This is because the `Transition` component relies on DOM transition events and will call the `onStart` and `onStop` callbacks when the transition starts and ends.

To solve this, we make sure to still call the `onStart` and `onStop` callbacks, because you can think of it as the transition was done immediately.
