### PR TITLE
Ensure page doesn't scroll down when pressing `Escape` to close the `Dialog` component

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [internal] Don’t set a focus fallback for Dialog’s in demo mode ([#3194](https://github.com/tailwindlabs/headlessui/pull/3194))
+- Ensure page doesn't scroll down when pressing `Escape` to close the `Dialog` component ([#3218](https://github.com/tailwindlabs/headlessui/pull/3218))
 
 ## [2.0.3] - 2024-05-07
 

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -310,6 +310,21 @@ function DialogFn<TTag extends ElementType = typeof DEFAULT_DIALOG_TAG>(
     if (event.key !== Keys.Escape) return
     event.preventDefault()
     event.stopPropagation()
+
+    // Ensure that we blur the current activeElement to prevent maintaining
+    // focus and potentially scrolling the page to the end (because the Dialog
+    // is rendered in a Portal at the end of the document.body and the browser
+    // tries to keep the focused element in view)
+    //
+    // Typically only happens in Safari.
+    if (
+      document.activeElement &&
+      'blur' in document.activeElement &&
+      typeof document.activeElement.blur === 'function'
+    ) {
+      document.activeElement.blur()
+    }
+
     close()
   })
 


### PR DESCRIPTION
This PR ensures that the page doesn't scroll down when pressing `Escape` to close an open `Dialog` component.

This only happens in Safari, and if the `document.activeElement` is an `<input>` for example. It also only happens when pressing `Escape`, not when clicking outside of the `Dialog` component.

The reason why is a bit confusing but it does make sense:

Whenever the the currently focused element is moved on the page, Safari will try to keep the `document.activeElement` in view. This means that when you press `Escape` that the `<input>` element is still focused, but since the `Dialog` closes, the `<input>` is still rendered in a portal at the end of the page. Because it's rendered there, Safari will try and keep it in view, which causes the page to scroll down.

It doesn't happen when clicking outside of the `Dialog` component because the `document.activeElement` will be the newly focused element, which is typically the `<body>` element.

To solve this, we will always call `document.activeElement.blur()` (which is also implicitly done when clicking outside of the `Dialog` component) when we press `Escape`.

Now, the `<input>` element is no longer focused, and Safari won't try to keep it in view, which prevents the page from scrolling down.
