### PR TITLE
Improve demo mode for `Dialog` component in Safari

### DIFF
--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -357,7 +357,7 @@ function DialogFn<TTag extends ElementType = typeof DEFAULT_DIALOG_TAG>(
     id,
     role,
     tabIndex: -1,
-    'aria-modal': dialogState === DialogStates.Open ? true : undefined,
+    'aria-modal': __demoMode ? undefined : dialogState === DialogStates.Open ? true : undefined,
     'aria-labelledby': state.titleId,
     'aria-describedby': describedby,
   }


### PR DESCRIPTION
When you have a `role="dialog"` and an `aria-modal="true"` at the same time, then Safari will focus the first focusable element inside the dialog.

This is not ideal, because in demo mode this means that the focus is moved around to various DOM elements.

This PR ensures that while demo mode is active, that the `aria-modal` attribute is not applied which means that focus is not automatically applied in Safari.
