### PR TITLE
Ensure clicking a `ComboboxOption` after filtering the options, correctly triggers a change

### DIFF
--- a/packages/@headlessui-react/src/hooks/use-frame-debounce.ts
+++ b/packages/@headlessui-react/src/hooks/use-frame-debounce.ts
@@ -13,6 +13,6 @@ export function useFrameDebounce() {
 
   return useEvent((cb: () => void) => {
     d.dispose()
-    d.nextFrame(() => cb())
+    d.nextFrame(cb)
   })
 }

--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Prevent closing the `Combobox` component when clicking inside the scrollbar area ([#3104](https://github.com/tailwindlabs/headlessui/pull/3104))
+- Ensure clicking a `ComboboxOption` after filtering the options, correctly triggers a change ([#3180](https://github.com/tailwindlabs/headlessui/pull/3180))
 
 ## [1.7.20] - 2024-04-15
 

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -23,6 +23,7 @@ import {
   type UnwrapNestedRefs,
 } from 'vue'
 import { useControllable } from '../../hooks/use-controllable'
+import { useFrameDebounce } from '../../hooks/use-frame-debounce'
 import { useId } from '../../hooks/use-id'
 import { useOutsideClick } from '../../hooks/use-outside-click'
 import { useResolveButtonType } from '../../hooks/use-resolve-button-type'
@@ -31,6 +32,7 @@ import { useTreeWalker } from '../../hooks/use-tree-walker'
 import { Hidden, Features as HiddenFeatures } from '../../internal/hidden'
 import { State, useOpenClosed, useOpenClosedProvider } from '../../internal/open-closed'
 import { Keys } from '../../keyboard'
+import { MouseButton } from '../../mouse'
 import { history } from '../../utils/active-element-history'
 import { Focus, calculateActiveIndex } from '../../utils/calculate-active-index'
 import { disposables } from '../../utils/disposables'
@@ -1062,8 +1064,13 @@ export let ComboboxInput = defineComponent({
       })
     }
 
+    let debounce = useFrameDebounce()
     function handleKeyDown(event: KeyboardEvent) {
       isTyping.value = true
+      debounce(() => {
+        isTyping.value = false
+      })
+
       switch (event.key) {
         // Ref: https://www.w3.org/WAI/ARIA/apg/patterns/menu/#keyboard-interaction-12
 

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -1479,8 +1479,8 @@ export let ComboboxOption = defineComponent({
     })
 
     function handleMouseDown(event: MouseEvent) {
-      // We use the `mousedown` event here since it fires before the focus event,
-      // allowing us to cancel the event before focus is moved from the
+      // We use the `mousedown` event here since it fires before the focus
+      // event, allowing us to cancel the event before focus is moved from the
       // `ComboboxInput` to the `ComboboxOption`. This keeps the input focused,
       // preserving the cursor position and any text selection.
       event.preventDefault()
@@ -1495,17 +1495,21 @@ export let ComboboxOption = defineComponent({
       if (disabled.value) return
       api.selectOption(id)
 
-      // We want to make sure that we don't accidentally trigger the virtual keyboard.
+      // We want to make sure that we don't accidentally trigger the virtual
+      // keyboard.
       //
-      // This would happen if the input is focused, the options are open, you select an option (which
-      // would blur the input, and focus the option (button), then we re-focus the input).
+      // This would happen if the input is focused, the options are open, you
+      // select an option (which would blur the input, and focus the option
+      // (button), then we re-focus the input).
       //
-      // This would be annoying on mobile (or on devices with a virtual keyboard). Right now we are
-      // assuming that the virtual keyboard would open on mobile devices (iOS / Android). This
-      // assumption is not perfect, but will work in the majority of the cases.
+      // This would be annoying on mobile (or on devices with a virtual
+      // keyboard). Right now we are assuming that the virtual keyboard would open
+      // on mobile devices (iOS / Android). This assumption is not perfect, but
+      // will work in the majority of the cases.
       //
-      // Ideally we can have a better check where we can explicitly check for the virtual keyboard.
-      // But right now this is still an experimental feature:
+      // Ideally we can have a better check where we can explicitly check for
+      // the virtual keyboard. But right now this is still an experimental
+      // feature:
       // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/virtualKeyboard
       if (!isMobile()) {
         requestAnimationFrame(() => dom(api.inputRef)?.focus({ preventScroll: true }))

--- a/packages/@headlessui-vue/src/hooks/use-disposables.ts
+++ b/packages/@headlessui-vue/src/hooks/use-disposables.ts
@@ -1,0 +1,12 @@
+import { onUnmounted } from 'vue'
+import { disposables } from '../utils/disposables'
+
+/**
+ * The `useDisposables` hook returns a `disposables` object that is disposed
+ * when the component is unmounted.
+ */
+export function useDisposables() {
+  let d = disposables()
+  onUnmounted(() => d.dispose())
+  return d
+}

--- a/packages/@headlessui-vue/src/hooks/use-frame-debounce.ts
+++ b/packages/@headlessui-vue/src/hooks/use-frame-debounce.ts
@@ -1,0 +1,17 @@
+import { useDisposables } from './use-disposables'
+
+/**
+ * Schedule some task in the next frame.
+ *
+ * - If you call the returned function multiple times, only the last task will
+ *   be executed.
+ * - If the component is unmounted, the task will be cancelled.
+ */
+export function useFrameDebounce() {
+  let d = useDisposables()
+
+  return (cb: () => void) => {
+    d.dispose()
+    d.nextFrame(() => cb())
+  }
+}

--- a/packages/@headlessui-vue/src/hooks/use-frame-debounce.ts
+++ b/packages/@headlessui-vue/src/hooks/use-frame-debounce.ts
@@ -12,6 +12,6 @@ export function useFrameDebounce() {
 
   return (cb: () => void) => {
     d.dispose()
-    d.nextFrame(() => cb())
+    d.nextFrame(cb)
   }
 }

--- a/packages/@headlessui-vue/src/mouse.ts
+++ b/packages/@headlessui-vue/src/mouse.ts
@@ -1,0 +1,4 @@
+export enum MouseButton {
+  Left = 0,
+  Right = 2,
+}


### PR DESCRIPTION
This PR fixes an issue where typing into a Combobox (filtering), and then clicking an option doesn't correctly choose the option.

We also made sure that the `ComboboxInput` stays focused after selecting an option (even when clicking).

Fixes: #3178

