### PR TITLE
Keep `<Combobox />` open when clicking in scrollbar on `<ComboboxOptions>`

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Keep `<Combobox />` open when clicking in scrollbar on `<ComboboxOptions>` ([#3249](https://github.com/tailwindlabs/headlessui/pull/3249))
+- Keep `<Combobox />` open when clicking scrollbar in `<ComboboxOptions>` ([#3249](https://github.com/tailwindlabs/headlessui/pull/3249))
 
 ## [2.0.4] - 2024-05-25
 

--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add ability to render multiple `<Dialog />` components at once (without nesting them) ([#3242](https://github.com/tailwindlabs/headlessui/pull/3242))
 
+### Fixed
+
+- Keep `<Combobox />` open when clicking in scrollbar on `<ComboboxOptions>` ([#3249](https://github.com/tailwindlabs/headlessui/pull/3249))
+
 ## [2.0.4] - 2024-05-25
 
 ### Fixed

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1676,6 +1676,18 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
     actions.setActivationTrigger(ActivationTrigger.Pointer)
   })
 
+  // When clicking inside of the scrollbar then a `click` will be triggered on
+  // the focusable element _below_ the scrollbar. If you use a `<Combobox>`
+  // inside of a `<Dialog>`, then clicking in the scrollbar of the
+  // `<ComboboxOptions>` will move focus to the `<Dialog>` which blurs the
+  // `<ComboboxInput>` which closes the `<Combobox>`.
+  //
+  // Preventing this default behavior in the `mousedown` event (which happens
+  // before `click`) will prevent this issue because the `click` never fires.
+  let handleMouseDown = useEvent((event: ReactMouseEvent) => {
+    event.preventDefault()
+  })
+
   let ourProps = mergeProps(anchor ? getFloatingPanelProps() : {}, {
     'aria-labelledby': labelledBy,
     role: 'listbox',
@@ -1688,6 +1700,7 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
       '--button-width': useElementSize(data.buttonRef, true).width,
     } as CSSProperties,
     onWheel: handleWheel,
+    onMouseDown: handleMouseDown,
   })
 
   // Map the children in a scrollable container when virtualization is enabled

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1676,13 +1676,13 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
     actions.setActivationTrigger(ActivationTrigger.Pointer)
   })
 
-  // When clicking inside of the scrollbar then a `click` will be triggered on
+  // When clicking inside of the scrollbar, a `click` event will be triggered on
   // the focusable element _below_ the scrollbar. If you use a `<Combobox>`
-  // inside of a `<Dialog>`, then clicking in the scrollbar of the
+  // inside of a `<Dialog>`, clicking the scrollbar of the
   // `<ComboboxOptions>` will move focus to the `<Dialog>` which blurs the
-  // `<ComboboxInput>` which closes the `<Combobox>`.
+  // `<ComboboxInput>` and closes the `<Combobox>`.
   //
-  // Preventing this default behavior in the `mousedown` event (which happens
+  // Preventing the default behavior in the `mousedown` event (which happens
   // before `click`) will prevent this issue because the `click` never fires.
   let handleMouseDown = useEvent((event: ReactMouseEvent) => {
     event.preventDefault()

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1678,9 +1678,9 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
 
   // When clicking inside of the scrollbar, a `click` event will be triggered on
   // the focusable element _below_ the scrollbar. If you use a `<Combobox>`
-  // inside of a `<Dialog>`, clicking the scrollbar of the
-  // `<ComboboxOptions>` will move focus to the `<Dialog>` which blurs the
-  // `<ComboboxInput>` and closes the `<Combobox>`.
+  // inside of a `<Dialog>`, clicking the scrollbar of the `<ComboboxOptions>`
+  // will move focus to the `<Dialog>` which blurs the `<ComboboxInput>` and
+  // closes the `<Combobox>`.
   //
   // Preventing the default behavior in the `mousedown` event (which happens
   // before `click`) will prevent this issue because the `click` never fires.


### PR DESCRIPTION
This PR fixes an issue where a `<Combobox>` would close if you click inside the scrollbar area on the `<ComboboxOptions>`. This is because clicking inside the scrollbar area performs a click on the element below the scrollbar (at least on macOS). If the element below is focusable, then focus will be moved there.

If focus is moved to the underlying element, then the `<ComboboxInput>` will blur which causes the `<Combobox>` will close.

This issue can be seen in #3230 where using the `<Combobox>` inside the `<Dialog>` then clicking in the scrollbar area of the `<ComboboxOptions>` will move the focus to the `<Dialog>` itself and closes the `<Combobox>`.

Fixes: #3230

