### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -798,10 +798,11 @@
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.0.4",
-      "license": "MIT",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.0.tgz",
+      "integrity": "sha512-lNzj5EQmEKn5FFKc04+zasr09h/uX8RtJRNj5gUXsSQIXHVWTVh+hVAg1vOMCexkX8EgvemMvIFpQfkosnVNyA==",
       "dependencies": {
-        "@floating-ui/dom": "^1.5.1"
+        "@floating-ui/dom": "^1.0.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1559,13 +1560,13 @@
       }
     },
     "node_modules/@react-aria/focus": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.16.2.tgz",
-      "integrity": "sha512-Rqo9ummmgotESfypzFjI3uh58yMpL+E+lJBbQuXkBM0u0cU2YYzu0uOrFrq3zcHk997udZvq1pGK/R+2xk9B7g==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.17.1.tgz",
+      "integrity": "sha512-FLTySoSNqX++u0nWZJPPN5etXY0WBxaIe/YuL/GTEeuqUIuC/2bJSaw5hlsM6T2yjy6Y/VAxBcKSdAFUlU6njQ==",
       "dependencies": {
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/interactions": "^3.21.3",
+        "@react-aria/utils": "^3.24.1",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0",
         "clsx": "^2.0.0"
       },
@@ -1574,13 +1575,13 @@
       }
     },
     "node_modules/@react-aria/interactions": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.21.1.tgz",
-      "integrity": "sha512-AlHf5SOzsShkHfV8GLLk3v9lEmYqYHURKcXWue0JdYbmquMRkUsf/+Tjl1+zHVAQ8lKqRnPYbTmc4AcZbqxltw==",
+      "version": "3.21.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.21.3.tgz",
+      "integrity": "sha512-BWIuf4qCs5FreDJ9AguawLVS0lV9UU+sK4CCnbCNNmYqOWY+1+gRXCsnOM32K+oMESBxilAjdHW5n1hsMqYMpA==",
       "dependencies": {
-        "@react-aria/ssr": "^3.9.2",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/ssr": "^3.9.4",
+        "@react-aria/utils": "^3.24.1",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
@@ -1588,9 +1589,9 @@
       }
     },
     "node_modules/@react-aria/ssr": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.2.tgz",
-      "integrity": "sha512-0gKkgDYdnq1w+ey8KzG9l+H5Z821qh9vVjztk55rUg71vTk/Eaebeir+WtzcLLwTjw3m/asIjx8Y59y1lJZhBw==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.4.tgz",
+      "integrity": "sha512-4jmAigVq409qcJvQyuorsmBR4+9r3+JEC60wC+Y0MZV0HCtTmm8D9guYXlJMdx0SSkgj0hHAyFm/HvPNFofCoQ==",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       },
@@ -1602,13 +1603,13 @@
       }
     },
     "node_modules/@react-aria/utils": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.23.2.tgz",
-      "integrity": "sha512-yznR9jJ0GG+YJvTMZxijQwVp+ahP66DY0apZf7X+dllyN+ByEDW+yaL1ewYPIpugxVzH5P8jhnBXsIyHKN411g==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.24.1.tgz",
+      "integrity": "sha512-O3s9qhPMd6n42x9sKeJ3lhu5V1Tlnzhu6Yk8QOvDuXf7UGuUjXf9mzfHJt1dYzID4l9Fwm8toczBzPM9t0jc8Q==",
       "dependencies": {
-        "@react-aria/ssr": "^3.9.2",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/ssr": "^3.9.4",
+        "@react-stately/utils": "^3.10.1",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0",
         "clsx": "^2.0.0"
       },
@@ -1617,9 +1618,9 @@
       }
     },
     "node_modules/@react-stately/utils": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.9.1.tgz",
