### PR TITLE
Don’t set a focus fallback for Dialog’s in demo mode

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- [internal] Don’t set a focus fallback for Dialog’s in demo mode ([#3194](https://github.com/tailwindlabs/headlessui/pull/3194))
 
 ## [2.0.3] - 2024-05-07
 

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -393,7 +393,7 @@ function DialogFn<TTag extends ElementType = typeof DEFAULT_DIALOG_TAG>(
                   <PortalWrapper>
                     <FocusTrap
                       initialFocus={initialFocus}
-                      initialFocusFallback={internalDialogRef}
+                      initialFocusFallback={__demoMode ? undefined : internalDialogRef}
                       containers={resolveRootContainers}
                       features={focusTrapFeatures}
                     >


### PR DESCRIPTION
A dialog in demo mode always focuses the dialog container when it's not supposed to focus anything by default. This PR fixes that by removing the "fallback" focus element which is focused when nothing else is focused.