### PR TITLE
Fix visual jitter in `Combobox` component when using native scrollbar

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keep `<Combobox />` open when clicking scrollbar in `<ComboboxOptions>` ([#3249](https://github.com/tailwindlabs/headlessui/pull/3249))
 - Merge incoming `style` prop on `ComboboxOptions`, `ListboxOptions`, `MenuItems`, and `PopoverPanel` components ([#3250](https://github.com/tailwindlabs/headlessui/pull/3250))
 - Prevent focus on `<Checkbox />` when it is `disabled` ([#3251](https://github.com/tailwindlabs/headlessui/pull/3251))
+- Fix visual jitter in `Combobox` component when using native scrollbar ([#3190](https://github.com/tailwindlabs/headlessui/pull/3190))
 
 ## [2.0.4] - 2024-05-25
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1688,6 +1688,14 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
     event.preventDefault()
   })
 
+  // When the user scrolls **using the native scrollbar**, the only event fired is
+  // the onScroll event. We need to make sure to set the current activation
+  // trigger to pointer, in order to let them scroll through the list.
+  let handleScroll = useEvent(() => {
+    if (isMobile()) return
+    actions.setActivationTrigger(ActivationTrigger.Pointer)
+  })
+
   let ourProps = mergeProps(anchor ? getFloatingPanelProps() : {}, {
     'aria-labelledby': labelledBy,
     role: 'listbox',
@@ -1702,6 +1710,7 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
     } as CSSProperties,
     onWheel: handleWheel,
     onMouseDown: handleMouseDown,
+    onScroll: handleScroll,
   })
 
   // Map the children in a scrollable container when virtualization is enabled

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1671,7 +1671,7 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
   }, [data])
 
   // When the user scrolls **using the mouse** (so scroll event isn't appropriate)
-  // we want to make sure that the current activation trigger is set to pointer
+  // we want to make sure that the current activation trigger is set to pointer.
   let handleWheel = useEvent(() => {
     actions.setActivationTrigger(ActivationTrigger.Pointer)
   })
@@ -1705,7 +1705,7 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
       '--input-width': useElementSize(data.inputRef, true).width,
       '--button-width': useElementSize(data.buttonRef, true).width,
     } as CSSProperties,
-    onWheel: handleWheel,
+    onWheel: data.activationTrigger === ActivationTrigger.Pointer ? undefined : handleWheel,
     onMouseDown: handleMouseDown,
   })
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1676,23 +1676,20 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
     actions.setActivationTrigger(ActivationTrigger.Pointer)
   })
 
-  // When clicking inside of the scrollbar, a `click` event will be triggered on
-  // the focusable element _below_ the scrollbar. If you use a `<Combobox>`
-  // inside of a `<Dialog>`, clicking the scrollbar of the `<ComboboxOptions>`
-  // will move focus to the `<Dialog>` which blurs the `<ComboboxInput>` and
-  // closes the `<Combobox>`.
-  //
-  // Preventing the default behavior in the `mousedown` event (which happens
-  // before `click`) will prevent this issue because the `click` never fires.
   let handleMouseDown = useEvent((event: ReactMouseEvent) => {
+    // When clicking inside of the scrollbar, a `click` event will be triggered
+    // on the focusable element _below_ the scrollbar. If you use a `<Combobox>`
+    // inside of a `<Dialog>`, clicking the scrollbar of the `<ComboboxOptions>`
+    // will move focus to the `<Dialog>` which blurs the `<ComboboxInput>` and
+    // closes the `<Combobox>`.
+    //
+    // Preventing the default behavior in the `mousedown` event (which happens
+    // before `click`) will prevent this issue because the `click` never fires.
     event.preventDefault()
-  })
 
-  // When the user scrolls **using the native scrollbar**, the only event fired
-  // is the onScroll event. We need to make sure to set the current activation
-  // trigger to pointer, in order to let them scroll through the list.
-  let handleScroll = useEvent(() => {
-    if (isMobile()) return
+    // When the user clicks in the `<Options/>`, we want to make sure that we
+    // set the activation trigger to `pointer` to prevent auto scrolling to the
+    // active option while the user is scrolling.
     actions.setActivationTrigger(ActivationTrigger.Pointer)
   })
 
@@ -1710,7 +1707,6 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
     } as CSSProperties,
     onWheel: handleWheel,
     onMouseDown: handleMouseDown,
-    onScroll: handleScroll,
   })
 
   // Map the children in a scrollable container when virtualization is enabled

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1688,8 +1688,8 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
     event.preventDefault()
   })
 
-  // When the user scrolls **using the native scrollbar**, the only event fired is
-  // the onScroll event. We need to make sure to set the current activation
+  // When the user scrolls **using the native scrollbar**, the only event fired
+  // is the onScroll event. We need to make sure to set the current activation
   // trigger to pointer, in order to let them scroll through the list.
   let handleScroll = useEvent(() => {
     if (isMobile()) return


### PR DESCRIPTION
Fixes #3189

## Bug
The dropdown will jitter when using the native scrollbar **before** entering the dropdown list with your cursor or using the mouse wheel to scroll.

This is because the `﻿ActivationTrigger` has not been set to pointer. As a result, ﻿`scrollToIndex` is called while you are attempting to scroll, leading to the rubberband effect.

## How to Reproduce
If you are on macOS, go to **System Settings** and set Show Scroll Bars to **Always**.

It can be difficult to reproduce without this, as you must hover over the native scroll bar first avoid triggering any React events.

![tw native scroll (Optimized)](https://github.com/danthomps/headlessui/assets/7358641/454bfe4d-c5aa-4295-9944-3c4ab40cdfa9)

### The bug on the Tailwind blog demo

https://github.com/danthomps/headlessui/assets/7358641/0fa2cc8b-7855-4a7a-a04e-0c5551a5e221

Occasionally, React can render the scrolling quickly enough to make the rubberbanding non-visible, making it somewhat challenging to consistently reproduce on the blog post.

### Reproducing on the Playground
Adding a **250ms artificial delay** on the scrolling makes it much more obvious.

If you scroll with your mouse wheel or move your pointer inside the dropdown, the issue will resolve itself. The bug only occurs when you enter native scrollbar **first** and interact with it directly.

![tw-combobox-scroll-bug (Optimized)](https://github.com/danthomps/headlessui/assets/7358641/8b838b81-5f1e-453e-a727-4e3485b4588a)

https://github.com/danthomps/headlessui/assets/7358641/b12fd80f-ddda-41fa-b3a8-68d3a7c6b931

## A Fix
Adding a `onScroll` handler that ignores mobile and sets the `ActivationTrigger` to pointer.

https://github.com/danthomps/headlessui/assets/7358641/c44864a9-be83-4477-b1b1-9e2d4f271374

Feel free to discard any or all of this fix or improve it further. If nothing else, this demonstrates how to reproduce it.