### PR TITLE
Remove accidental deprecation comments on `<DialogPanel>` and `<DialogTitle>`

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Remove accidental deprecation comments on `<DialogPanel>` and `<DialogTitle>` ([#3176](https://github.com/tailwindlabs/headlessui/pull/3176))
 
 ## [2.0.0] - 2024-05-06
 

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -536,9 +536,7 @@ export interface _internal_ComponentDialogTitle extends HasDisplayName {
 export interface _internal_ComponentDialogDescription extends _internal_ComponentDescription {}
 
 let DialogRoot = forwardRefWithAs(DialogFn) as _internal_ComponentDialog
-/** @deprecated use a plain `<div>` instead of `<DialogBackdrop>` */
 export let DialogPanel = forwardRefWithAs(PanelFn) as _internal_ComponentDialogPanel
-/** @deprecated use a plain `<div>` instead of `<DialogOverlay>` */
 export let DialogTitle = forwardRefWithAs(TitleFn) as _internal_ComponentDialogTitle
 /** @deprecated use `<Description>` instead of `<DialogDescription>` */
 export let DialogDescription = Description as _internal_ComponentDialogDescription


### PR DESCRIPTION
These got left in from a rebase when they shouldn’t’ve been. whoops.

Fixes #3175