### PR TITLE
Ensure the `static` and `portal` props work nicely together

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1680,7 +1680,7 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
   })
 
   return (
-    <Portal enabled={visible && portal}>
+    <Portal enabled={portal ? props.static || visible : false}>
       <ComboboxDataContext.Provider
         value={data.mode === ValueMode.Multi ? data : { ...data, isSelected }}
       >

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -1110,7 +1110,7 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
   })
 
   return (
-    <Portal enabled={visible && portal}>
+    <Portal enabled={portal ? props.static || visible : false}>
       <ListboxDataContext.Provider
         value={data.mode === ValueMode.Multi ? data : { ...data, isSelected }}
       >

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -783,7 +783,7 @@ function ItemsFn<TTag extends ElementType = typeof DEFAULT_ITEMS_TAG>(
   })
 
   return (
-    <Portal enabled={visible && portal}>
+    <Portal enabled={portal ? props.static || visible : false}>
       {render({
         ourProps,
         theirProps,

--- a/packages/@headlessui-react/src/components/popover/popover.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.tsx
@@ -1015,7 +1015,7 @@ function PanelFn<TTag extends ElementType = typeof DEFAULT_PANEL_TAG>(
   return (
     <PopoverPanelContext.Provider value={id}>
       <PopoverAPIContext.Provider value={{ close, isPortalled }}>
-        <Portal enabled={visible && portal}>
+        <Portal enabled={portal ? props.static || visible : false}>
           {visible && isPortalled && (
             <Hidden
               id={beforePanelSentinelId}


### PR DESCRIPTION
This PR fixes an issue where the `static` prop and the `portal` prop (or `anchor` prop which enables the `portal` prop by default) didn't work well together. This is because the wrapping `<Portal />` component was not taking the `static` prop into account.

This is needed when you want to use the `portal` and/or `anchor` prop in combination with a 3rd party animation library (such as `framer-motion`) where the `static` prop is needed.

