### PR TITLE
Extract assert

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -56,6 +56,7 @@ import { useProvidedId } from '../../internal/id'
 import { OpenClosedProvider, State, useOpenClosed } from '../../internal/open-closed'
 import type { EnsureArray, Props } from '../../types'
 import { history } from '../../utils/active-element-history'
+import { assert } from '../../utils/assert'
 import { isDisabledReactIssue7711 } from '../../utils/bugs'
 import { Focus, calculateActiveIndex } from '../../utils/calculate-active-index'
 import { disposables } from '../../utils/disposables'
@@ -410,11 +411,12 @@ ComboboxActionsContext.displayName = 'ComboboxActionsContext'
 
 function useActions(component: string) {
   let context = useContext(ComboboxActionsContext)
-  if (context === null) {
-    let err = new Error(`<${component} /> is missing a parent <Combobox /> component.`)
-    if (Error.captureStackTrace) Error.captureStackTrace(err, useActions)
-    throw err
-  }
+  assert(
+    context !== null,
+    `<${component} /> is missing a parent <Combobox /> component.`,
+    useActions
+  )
+
   return context
 }
 type _Actions = ReturnType<typeof useActions>
@@ -558,11 +560,7 @@ ComboboxDataContext.displayName = 'ComboboxDataContext'
 
 function useData(component: string) {
   let context = useContext(ComboboxDataContext)
-  if (context === null) {
-    let err = new Error(`<${component} /> is missing a parent <Combobox /> component.`)
-    if (Error.captureStackTrace) Error.captureStackTrace(err, useData)
-    throw err
-  }
+  assert(context !== null, `<${component} /> is missing a parent <Combobox /> component.`, useData)
   return context
 }
 type _Data = ReturnType<typeof useData>

--- a/packages/@headlessui-react/src/components/description/description.tsx
+++ b/packages/@headlessui-react/src/components/description/description.tsx
@@ -15,6 +15,7 @@ import { useIsoMorphicEffect } from '../../hooks/use-iso-morphic-effect'
 import { useSyncRefs } from '../../hooks/use-sync-refs'
 import { useDisabled } from '../../internal/disabled'
 import type { Props } from '../../types'
+import { assert } from '../../utils/assert'
 import { forwardRefWithAs, render, type HasDisplayName, type RefProp } from '../../utils/render'
 
 // ---
@@ -32,13 +33,11 @@ DescriptionContext.displayName = 'DescriptionContext'
 
 function useDescriptionContext() {
   let context = useContext(DescriptionContext)
-  if (context === null) {
-    let err = new Error(
-      'You used a <Description /> component, but it is not inside a relevant parent.'
-    )
-    if (Error.captureStackTrace) Error.captureStackTrace(err, useDescriptionContext)
-    throw err
-  }
+  assert(
+    context !== null,
+    'You used a <Description /> component, but it is not inside a relevant parent.',
+    useDescriptionContext
+  )
   return context
 }
 

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -35,6 +35,7 @@ import { State, useOpenClosed } from '../../internal/open-closed'
 import { ForcePortalRoot } from '../../internal/portal-force-root'
 import { StackMessage, StackProvider } from '../../internal/stack-context'
 import type { Props } from '../../types'
