### PR TITLE
Don’t cancel `touchmove` on `input` elements inside a dialog

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix enter transitions in `Transition` component ([#3074](https://github.com/tailwindlabs/headlessui/pull/3074))
 - Fix focus handling in `ListboxOptions` and `MenuItems` components ([#3112](https://github.com/tailwindlabs/headlessui/pull/3112))
 - Fix horizontal scrolling inside the `Dialog` component ([#2889](https://github.com/tailwindlabs/headlessui/pull/2889))
+- Don’t cancel `touchmove` on `input` elements inside a dialog ([#3166](https://github.com/tailwindlabs/headlessui/pull/3166))
 
 ### Changed
 

--- a/packages/@headlessui-react/src/hooks/document-overflow/handle-ios-locking.ts
+++ b/packages/@headlessui-react/src/hooks/document-overflow/handle-ios-locking.ts
@@ -94,13 +94,13 @@ export function handleIOSLocking(): ScrollLockStep<ContainerMetadata> {
           (e) => {
             // Check if we are scrolling inside any of the allowed containers, if not let's cancel the event!
             if (e.target instanceof HTMLElement) {
-              if (inAllowedContainer(e.target as HTMLElement)) {
-                // Some inputs like `<input type=range>` use touch events to
-                // allow interaction. We should not prevent this event.
-                if (e.target.tagName === 'INPUT') {
-                  return
-                }
+              // Some inputs like `<input type=range>` use touch events to
+              // allow interaction. We should not prevent this event.
+              if (e.target.tagName === 'INPUT') {
+                return
+              }
 
+              if (inAllowedContainer(e.target as HTMLElement)) {
                 // Even if we are in an allowed container, on iOS the main page can still scroll, we
                 // have to make sure that we `event.preventDefault()` this event to prevent that.
                 //

--- a/packages/@headlessui-react/src/hooks/document-overflow/handle-ios-locking.ts
+++ b/packages/@headlessui-react/src/hooks/document-overflow/handle-ios-locking.ts
@@ -95,6 +95,12 @@ export function handleIOSLocking(): ScrollLockStep<ContainerMetadata> {
             // Check if we are scrolling inside any of the allowed containers, if not let's cancel the event!
             if (e.target instanceof HTMLElement) {
               if (inAllowedContainer(e.target as HTMLElement)) {
+                // Some inputs like `<input type=range>` use touch events to
+                // allow interaction. We should not prevent this event.
+                if (e.target.tagName === 'INPUT') {
+                  return
+                }
+
                 // Even if we are in an allowed container, on iOS the main page can still scroll, we
                 // have to make sure that we `event.preventDefault()` this event to prevent that.
                 //

--- a/packages/@headlessui-vue/src/hooks/document-overflow/handle-ios-locking.ts
+++ b/packages/@headlessui-vue/src/hooks/document-overflow/handle-ios-locking.ts
@@ -94,13 +94,13 @@ export function handleIOSLocking(): ScrollLockStep<ContainerMetadata> {
           (e) => {
             // Check if we are scrolling inside any of the allowed containers, if not let's cancel the event!
             if (e.target instanceof HTMLElement) {
-              if (inAllowedContainer(e.target as HTMLElement)) {
-                // Some inputs like `<input type=range>` use touch events to
-                // allow interaction. We should not prevent this event.
-                if (e.target.tagName === 'INPUT') {
-                  return
-                }
+              // Some inputs like `<input type=range>` use touch events to
+              // allow interaction. We should not prevent this event.
+              if (e.target.tagName === 'INPUT') {
+                return
+              }
 
+              if (inAllowedContainer(e.target as HTMLElement)) {
                 // Even if we are in an allowed container, on iOS the main page can still scroll, we
                 // have to make sure that we `event.preventDefault()` this event to prevent that.
                 //

--- a/packages/@headlessui-vue/src/hooks/document-overflow/handle-ios-locking.ts
+++ b/packages/@headlessui-vue/src/hooks/document-overflow/handle-ios-locking.ts
@@ -95,6 +95,12 @@ export function handleIOSLocking(): ScrollLockStep<ContainerMetadata> {
             // Check if we are scrolling inside any of the allowed containers, if not let's cancel the event!
             if (e.target instanceof HTMLElement) {
               if (inAllowedContainer(e.target as HTMLElement)) {
+                // Some inputs like `<input type=range>` use touch events to
+                // allow interaction. We should not prevent this event.
+                if (e.target.tagName === 'INPUT') {
+                  return
+                }
+
                 // Even if we are in an allowed container, on iOS the main page can still scroll, we
                 // have to make sure that we `event.preventDefault()` this event to prevent that.
                 //


### PR DESCRIPTION
We prevent the default `touchmove` event on some elements inside a dialog _on iOS_ as it is the only reliable way to prevent scrolling as `overflow: hidden` itself is not enough in some cases.

We shouldn't do this for `input` elements because cancelling the event for `<input type="range">` prevents the user from interacting with it at all. This PR checks for input elements and bails.

Fixes #3165
