### PR TITLE
Only render virtual options wrapper when there are items to show

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Only check for elements in `useInertOthers` ([#3154](https://github.com/tailwindlabs/headlessui/pull/3154))
 - Fix anchored elements not flipping when there is padding ([#3157](https://github.com/tailwindlabs/headlessui/pull/3157))
 - Render virtual items during an exiting transition ([#3160](https://github.com/tailwindlabs/headlessui/pull/3160))
+- Only render virtual options wrapper when there are items to show ([#3161](https://github.com/tailwindlabs/headlessui/pull/3161))
 
 ### Changed
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -449,6 +449,12 @@ function VirtualProvider(props: {
     setBaseKey((v) => v + 1)
   }, [data.virtual?.options])
 
+  let items = virtualizer.getVirtualItems()
+
+  if (items.length === 0) {
+    return null
+  }
+
   return (
     <VirtualContext.Provider value={virtualizer}>
       <div
@@ -483,7 +489,7 @@ function VirtualProvider(props: {
           }
         }}
       >
-        {virtualizer.getVirtualItems().map((item) => {
+        {items.map((item) => {
           return (
             <Fragment key={item.key}>
               {React.cloneElement(


### PR DESCRIPTION
With this change you'll be able to use the `empty:hidden` class to hide the combobox options when there are no options visible in both virtualized and normal comboboxes.