-      "integrity": "sha512-yzw75GE0iUWiyps02BOAPTrybcsMIxEJlzXqtvllAb01O9uX5n0i3X+u2eCpj2UoDF4zS08Ps0jPgWxg8xEYtA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.1.tgz",
+      "integrity": "sha512-VS/EHRyicef25zDZcM/ClpzYMC5i2YGN6uegOeQawmgfGjb02yaCX0F0zR69Pod9m2Hr3wunTbtpgVXvYbZItg==",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       },
@@ -1628,9 +1629,9 @@
       }
     },
     "node_modules/@react-types/shared": {
-      "version": "3.22.1",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.22.1.tgz",
-      "integrity": "sha512-PCpa+Vo6BKnRMuOEzy5zAZ3/H5tnQg1e80khMhK2xys0j6ZqzkgQC+fHMNZ7VDFNLqqNMj/o0eVeSBDh2POjkw==",
+      "version": "3.23.1",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.23.1.tgz",
+      "integrity": "sha512-5d+3HbFDxGZjhbMBeFHRQhexMFt4pUce3okyRtUVKbbedQFUrtXSBg9VszgF2RTeQDKDkMCIQDtz5ccP/Lk1gw==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
@@ -1959,9 +1960,9 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "15.0.5",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-15.0.5.tgz",
-      "integrity": "sha512-ttodVWYA2i2w4hRa6krKrmS1vKxAEkwDz34y+CwbcrbZUxFzUYN3a5xZyFKo+K6LBseCRCUkwcjATpaNn/UsIA==",
+      "version": "15.0.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-15.0.7.tgz",
+      "integrity": "sha512-cg0RvEdD1TIhhkm1IeYMQxrzy0MtUNfa3minv4MjbgcYzJAZ7yD0i0lwoPOTPr+INtiXFezt2o8xMSnyHhEn2Q==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -1972,8 +1973,14 @@
         "node": ">=18"
       },
       "peerDependencies": {
+        "@types/react": "^18.0.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tootallnate/once": {
@@ -2267,9 +2274,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==",
+      "version": "18.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
+      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -10665,17 +10672,17 @@
     },
     "packages/@headlessui-react": {
       "name": "@headlessui/react",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/react": "^0.26.13",
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/interactions": "^3.21.1",
+        "@floating-ui/react": "^0.26.16",
+        "@react-aria/focus": "^3.17.1",
+        "@react-aria/interactions": "^3.21.3",
         "@tanstack/react-virtual": "3.5.0"
       },
       "devDependencies": {
-        "@testing-library/react": "^15.0.5",
-        "@types/react": "^18.3.1",
+        "@testing-library/react": "^15.0.7",
+        "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -10690,11 +10697,11 @@
       }
     },
     "packages/@headlessui-react/node_modules/@floating-ui/react": {
-      "version": "0.26.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.13.tgz",
-      "integrity": "sha512-kBa9wntpugzrZ8t/4yWelvSmEKZdeTXTJzrxqyrLmcU/n1SM4nvse8yQh2e1b37rJGvtu0EplV9+IkBrCJ1vkw==",
+      "version": "0.26.16",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.16.tgz",
+      "integrity": "sha512-HEf43zxZNAI/E781QIVpYSF3K2VH4TTYZpqecjdsFkjsaU1EbaWcM++kw0HXFffj7gDUcBFevX8s0rQGQpxkow==",
       "dependencies": {
-        "@floating-ui/react-dom": "^2.0.0",
+        "@floating-ui/react-dom": "^2.1.0",
         "@floating-ui/utils": "^0.2.0",
         "tabbable": "^6.0.0"
       },

--- a/packages/@headlessui-react/package.json
+++ b/packages/@headlessui-react/package.json
@@ -46,17 +46,17 @@
     "react-dom": "^18"
   },
   "devDependencies": {
-    "@testing-library/react": "^15.0.5",
-    "@types/react": "^18.3.1",
+    "@testing-library/react": "^15.0.7",
+    "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "snapshot-diff": "^0.10.0"
   },
   "dependencies": {
-    "@floating-ui/react": "^0.26.13",
+    "@floating-ui/react": "^0.26.16",
     "@tanstack/react-virtual": "3.5.0",
-    "@react-aria/focus": "^3.16.2",
-    "@react-aria/interactions": "^3.21.1"
+    "@react-aria/focus": "^3.17.1",
+    "@react-aria/interactions": "^3.21.3"
   }
 }


### PR DESCRIPTION
This PR bumps dependencies in `package.json` to the latest version.
This is technically not needed because all versions are within the range specified in `package.json`, but it also doesn't hurt.

Fixes: #3238

