### PR TITLE
Make sure disabling demo mode on `<Combobox>` works

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Make sure disabling demo mode on `<Combobox>` works ([#3182](hhttps://github.com/tailwindlabs/headlessui/pull/3182))
 
 ## [2.0.2] - 2024-05-07
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -742,7 +742,6 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
       compare,
       isSelected,
       isActive,
-      __demoMode,
     }),
     [value, defaultValue, disabled, multiple, __demoMode, state, virtual]
   )


### PR DESCRIPTION
Our internal `__demoMode` prop that we use is intended to be disabled internally once a user interacts with the Combobox. However, we were incorrectly overriding this in a `useMemo` with the value of the prop which was always `true`.