+import { assert } from '../../utils/assert'
 import { match } from '../../utils/match'
 import {
   RenderFeatures,
@@ -96,11 +97,11 @@ DialogContext.displayName = 'DialogContext'
 
 function useDialogContext(component: string) {
   let context = useContext(DialogContext)
-  if (context === null) {
-    let err = new Error(`<${component} /> is missing a parent <Dialog /> component.`)
-    if (Error.captureStackTrace) Error.captureStackTrace(err, useDialogContext)
-    throw err
-  }
+  assert(
+    context !== null,
+    `<${component} /> is missing a parent <Dialog /> component.`,
+    useDialogContext
+  )
   return context
 }
 

--- a/packages/@headlessui-react/src/components/disclosure/disclosure.tsx
+++ b/packages/@headlessui-react/src/components/disclosure/disclosure.tsx
@@ -27,6 +27,7 @@ import { optionalRef, useSyncRefs } from '../../hooks/use-sync-refs'
 import { CloseProvider } from '../../internal/close-provider'
 import { OpenClosedProvider, State, useOpenClosed } from '../../internal/open-closed'
 import type { Props } from '../../types'
+import { assert } from '../../utils/assert'
 import { isDisabledReactIssue7711 } from '../../utils/bugs'
 import { match } from '../../utils/match'
 import { getOwnerDocument } from '../../utils/owner'
@@ -119,11 +120,11 @@ DisclosureContext.displayName = 'DisclosureContext'
 
 function useDisclosureContext(component: string) {
   let context = useContext(DisclosureContext)
-  if (context === null) {
-    let err = new Error(`<${component} /> is missing a parent <Disclosure /> component.`)
-    if (Error.captureStackTrace) Error.captureStackTrace(err, useDisclosureContext)
-    throw err
-  }
+  assert(
+    context !== null,
+    `<${component} /> is missing a parent <Disclosure /> component.`,
+    useDisclosureContext
+  )
   return context
 }
 
@@ -134,11 +135,11 @@ DisclosureAPIContext.displayName = 'DisclosureAPIContext'
 
 function useDisclosureAPIContext(component: string) {
   let context = useContext(DisclosureAPIContext)
-  if (context === null) {
-    let err = new Error(`<${component} /> is missing a parent <Disclosure /> component.`)
-    if (Error.captureStackTrace) Error.captureStackTrace(err, useDisclosureAPIContext)
-    throw err
-  }
+  assert(
+    context !== null,
+    `<${component} /> is missing a parent <Disclosure /> component.`,
+    useDisclosureAPIContext
+  )
   return context
 }
 

--- a/packages/@headlessui-react/src/components/label/label.tsx
+++ b/packages/@headlessui-react/src/components/label/label.tsx
@@ -17,6 +17,7 @@ import { useSyncRefs } from '../../hooks/use-sync-refs'
 import { useDisabled } from '../../internal/disabled'
 import { useProvidedId } from '../../internal/id'
 import type { Props } from '../../types'
+import { assert } from '../../utils/assert'
 import { forwardRefWithAs, render, type HasDisplayName, type RefProp } from '../../utils/render'
 
 // ---
@@ -34,11 +35,11 @@ LabelContext.displayName = 'LabelContext'
 
 export function useLabelContext() {
   let context = useContext(LabelContext)
-  if (context === null) {
-    let err = new Error('You used a <Label /> component, but it is not inside a relevant parent.')
-    if (Error.captureStackTrace) Error.captureStackTrace(err, useLabelContext)
-    throw err
-  }
+  assert(
+    context !== null,
+    'You used a <Label /> component, but it is not inside a relevant parent.',
+    useLabelContext
+  )
   return context
 }
 

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -54,6 +54,7 @@ import { FormFields } from '../../internal/form-fields'
 import { useProvidedId } from '../../internal/id'
 import { OpenClosedProvider, State, useOpenClosed } from '../../internal/open-closed'
 import type { EnsureArray, Props } from '../../types'
+import { assert } from '../../utils/assert'
 import { isDisabledReactIssue7711 } from '../../utils/bugs'
 import { Focus, calculateActiveIndex } from '../../utils/calculate-active-index'
 import { disposables } from '../../utils/disposables'
@@ -390,11 +391,11 @@ ListboxActionsContext.displayName = 'ListboxActionsContext'
 
 function useActions(component: string) {
   let context = useContext(ListboxActionsContext)
-  if (context === null) {
-    let err = new Error(`<${component} /> is missing a parent <Listbox /> component.`)
-    if (Error.captureStackTrace) Error.captureStackTrace(err, useActions)
-    throw err
-  }
+  assert(
+    context !== null,
+    `<${component} /> is missing a parent <Listbox /> component.`,
+    useActions
+  )
   return context
 }
 type _Actions = ReturnType<typeof useActions>
@@ -426,11 +427,7 @@ ListboxDataContext.displayName = 'ListboxDataContext'
 
 function useData(component: string) {
   let context = useContext(ListboxDataContext)
-  if (context === null) {
-    let err = new Error(`<${component} /> is missing a parent <Listbox /> component.`)
-    if (Error.captureStackTrace) Error.captureStackTrace(err, useData)
-    throw err
-  }
+  assert(context !== null, `<${component} /> is missing a parent <Listbox /> component.`, useData)
   return context
 }
 type _Data = ReturnType<typeof useData>

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -48,6 +48,7 @@ import {
 } from '../../internal/floating'
 import { OpenClosedProvider, State, useOpenClosed } from '../../internal/open-closed'
 import type { Props } from '../../types'
+import { assert } from '../../utils/assert'
 import { isDisabledReactIssue7711 } from '../../utils/bugs'
 import { Focus, calculateActiveIndex } from '../../utils/calculate-active-index'
 import { disposables } from '../../utils/disposables'
@@ -339,11 +340,11 @@ MenuContext.displayName = 'MenuContext'
 
 function useMenuContext(component: string) {
   let context = useContext(MenuContext)
-  if (context === null) {
-    let err = new Error(`<${component} /> is missing a parent <Menu /> component.`)
-    if (Error.captureStackTrace) Error.captureStackTrace(err, useMenuContext)
-    throw err
-  }
+  assert(
+    context !== null,
+    `<${component} /> is missing a parent <Menu /> component.`,
+    useMenuContext
+  )
   return context
 }
 

--- a/packages/@headlessui-react/src/components/popover/popover.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.tsx
@@ -48,6 +48,7 @@ import {
 import { Hidden, HiddenFeatures } from '../../internal/hidden'
 import { OpenClosedProvider, State, useOpenClosed } from '../../internal/open-closed'
 import type { Props } from '../../types'
+import { assert } from '../../utils/assert'
 import { isDisabledReactIssue7711 } from '../../utils/bugs'
 import {
   Focus,
@@ -157,11 +158,11 @@ PopoverContext.displayName = 'PopoverContext'
 
 function usePopoverContext(component: string) {
   let context = useContext(PopoverContext)
-  if (context === null) {
-    let err = new Error(`<${component} /> is missing a parent <Popover /> component.`)
-    if (Error.captureStackTrace) Error.captureStackTrace(err, usePopoverContext)
-    throw err
-  }
+  assert(
+    context !== null,
+    `<${component} /> is missing a parent <Popover /> component.`,
+    usePopoverContext
+  )
   return context
 }
 
@@ -175,11 +176,11 @@ PopoverAPIContext.displayName = 'PopoverAPIContext'
 
 function usePopoverAPIContext(component: string) {
   let context = useContext(PopoverAPIContext)
-  if (context === null) {
-    let err = new Error(`<${component} /> is missing a parent <Popover /> component.`)
-    if (Error.captureStackTrace) Error.captureStackTrace(err, usePopoverAPIContext)
-    throw err
-  }
+  assert(
+    context !== null,
+    `<${component} /> is missing a parent <Popover /> component.`,
+    usePopoverAPIContext
+  )
   return context
 }
 

--- a/packages/@headlessui-react/src/components/radio-group/radio-group.tsx
+++ b/packages/@headlessui-react/src/components/radio-group/radio-group.tsx
@@ -26,6 +26,7 @@ import { useDisabled } from '../../internal/disabled'
 import { FormFields } from '../../internal/form-fields'
 import { useProvidedId } from '../../internal/id'
 import type { Expand, Props } from '../../types'
+import { assert } from '../../utils/assert'
 import { isDisabledReactIssue7711 } from '../../utils/bugs'
 import { Focus, FocusResult, focusIn, sortByDomNode } from '../../utils/focus-management'
 import { attemptSubmit } from '../../utils/form'
@@ -106,11 +107,11 @@ RadioGroupDataContext.displayName = 'RadioGroupDataContext'
 
 function useData(component: string) {
   let context = useContext(RadioGroupDataContext)
-  if (context === null) {
-    let err = new Error(`<${component} /> is missing a parent <RadioGroup /> component.`)
-    if (Error.captureStackTrace) Error.captureStackTrace(err, useData)
-    throw err
-  }
+  assert(
+    context !== null,
+    `<${component} /> is missing a parent <RadioGroup /> component.`,
+    useData
+  )
   return context
 }
 type _Data = ReturnType<typeof useData>
@@ -123,11 +124,11 @@ RadioGroupActionsContext.displayName = 'RadioGroupActionsContext'
 
 function useActions(component: string) {
   let context = useContext(RadioGroupActionsContext)
-  if (context === null) {
-    let err = new Error(`<${component} /> is missing a parent <RadioGroup /> component.`)
-    if (Error.captureStackTrace) Error.captureStackTrace(err, useActions)
-    throw err
-  }
+  assert(
+    context !== null,
+    `<${component} /> is missing a parent <RadioGroup /> component.`,
+    useActions
+  )
   return context
 }
 type _Actions = ReturnType<typeof useActions>

--- a/packages/@headlessui-react/src/components/tabs/tabs.tsx
+++ b/packages/@headlessui-react/src/components/tabs/tabs.tsx
@@ -24,6 +24,7 @@ import { useSyncRefs } from '../../hooks/use-sync-refs'
 import { FocusSentinel } from '../../internal/focus-sentinel'
 import { Hidden } from '../../internal/hidden'
 import type { Props } from '../../types'
+import { assert } from '../../utils/assert'
 import { Focus, FocusResult, focusIn, sortByDomNode } from '../../utils/focus-management'
 import { match } from '../../utils/match'
 import { microTask } from '../../utils/micro-task'
@@ -186,11 +187,7 @@ TabsDataContext.displayName = 'TabsDataContext'
 
 function useData(component: string) {
   let context = useContext(TabsDataContext)
-  if (context === null) {
-    let err = new Error(`<${component} /> is missing a parent <Tab.Group /> component.`)
-    if (Error.captureStackTrace) Error.captureStackTrace(err, useData)
-    throw err
-  }
+  assert(context !== null, `<${component} /> is missing a parent <Tab.Group /> component.`, useData)
   return context
 }
 type _Data = ReturnType<typeof useData>
@@ -204,11 +201,11 @@ TabsActionsContext.displayName = 'TabsActionsContext'
 
 function useActions(component: string) {
   let context = useContext(TabsActionsContext)
-  if (context === null) {
-    let err = new Error(`<${component} /> is missing a parent <Tab.Group /> component.`)
-    if (Error.captureStackTrace) Error.captureStackTrace(err, useActions)
-    throw err
-  }
+  assert(
+    context !== null,
+    `<${component} /> is missing a parent <Tab.Group /> component.`,
+    useActions
+  )
   return context
 }
 type _Actions = ReturnType<typeof useActions>

--- a/packages/@headlessui-react/src/components/tooltip/tooltip.tsx
+++ b/packages/@headlessui-react/src/components/tooltip/tooltip.tsx
@@ -28,6 +28,7 @@ import {
 } from '../../internal/floating'
 import { State, useOpenClosed } from '../../internal/open-closed'
 import type { Props } from '../../types'
+import { assert } from '../../utils/assert'
 import { match } from '../../utils/match'
 import {
   RenderFeatures,
@@ -157,11 +158,11 @@ TooltipActionsContext.displayName = 'TooltipActionsContext'
 
 function useActions(component: string) {
   let context = useContext(TooltipActionsContext)
-  if (context === null) {
-    let err = new Error(`<${component} /> is missing a parent <Tooltip /> component.`)
-    if (Error.captureStackTrace) Error.captureStackTrace(err, useActions)
-    throw err
-  }
+  assert(
+    context !== null,
+    `<${component} /> is missing a parent <Tooltip /> component.`,
+    useActions
+  )
   return context
 }
 type _Actions = ReturnType<typeof useActions>
@@ -171,11 +172,7 @@ TooltipDataContext.displayName = 'TooltipDataContext'
 
 function useData(component: string) {
   let context = useContext(TooltipDataContext)
-  if (context === null) {
-    let err = new Error(`<${component} /> is missing a parent <Tooltip /> component.`)
-    if (Error.captureStackTrace) Error.captureStackTrace(err, useData)
-    throw err
-  }
+  assert(context !== null, `<${component} /> is missing a parent <Tooltip /> component.`, useData)
   return context
 }
 type _Data = ReturnType<typeof useData>

--- a/packages/@headlessui-react/src/utils/assert.ts
+++ b/packages/@headlessui-react/src/utils/assert.ts
@@ -1,0 +1,24 @@
+export function assert(
+  condition: boolean,
+  messageOrMessageGetter: string | (() => string),
+  functionToSkipStackFrames: Function = assert
+): asserts condition {
+  if (condition) {
+    return
+  }
+
+  const message = getMessage(messageOrMessageGetter)
+  const error = new Error(message)
+
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(error, functionToSkipStackFrames)
+  }
+
+  throw error
+}
+
+function getMessage(messageOrMessageGetter: string | (() => string)) {
+  return typeof messageOrMessageGetter === 'string'
+    ? messageOrMessageGetter
+    : messageOrMessageGetter()
+}

--- a/packages/@headlessui-react/src/utils/match.ts
+++ b/packages/@headlessui-react/src/utils/match.ts
@@ -1,20 +1,21 @@
+import { assert } from './assert'
+
 export function match<TValue extends string | number = string, TReturnValue = unknown>(
   value: TValue,
   lookup: Record<TValue, TReturnValue | ((...args: any[]) => TReturnValue)>,
   ...args: any[]
 ): TReturnValue {
-  if (value in lookup) {
-    let returnValue = lookup[value]
-    return typeof returnValue === 'function' ? returnValue(...args) : returnValue
-  }
-
-  let error = new Error(
-    `Tried to handle "${value}" but there is no handler defined. Only defined handlers are: ${Object.keys(
-      lookup
-    )
-      .map((key) => `"${key}"`)
-      .join(', ')}.`
+  assert(
+    value in lookup,
+    () =>
+      `Tried to handle "${value}" but there is no handler defined. Only defined handlers are: ${Object.keys(
+        lookup
+      )
+        .map((key) => `"${key}"`)
+        .join(', ')}.`,
+    match
   )
-  if (Error.captureStackTrace) Error.captureStackTrace(error, match)
-  throw error
+
+  let returnValue = lookup[value]
+  return typeof returnValue === 'function' ? returnValue(...args) : returnValue
 }


### PR DESCRIPTION
Extract `assert` utility to reduce duplication and simplify the code. Similar changes can be made in vue package.

This PR does not introduce any new functionality and does not fix any issues.