### PR TITLE
Improve performance of internal `useInertOthers` hook

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Improve performance of internal `useInertOthers` hook ([#3181](https://github.com/tailwindlabs/headlessui/pull/3181))
 
 ## [2.0.1] - 2024-05-06
 

--- a/packages/@headlessui-react/src/hooks/use-inert-others.tsx
+++ b/packages/@headlessui-react/src/hooks/use-inert-others.tsx
@@ -74,8 +74,8 @@ function markNotInert(element: HTMLElement) {
  */
 export function useInertOthers(
   {
-    allowed = () => [],
-    disallowed = () => [],
+    allowed,
+    disallowed,
   }: { allowed?: () => (HTMLElement | null)[]; disallowed?: () => (HTMLElement | null)[] } = {},
   enabled = true
 ) {
@@ -85,14 +85,14 @@ export function useInertOthers(
     let d = disposables()
 
     // Mark all disallowed elements as inert
-    for (let element of disallowed()) {
+    for (let element of disallowed?.() ?? []) {
       if (!element) continue
 
       d.add(markInert(element))
     }
 
     // Mark all siblings of allowed elements (and parents) as inert
-    let allowedElements = allowed()
+    let allowedElements = allowed?.() ?? []
 
     for (let element of allowedElements) {
       if (!element) continue


### PR DESCRIPTION
This PR improves the performance of the internal `useInertOthers` hook, which will be visible when a lot of elements are rendered on the page.

This gets rid of the default function arguments for `allowed` and `disallowed` and does an internal null check instead.
