### PR TITLE
Use native `fieldset` instead of `div` by default for `<Fieldset />` component

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Mark `SwitchGroup` as deprecated, prefer `Field` instead ([#3232](https://github.com/tailwindlabs/headlessui/pull/3232))
 
+### Changed
+
+- Use native `fieldset` instead of `div` by default for `<Fieldset />` component ([#3237](https://github.com/tailwindlabs/headlessui/pull/3237))
+
 ## [2.0.3] - 2024-05-07
 
 ### Fixed

--- a/packages/@headlessui-react/src/components/field/field.test.tsx
+++ b/packages/@headlessui-react/src/components/field/field.test.tsx
@@ -55,7 +55,7 @@ describe('Rendering', () => {
     let fieldset = container.firstChild
     let field = fieldset?.firstChild
 
-    expect(fieldset).toHaveAttribute('aria-disabled', 'true')
+    expect(fieldset).toHaveAttribute('disabled')
     expect(field).toHaveAttribute('aria-disabled', 'true')
   })
 })

--- a/packages/@headlessui-react/src/components/fieldset/fieldset.test.tsx
+++ b/packages/@headlessui-react/src/components/fieldset/fieldset.test.tsx
@@ -22,6 +22,20 @@ describe('Rendering', () => {
 
     let fieldset = container.firstChild
 
+    expect(fieldset).toBeInstanceOf(HTMLFieldSetElement)
+    expect(fieldset).not.toHaveAttribute('role', 'group')
+  })
+
+  it('should render a `Fieldset` using a custom component', async () => {
+    let { container } = render(
+      <Fieldset as="span">
+        <input />
+      </Fieldset>
+    )
+
+    let fieldset = container.firstChild
+
+    expect(fieldset).toBeInstanceOf(HTMLSpanElement)
     expect(fieldset).toHaveAttribute('role', 'group')
   })
 
@@ -34,8 +48,19 @@ describe('Rendering', () => {
 
     let fieldset = container.firstChild
 
-    expect(fieldset).toHaveAttribute('role', 'group')
     expect(fieldset).toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('should make nested inputs disabled when the fieldset is disabled', async () => {
+    let { container } = render(
+      <Fieldset disabled>
+        <input />
+      </Fieldset>
+    )
+
+    let fieldset = container.firstChild
+
+    expect(fieldset?.firstChild).toBeDisabled()
   })
 
   it('should link a `Fieldset` to a nested `Legend`', async () => {

--- a/packages/@headlessui-react/src/components/fieldset/fieldset.test.tsx
+++ b/packages/@headlessui-react/src/components/fieldset/fieldset.test.tsx
@@ -39,9 +39,21 @@ describe('Rendering', () => {
     expect(fieldset).toHaveAttribute('role', 'group')
   })
 
-  it('should add an `aria-disabled` attribute when disabling the `Fieldset`', async () => {
+  it('should forward the `disabled` attribute when disabling the `Fieldset`', async () => {
     let { container } = render(
       <Fieldset disabled>
+        <input />
+      </Fieldset>
+    )
+
+    let fieldset = container.firstChild
+
+    expect(fieldset).toHaveAttribute('disabled')
+  })
+
+  it('should add an `aria-disabled` attribute when disabling the `Fieldset` when using another element via the `as` prop', async () => {
+    let { container } = render(
+      <Fieldset as="span" disabled>
         <input />
       </Fieldset>
     )

--- a/packages/@headlessui-react/src/components/fieldset/fieldset.tsx
+++ b/packages/@headlessui-react/src/components/fieldset/fieldset.tsx
@@ -35,20 +35,20 @@ function FieldsetFn<TTag extends ElementType = typeof DEFAULT_FIELDSET_TAG>(
   let [labelledBy, LabelProvider] = useLabels()
 
   let slot = useMemo(() => ({ disabled }) satisfies FieldsetRenderPropArg, [disabled])
-  let usesFieldset = tag === 'fieldset'
 
-  let ourProps = usesFieldset
-    ? {
-        ref: fieldsetRef,
-        'aria-labelledby': labelledBy,
-        disabled: disabled || undefined,
-      }
-    : {
-        ref: fieldsetRef,
-        role: 'group',
-        'aria-labelledby': labelledBy,
-        'aria-disabled': disabled || undefined,
-      }
+  let ourProps =
+    tag === 'fieldset'
+      ? {
+          ref: fieldsetRef,
+          'aria-labelledby': labelledBy,
+          disabled: disabled || undefined,
+        }
+      : {
+          ref: fieldsetRef,
+          role: 'group',
+          'aria-labelledby': labelledBy,
+          'aria-disabled': disabled || undefined,
+        }
 
   return (
     <DisabledProvider value={disabled}>

--- a/packages/@headlessui-react/src/components/fieldset/fieldset.tsx
+++ b/packages/@headlessui-react/src/components/fieldset/fieldset.tsx
@@ -33,7 +33,7 @@ function FieldsetFn<TTag extends ElementType = typeof DEFAULT_FIELDSET_TAG>(
 
   let ourProps = {
     ref,
-    role: 'group',
+    role: (props.as ?? DEFAULT_FIELDSET_TAG) === 'fieldset' ? undefined : 'group',
 
     'aria-labelledby': labelledBy,
     'aria-disabled': disabled || undefined,

--- a/packages/@headlessui-react/src/components/fieldset/fieldset.tsx
+++ b/packages/@headlessui-react/src/components/fieldset/fieldset.tsx
@@ -9,7 +9,7 @@ import { useLabels } from '../label/label'
 let DEFAULT_FIELDSET_TAG = 'div' as const
 
 type FieldsetRenderPropArg = {}
-type FieldsetPropsWeControl = 'aria-controls'
+type FieldsetPropsWeControl = 'aria-labelledby' | 'aria-disabled' | 'role'
 
 export type FieldsetProps<TTag extends ElementType = typeof DEFAULT_FIELDSET_TAG> = Props<
   TTag,

--- a/packages/@headlessui-react/src/components/fieldset/fieldset.tsx
+++ b/packages/@headlessui-react/src/components/fieldset/fieldset.tsx
@@ -6,7 +6,7 @@ import type { Props } from '../../types'
 import { forwardRefWithAs, render, type HasDisplayName } from '../../utils/render'
 import { useLabels } from '../label/label'
 
-let DEFAULT_FIELDSET_TAG = 'div' as const
+let DEFAULT_FIELDSET_TAG = 'fieldset' as const
 
 type FieldsetRenderPropArg = {}
 type FieldsetPropsWeControl = 'aria-labelledby' | 'aria-disabled' | 'role'

--- a/packages/@headlessui-react/src/components/fieldset/fieldset.tsx
+++ b/packages/@headlessui-react/src/components/fieldset/fieldset.tsx
@@ -30,15 +30,20 @@ function FieldsetFn<TTag extends ElementType = typeof DEFAULT_FIELDSET_TAG>(
   let [labelledBy, LabelProvider] = useLabels()
 
   let slot = useMemo(() => ({ disabled }) satisfies FieldsetRenderPropArg, [disabled])
+  let usesFieldset = (props.as ?? DEFAULT_FIELDSET_TAG) === 'fieldset'
 
-  let ourProps = {
-    ref,
-    role: (props.as ?? DEFAULT_FIELDSET_TAG) === 'fieldset' ? undefined : 'group',
-
-    'aria-labelledby': labelledBy,
-    'aria-disabled': disabled || undefined,
-    disabled: disabled || undefined,
-  }
+  let ourProps = usesFieldset
+    ? {
+        ref,
+        'aria-labelledby': labelledBy,
+        disabled: disabled || undefined,
+      }
+    : {
+        ref,
+        role: 'group',
+        'aria-labelledby': labelledBy,
+        'aria-disabled': disabled || undefined,
+      }
 
   return (
     <DisabledProvider value={disabled}>

--- a/packages/@headlessui-react/src/components/fieldset/fieldset.tsx
+++ b/packages/@headlessui-react/src/components/fieldset/fieldset.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import React, { useMemo, type ElementType, type Ref } from 'react'
+import { useResolvedTag } from '../../hooks/use-resolved-tag'
+import { useSyncRefs } from '../../hooks/use-sync-refs'
 import { DisabledProvider, useDisabled } from '../../internal/disabled'
 import type { Props } from '../../types'
 import { forwardRefWithAs, render, type HasDisplayName } from '../../utils/render'
@@ -27,19 +29,22 @@ function FieldsetFn<TTag extends ElementType = typeof DEFAULT_FIELDSET_TAG>(
   let providedDisabled = useDisabled()
   let { disabled = providedDisabled || false, ...theirProps } = props
 
+  let [tag, resolveTag] = useResolvedTag(props.as ?? DEFAULT_FIELDSET_TAG)
+  let fieldsetRef = useSyncRefs(ref, resolveTag)
+
   let [labelledBy, LabelProvider] = useLabels()
 
   let slot = useMemo(() => ({ disabled }) satisfies FieldsetRenderPropArg, [disabled])
-  let usesFieldset = (props.as ?? DEFAULT_FIELDSET_TAG) === 'fieldset'
+  let usesFieldset = tag === 'fieldset'
 
   let ourProps = usesFieldset
     ? {
-        ref,
+        ref: fieldsetRef,
         'aria-labelledby': labelledBy,
         disabled: disabled || undefined,
       }
     : {
-        ref,
+        ref: fieldsetRef,
         role: 'group',
         'aria-labelledby': labelledBy,
         'aria-disabled': disabled || undefined,

--- a/packages/@headlessui-react/src/components/fieldset/fieldset.tsx
+++ b/packages/@headlessui-react/src/components/fieldset/fieldset.tsx
@@ -37,6 +37,7 @@ function FieldsetFn<TTag extends ElementType = typeof DEFAULT_FIELDSET_TAG>(
 
     'aria-labelledby': labelledBy,
     'aria-disabled': disabled || undefined,
+    disabled: disabled || undefined,
   }
 
   return (

--- a/packages/@headlessui-react/src/hooks/use-resolved-tag.ts
+++ b/packages/@headlessui-react/src/hooks/use-resolved-tag.ts
@@ -1,0 +1,33 @@
+import { useCallback, useState } from 'react'
+
+/**
+ * Resolve the actual rendered tag of a DOM node. If the `tag` provided is
+ * already a string we can use that as-is. This will happen when the `as` prop is
+ * not used or when it's used with a string value.
+ *
+ * If an actual component is used, then we need to do some more work because
+ * then we actually need to render the component to know what the tag name is.
+ */
+export function useResolvedTag<T extends React.ElementType>(tag: T) {
+  let tagName = typeof tag === 'string' ? tag : undefined
+  let [resolvedTag, setResolvedTag] = useState<string | undefined>(tagName)
+
+  return [
+    // The resolved tag name
+    tagName ?? resolvedTag,
+
+    // This callback should be passed to the `ref` of a component
+    useCallback(
+      (ref: any) => {
+        // Tag name is already known and it's a string, no need to re-render
+        if (tagName) return
+
+        if (ref instanceof HTMLElement) {
+          // Tag name is not known yet, render the component to find out
+          setResolvedTag(ref.tagName.toLowerCase())
+        }
+      },
+      [tagName]
+    ),
+  ] as const
+}


### PR DESCRIPTION
This PR improves the default behavior of our `<Fieldset />` component.

Initially we used a `div` because `fieldset` / `legend` is hard to style otherwise. However, a fieldset on its own is still useful and has some benefits (such as disabling all native form elements if the `fieldset` itself is disabled).

We still setup an internal `DisabledProvider` such that our own components can read from this state and disable themselves accordingly.

This is technically a breaking change, but I doubt that anyone runs into this issue.

If so, you can apply the following diff to fix it:

```diff
- <Fieldset>
+ <Fieldset as="div">
    {/* … */}
  </Fieldset>
```

Note: if you were already using `disabled` on the `<Fieldset disabled>`, and you use `as="div"` then you won't have the default behavior where it disables these form elements.

---

Implementation looks a bit more complex, but essentially added new functionality to compute what the final `tagName` is of a component and based on this information we know which props to render. If a native `fieldset` is used, we can use the `disabled` prop, if another element is used we can render `aria-disabled` and a `role="group"`.

The new internal `useResolveTag` will compute the tag name, and it defaults to the `props.as` value.

