### PR TITLE
Only check for elements in `useInertOthers`

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `overflow: auto` when using the `anchor` prop ([#3138](https://github.com/tailwindlabs/headlessui/pull/3138))
 - Ensure `TransitionRoot` component without props transitions correctly ([#3147](https://github.com/tailwindlabs/headlessui/pull/3147))
 - Ensure the `static` and `portal` props work nicely together ([#3152](https://github.com/tailwindlabs/headlessui/pull/3152))
-- Only check for elements in useInertOthers ([#3154](https://github.com/tailwindlabs/headlessui/pull/3154))
+- Only check for elements in `useInertOthers` ([#3154](https://github.com/tailwindlabs/headlessui/pull/3154))
 
 ### Changed
 

--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `overflow: auto` when using the `anchor` prop ([#3138](https://github.com/tailwindlabs/headlessui/pull/3138))
 - Ensure `TransitionRoot` component without props transitions correctly ([#3147](https://github.com/tailwindlabs/headlessui/pull/3147))
 - Ensure the `static` and `portal` props work nicely together ([#3152](https://github.com/tailwindlabs/headlessui/pull/3152))
+- Only check for elements in useInertOthers ([#3154](https://github.com/tailwindlabs/headlessui/pull/3154))
 
 ### Changed
 

--- a/packages/@headlessui-react/src/hooks/use-inert-others.tsx
+++ b/packages/@headlessui-react/src/hooks/use-inert-others.tsx
@@ -103,7 +103,7 @@ export function useInertOthers(
       let parent = element.parentElement
       while (parent && parent !== ownerDocument.body) {
         // Mark all siblings as inert
-        for (let node of parent.childNodes) {
+        for (let node of parent.children) {
           // If the node contains any of the elements we should not mark it as inert
           // because it would make the elements unreachable.
           if (allowedElements.some((el) => node.contains(el))) continue


### PR DESCRIPTION
If you had a bare text node anywhere in the parent tree of an "allowed element" passed to useInertOthers() we would error because `getAtribute()` only exists on elements.

Basically code like this fails after interacting with the menu:

```jsx
test
<Menu>…</Menu>
```