### PR TITLE
Fix crash when toggling between `virtual` and non-virtual mode in `Combobox` component

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [internal] Don’t set a focus fallback for Dialog’s in demo mode ([#3194](https://github.com/tailwindlabs/headlessui/pull/3194))
 - Ensure page doesn't scroll down when pressing `Escape` to close the `Dialog` component ([#3218](https://github.com/tailwindlabs/headlessui/pull/3218))
+- Fix crash when toggling between `virtual` and non-virtual mode in `Combobox` component ([#3236](https://github.com/tailwindlabs/headlessui/pull/3236))
 
 ### Deprecated
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -182,7 +182,7 @@ type Actions<T> =
   | { type: ActionTypes.SetActivationTrigger; trigger: ActivationTrigger }
   | {
       type: ActionTypes.UpdateVirtualConfiguration
-      disabled: (value: any) => boolean
+      disabled: ((value: any) => boolean) | null
       options: T[]
     }
 
@@ -378,7 +378,7 @@ let reducers: {
     }
   },
   [ActionTypes.UpdateVirtualConfiguration]: (state, action) => {
-    if (state.virtual?.options === action.options) {
+    if (state.virtual?.options === action.options && state.virtual?.disabled === action.disabled) {
       return state
     }
 
@@ -395,7 +395,7 @@ let reducers: {
     return {
       ...state,
       activeOptionIndex: adjustedActiveOptionIndex,
-      virtual: { disabled: action.disabled, options: action.options },
+      virtual: { disabled: action.disabled ?? (() => false), options: action.options },
     }
   },
 }
@@ -754,7 +754,7 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
     if (!virtual) return
     dispatch({
       type: ActionTypes.UpdateVirtualConfiguration,
-      disabled: virtual.disabled ?? (() => false),
+      disabled: virtual.disabled ?? null,
       options: virtual.options,
     })
   }, [virtual, virtual?.options, virtual?.disabled])

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -182,8 +182,8 @@ type Actions<T> =
   | { type: ActionTypes.SetActivationTrigger; trigger: ActivationTrigger }
   | {
       type: ActionTypes.UpdateVirtualConfiguration
-      disabled: ((value: any) => boolean) | null
       options: T[]
+      disabled: ((value: any) => boolean) | null
     }
 
 let reducers: {
@@ -395,7 +395,7 @@ let reducers: {
     return {
       ...state,
       activeOptionIndex: adjustedActiveOptionIndex,
-      virtual: { disabled: action.disabled ?? (() => false), options: action.options },
+      virtual: { options: action.options, disabled: action.disabled ?? (() => false) },
     }
   },
 }
@@ -754,8 +754,8 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
     if (!virtual) return
     dispatch({
       type: ActionTypes.UpdateVirtualConfiguration,
-      disabled: virtual.disabled ?? null,
       options: virtual.options,
+      disabled: virtual.disabled ?? null,
     })
   }, [virtual, virtual?.options, virtual?.disabled])
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -245,7 +245,7 @@ let reducers: {
         action.focus === Focus.Specific
           ? action.idx
           : calculateActiveIndex(action, {
-              resolveItems: () => state.virtual!.options,
+              resolveItems: () => options,
               resolveActiveIndex: () =>
                 state.activeOptionIndex ?? options.findIndex((option) => !disabled(option)) ?? null,
               resolveDisabled: disabled,
@@ -377,7 +377,14 @@ let reducers: {
     }
   },
   [ActionTypes.UpdateVirtualConfiguration]: (state, action) => {
-    if (state.virtual?.options === action.options && state.virtual?.disabled === action.disabled) {
+    if (state.virtual === null) {
+      return {
+        ...state,
+        virtual: { options: action.options, disabled: action.disabled ?? (() => false) },
+      }
+    }
+
+    if (state.virtual.options === action.options && state.virtual.disabled === action.disabled) {
       return state
     }
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -243,7 +243,7 @@ let reducers: {
               resolveItems: () => state.virtual!.options,
               resolveActiveIndex: () =>
                 state.activeOptionIndex ??
-                state.virtual!.options.findIndex((option) => !state.virtual!.disabled(option)) ??
+                state.virtual?.options.findIndex((option) => !state.virtual?.disabled?.(option)) ??
                 null,
               resolveDisabled: state.virtual!.disabled,
               resolveId() {
@@ -391,7 +391,10 @@ let reducers: {
     return {
       ...state,
       activeOptionIndex: adjustedActiveOptionIndex,
-      virtual: Object.assign({}, state.virtual, { options: action.options }),
+      virtual:
+        state.virtual === null
+          ? { disabled: () => false, options: action.options }
+          : { ...state.virtual, options: action.options },
     }
   },
 }
@@ -710,7 +713,7 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
       defaultValue,
       disabled,
       mode: multiple ? ValueMode.Multi : ValueMode.Single,
-      virtual: state.virtual,
+      virtual: virtual ? state.virtual : null,
       get activeOptionIndex() {
         if (
           defaultToFirstOption.current &&
@@ -1757,7 +1760,7 @@ function OptionFn<
   let {
     id = `headlessui-combobox-option-${internalId}`,
     value,
-    disabled = data.virtual?.disabled(value) ?? false,
+    disabled = data.virtual?.disabled?.(value) ?? false,
     order = null,
     ...theirProps
   } = props


### PR DESCRIPTION
This PR fixes an issue where toggling between virtual and non-virtual mode would not correctly merge the `virtual` configuration and therefore it would crash the entire component.

This PR fixes that behavior and correctly switches to virtual mode. This also contains some internal refactors to clean things up related to `virtual` mode.

Fixes: #3235
