### PR TITLE
Remove deprecated `DialogBackdrop` and `DialogOverlay` components

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecate the `entered` prop on the `Transition` component ([#3089](https://github.com/tailwindlabs/headlessui/pull/3089))
 - Deprecate dot notation for components ([#2887](https://github.com/tailwindlabs/headlessui/pull/2887), [#3170](https://github.com/tailwindlabs/headlessui/pull/3170))
 - Add frozen value to `ComboboxOptions` component ([#3126](https://github.com/tailwindlabs/headlessui/pull/3126))
+- Remove deprecated `DialogBackdrop` and `DialogOverlay` components ([#3171](https://github.com/tailwindlabs/headlessui/pull/3171))
 
 ## [1.7.19] - 2024-04-15
 

--- a/packages/@headlessui-react/src/components/dialog-backdrop/dialog-backdrop.tsx
+++ b/packages/@headlessui-react/src/components/dialog-backdrop/dialog-backdrop.tsx
@@ -1,3 +1,0 @@
-// Next.js barrel file improvements (GENERATED FILE)
-export type * from '../dialog/dialog'
-export { DialogBackdrop } from '../dialog/dialog'

--- a/packages/@headlessui-react/src/components/dialog-overlay/dialog-overlay.tsx
+++ b/packages/@headlessui-react/src/components/dialog-overlay/dialog-overlay.tsx
@@ -1,3 +1,0 @@
-// Next.js barrel file improvements (GENERATED FILE)
-export type * from '../dialog/dialog'
-export { DialogOverlay } from '../dialog/dialog'

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -35,7 +35,6 @@ import { State, useOpenClosed } from '../../internal/open-closed'
 import { ForcePortalRoot } from '../../internal/portal-force-root'
 import { StackMessage, StackProvider } from '../../internal/stack-context'
 import type { Props } from '../../types'
-import { isDisabledReactIssue7711 } from '../../utils/bugs'
 import { match } from '../../utils/match'
 import {
   RenderFeatures,
@@ -426,115 +425,6 @@ function DialogFn<TTag extends ElementType = typeof DEFAULT_DIALOG_TAG>(
 
 // ---
 
-let DEFAULT_OVERLAY_TAG = 'div' as const
-type OverlayRenderPropArg = {
-  open: boolean
-}
-type OverlayPropsWeControl = 'aria-hidden'
-
-export type DialogOverlayProps<TTag extends ElementType = typeof DEFAULT_OVERLAY_TAG> = Props<
-  TTag,
-  OverlayRenderPropArg,
-  OverlayPropsWeControl
->
-
-function OverlayFn<TTag extends ElementType = typeof DEFAULT_OVERLAY_TAG>(
-  props: DialogOverlayProps<TTag>,
-  ref: Ref<HTMLElement>
-) {
-  let internalId = useId()
-  let { id = `headlessui-dialog-overlay-${internalId}`, ...theirProps } = props
-  let [{ dialogState, close }] = useDialogContext('Dialog.Overlay')
-  let overlayRef = useSyncRefs(ref)
-
-  let handleClick = useEvent((event: ReactMouseEvent) => {
-    if (event.target !== event.currentTarget) return
-    if (isDisabledReactIssue7711(event.currentTarget)) return event.preventDefault()
-    event.preventDefault()
-    event.stopPropagation()
-    close()
-  })
-
-  let slot = useMemo(
-    () => ({ open: dialogState === DialogStates.Open }) satisfies OverlayRenderPropArg,
-    [dialogState]
-  )
-
-  let ourProps = {
-    ref: overlayRef,
-    id,
-    'aria-hidden': true,
-    onClick: handleClick,
-  }
-
-  return render({
-    ourProps,
-    theirProps,
-    slot,
-    defaultTag: DEFAULT_OVERLAY_TAG,
-    name: 'Dialog.Overlay',
-  })
-}
-
-// ---
-
-let DEFAULT_BACKDROP_TAG = 'div' as const
-type BackdropRenderPropArg = {
-  open: boolean
-}
-type BackdropPropsWeControl = 'aria-hidden'
-
-export type DialogBackdropProps<TTag extends ElementType = typeof DEFAULT_BACKDROP_TAG> = Props<
-  TTag,
-  BackdropRenderPropArg,
-  BackdropPropsWeControl
->
-
-function BackdropFn<TTag extends ElementType = typeof DEFAULT_BACKDROP_TAG>(
-  props: DialogBackdropProps<TTag>,
-  ref: Ref<HTMLElement>
-) {
-  let internalId = useId()
-  let { id = `headlessui-dialog-backdrop-${internalId}`, ...theirProps } = props
-  let [{ dialogState }, state] = useDialogContext('Dialog.Backdrop')
-  let backdropRef = useSyncRefs(ref)
-
-  useEffect(() => {
-    if (state.panelRef.current === null) {
-      throw new Error(
-        `A <Dialog.Backdrop /> component is being used, but a <Dialog.Panel /> component is missing.`
-      )
-    }
-  }, [state.panelRef])
-
-  let slot = useMemo(
-    () => ({ open: dialogState === DialogStates.Open }) satisfies BackdropRenderPropArg,
-    [dialogState]
-  )
-
-  let ourProps = {
-    ref: backdropRef,
-    id,
-    'aria-hidden': true,
-  }
-
-  return (
-    <ForcePortalRoot force>
-      <Portal>
-        {render({
-          ourProps,
-          theirProps,
-          slot,
-          defaultTag: DEFAULT_BACKDROP_TAG,
-          name: 'Dialog.Backdrop',
-        })}
-      </Portal>
-    </ForcePortalRoot>
-  )
-}
-
-// ---
-
 let DEFAULT_PANEL_TAG = 'div' as const
 type PanelRenderPropArg = {
   open: boolean
@@ -631,21 +521,9 @@ export interface _internal_ComponentDialog extends HasDisplayName {
   ): JSX.Element
 }
 
-export interface _internal_ComponentDialogBackdrop extends HasDisplayName {
-  <TTag extends ElementType = typeof DEFAULT_BACKDROP_TAG>(
-    props: DialogBackdropProps<TTag> & RefProp<typeof BackdropFn>
-  ): JSX.Element
-}
-
 export interface _internal_ComponentDialogPanel extends HasDisplayName {
   <TTag extends ElementType = typeof DEFAULT_PANEL_TAG>(
     props: DialogPanelProps<TTag> & RefProp<typeof PanelFn>
-  ): JSX.Element
-}
-
-export interface _internal_ComponentDialogOverlay extends HasDisplayName {
-  <TTag extends ElementType = typeof DEFAULT_OVERLAY_TAG>(
-    props: DialogOverlayProps<TTag> & RefProp<typeof OverlayFn>
   ): JSX.Element
 }
 
@@ -659,21 +537,15 @@ export interface _internal_ComponentDialogDescription extends _internal_Componen
 
 let DialogRoot = forwardRefWithAs(DialogFn) as _internal_ComponentDialog
 /** @deprecated use a plain `<div>` instead of `<DialogBackdrop>` */
-export let DialogBackdrop = forwardRefWithAs(BackdropFn) as _internal_ComponentDialogBackdrop
 export let DialogPanel = forwardRefWithAs(PanelFn) as _internal_ComponentDialogPanel
 /** @deprecated use a plain `<div>` instead of `<DialogOverlay>` */
-export let DialogOverlay = forwardRefWithAs(OverlayFn) as _internal_ComponentDialogOverlay
 export let DialogTitle = forwardRefWithAs(TitleFn) as _internal_ComponentDialogTitle
 /** @deprecated use `<Description>` instead of `<DialogDescription>` */
 export let DialogDescription = Description as _internal_ComponentDialogDescription
 
 export let Dialog = Object.assign(DialogRoot, {
-  /** @deprecated use a plain `<div>` instead of `<Dialog.Backdrop>` */
-  Backdrop: DialogBackdrop,
   /** @deprecated use `<DialogPanel>` instead of `<Dialog.Panel>` */
   Panel: DialogPanel,
-  /** @deprecated use a plain `<div>` instead of `<Dialog.Overlay>` */
-  Overlay: DialogOverlay,
   /** @deprecated use `<DialogTitle>` instead of `<Dialog.Title>` */
   Title: DialogTitle,
   /** @deprecated use `<Description>` instead of `<Dialog.Description>` */

--- a/packages/@headlessui-react/src/index.test.ts
+++ b/packages/@headlessui-react/src/index.test.ts
@@ -24,9 +24,7 @@ it('should expose the correct components', () => {
     'Description',
 
     'Dialog',
-    'DialogBackdrop',
     'DialogDescription',
-    'DialogOverlay',
     'DialogPanel',
     'DialogTitle',
 

--- a/packages/@headlessui-react/src/test-utils/accessibility-assertions.ts
+++ b/packages/@headlessui-react/src/test-utils/accessibility-assertions.ts
@@ -1490,18 +1490,6 @@ export function getDialogDescription(): HTMLElement | null {
   return document.querySelector('[id^="headlessui-description-"]')
 }
 
-export function getDialogOverlay(): HTMLElement | null {
-  return document.querySelector('[id^="headlessui-dialog-overlay-"]')
-}
-
-export function getDialogBackdrop(): HTMLElement | null {
-  return document.querySelector('[id^="headlessui-dialog-backdrop-"]')
-}
-
-export function getDialogOverlays(): HTMLElement[] {
-  return Array.from(document.querySelectorAll('[id^="headlessui-dialog-overlay-"]'))
-}
-
 // ---
 
 export enum DialogState {
@@ -1678,53 +1666,6 @@ export function assertDialogDescription(
     }
   } catch (err) {
     if (err instanceof Error) Error.captureStackTrace(err, assertDialogDescription)
-    throw err
-  }
-}
-
-export function assertDialogOverlay(
-  options: {
-    attributes?: Record<string, string | null>
-    textContent?: string
-    state: DialogState
-  },
-  overlay = getDialogOverlay()
-) {
-  try {
-    switch (options.state) {
-      case DialogState.InvisibleHidden:
-        if (overlay === null) return expect(overlay).not.toBe(null)
-
-        assertHidden(overlay)
-
-        if (options.textContent) expect(overlay).toHaveTextContent(options.textContent)
-
-        for (let attributeName in options.attributes) {
-          expect(overlay).toHaveAttribute(attributeName, options.attributes[attributeName])
-        }
-        break
-
-      case DialogState.Visible:
-        if (overlay === null) return expect(overlay).not.toBe(null)
-
-        assertVisible(overlay)
-
-        if (options.textContent) expect(overlay).toHaveTextContent(options.textContent)
-
-        for (let attributeName in options.attributes) {
-          expect(overlay).toHaveAttribute(attributeName, options.attributes[attributeName])
-        }
-        break
-
-      case DialogState.InvisibleUnmounted:
-        expect(overlay).toBe(null)
-        break
-
-      default:
-        assertNever(options.state)
-    }
-  } catch (err) {
-    if (err instanceof Error) Error.captureStackTrace(err, assertDialogOverlay)
     throw err
   }
 }

--- a/playgrounds/react/pages/dialog/dialog.tsx
+++ b/playgrounds/react/pages/dialog/dialog.tsx
@@ -21,8 +21,8 @@ function Nested({ onClose, level = 0 }) {
   return (
     <>
       <Dialog open={true} onClose={onClose} className="fixed inset-0 z-10">
-        <Dialog.Overlay className="fixed inset-0 bg-gray-500 opacity-25" />
-        <div
+        <div className="fixed inset-0 bg-gray-500 opacity-25" />
+        <Dialog.Panel
           className="fixed left-12 top-24 z-10 w-96 bg-white p-4"
           style={{
             transform: `translate(calc(50px * ${level}), calc(50px * ${level}))`,
@@ -34,7 +34,7 @@ function Nested({ onClose, level = 0 }) {
             <Button onClick={() => setShowChild(true)}>Open (2)</Button>
             <Button onClick={() => setShowChild(true)}>Open (3)</Button>
           </div>
-        </div>
+        </Dialog.Panel>
         {showChild && <Nested onClose={() => setShowChild(false)} level={level + 1} />}
       </Dialog>
     </>


### PR DESCRIPTION
We deprecated those components in v1.6, since they are no longer documented and this is a major release, we can safely get rid of it.

If you still run into this, you should be able to replace the `<DialogOverlay>` and `<DialogBackdrop>` components with a simple `<div>` instead.

```diff
   <Dialog>
-    <DialogOverlay className="..." />
+    <div className="..." />
     <DialogPanel>
       Content
     </DialogPanel>
   </Dialog>
```

Or

```diff
   <Dialog>
-    <DialogBackdrop className="..." />
+    <div className="..." />
     <DialogPanel>
       Content
     </DialogPanel>
   </Dialog>
```
