### PR TITLE
Mark `SwitchGroup` as deprecated, prefer `Field` instead

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [internal] Don’t set a focus fallback for Dialog’s in demo mode ([#3194](https://github.com/tailwindlabs/headlessui/pull/3194))
 - Ensure page doesn't scroll down when pressing `Escape` to close the `Dialog` component ([#3218](https://github.com/tailwindlabs/headlessui/pull/3218))
 
+### Deprecated
+
+- Mark `SwitchGroup` as deprecated, prefer `Field` instead ([#3232](https://github.com/tailwindlabs/headlessui/pull/3232))
+
 ## [2.0.3] - 2024-05-07
 
 ### Fixed

--- a/packages/@headlessui-react/src/components/switch/switch.tsx
+++ b/packages/@headlessui-react/src/components/switch/switch.tsx
@@ -269,6 +269,7 @@ export interface _internal_ComponentSwitchLabel extends _internal_ComponentLabel
 export interface _internal_ComponentSwitchDescription extends _internal_ComponentDescription {}
 
 let SwitchRoot = forwardRefWithAs(SwitchFn) as _internal_ComponentSwitch
+/** @deprecated use `<Field>` instead of `<SwitchGroup>` */
 export let SwitchGroup = GroupFn as _internal_ComponentSwitchGroup
 /** @deprecated use `<Label>` instead of `<SwitchLabel>` */
 export let SwitchLabel = Label as _internal_ComponentSwitchLabel
@@ -276,7 +277,7 @@ export let SwitchLabel = Label as _internal_ComponentSwitchLabel
 export let SwitchDescription = Description as _internal_ComponentSwitchDescription
 
 export let Switch = Object.assign(SwitchRoot, {
-  /** @deprecated use `<SwitchGroup>` instead of `<Switch.Group>` */
+  /** @deprecated use `<Field>` instead of `<Switch.Group>` */
   Group: SwitchGroup,
   /** @deprecated use `<Label>` instead of `<Switch.Label>` */
   Label: SwitchLabel,


### PR DESCRIPTION
This PR marks the `SwitchGroup` component as deprecated in favor of the new `<Field>` component.

The `SwitchGroup` component was useful if you wanted to link a `<Switch>` and a `<Switch.Label>` together. However, now we have more generic components that allows you to do this instead and is more consistent with all other components as well.

E.g.:

```tsx
<Switch.Group>
 <Switch.Label>Label</Switch.Label>
 <Switch />
</Switch.Group>
```

↓↓↓↓

```tsx
<SwitchGroup>
 <SwitchLabel>Label</SwitchLabel>
 <Switch />
</SwitchGroup>
```

↓↓↓↓

```tsx
<Field>
 <Label>Label</Label>
 <Switch />
</Field>
```


This `Field` and `Label` component combination can also be used with other components like `Checkbox`, `Combobox`, `Input`, `Listbox`, `Radio`, `Select`, and `Textarea`.
