### PR TITLE
Improve internal `useElementSize` hook by computing the size as soon as possible

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1644,6 +1644,7 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
       option: undefined,
     } satisfies OptionsRenderPropArg
   }, [data])
+
   let ourProps = mergeProps(anchor ? getFloatingPanelProps() : {}, {
     'aria-labelledby': labelledBy,
     role: 'listbox',


### PR DESCRIPTION
This PR improves the `useElementSize` hook by ensuring that the size of an element is calculated as soon as possible.

Instead of waiting for a `useEffect` to trigger, we can use `useMemo` to always compute the size the moment a DOM element is available (or changes).

Once a DOM node is stable, we also setup a `ResizeObserver` to watch for changes. If we detect a resize, we simply force a re-render which also forces the `useMemo` to recompute. This way we can always rely on the `useMemo` to be the single source of truth without managing state ourselves.


