### PR TITLE
Use `useId` instead of React internals

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Merge incoming `style` prop on `ComboboxOptions`, `ListboxOptions`, `MenuItems`, and `PopoverPanel` components ([#3250](https://github.com/tailwindlabs/headlessui/pull/3250))
 - Prevent focus on `<Checkbox />` when it is `disabled` ([#3251](https://github.com/tailwindlabs/headlessui/pull/3251))
 - Fix visual jitter in `Combobox` component when using native scrollbar ([#3190](https://github.com/tailwindlabs/headlessui/pull/3190))
+- Use `useId` instead of React internals (for React 19 compatibility) ([#3254](https://github.com/tailwindlabs/headlessui/pull/3254))
 
 ## [2.0.4] - 2024-05-25
 

--- a/packages/@headlessui-react/src/utils/stable-collection.tsx
+++ b/packages/@headlessui-react/src/utils/stable-collection.tsx
@@ -51,15 +51,8 @@ export function useStableCollectionIndex(group: string) {
   let collection = React.useContext(StableCollectionContext)
   if (!collection) throw new Error('You must wrap your component in a <StableCollection>')
 
-  let key = useStableCollectionKey()
+  let key = React.useId()
   let [idx, cleanupIdx] = collection.current.get(group, key)
   React.useEffect(() => cleanupIdx, [])
   return idx
-}
-
-/**
- * Return a stable key based on the position of this node.
- */
-function useStableCollectionKey(): string {
-  return React.useId()
 }

--- a/packages/@headlessui-react/src/utils/stable-collection.tsx
+++ b/packages/@headlessui-react/src/utils/stable-collection.tsx
@@ -18,8 +18,9 @@ function createCollection() {
       }
 
       let renders = list.get(key) ?? 0
-      // FIXME: This is a side-effect during render.
-      // `release` is only called in an effect cleanup so we may never release if we had to render multiple times before commit e.g. when a sibling suspends.
+      // FIXME: This is a side-effect during render. `release` is only called in
+      // an effect cleanup so we may never release if we had to render multiple
+      // times before commit e.g. when a sibling suspends.
       list.set(key, renders + 1)
 
       let index = Array.from(list.keys()).indexOf(key)

--- a/packages/@headlessui-react/src/utils/stable-collection.tsx
+++ b/packages/@headlessui-react/src/utils/stable-collection.tsx
@@ -18,6 +18,8 @@ function createCollection() {
       }
 
       let renders = list.get(key) ?? 0
+      // FIXME: This is a side-effect during render.
+      // `release` is only called in an effect cleanup so we may never release if we had to render multiple times before commit e.g. when a sibling suspends.
       list.set(key, renders + 1)
 
       let index = Array.from(list.keys()).indexOf(key)
@@ -57,25 +59,7 @@ export function useStableCollectionIndex(group: string) {
 
 /**
  * Return a stable key based on the position of this node.
- *
- * @returns {symbol | string}
  */
-function useStableCollectionKey() {
-  let owner =
-    // @ts-ignore
-    React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED?.ReactCurrentOwner?.current ?? null
-
-  // ssr: dev/prod
-  // client: prod
-  if (!owner) return Symbol()
-
-  // client: dev
-  let indexes = []
-  let fiber = owner
-  while (fiber) {
-    indexes.push(fiber.index)
-    fiber = fiber.return
-  }
-
-  return '$.' + indexes.join('.')
+function useStableCollectionKey(): string {
+  return React.useId()
 }


### PR DESCRIPTION
These may break in any React release which may result in blocking the ecosystem from seemlessly upgrading to new React releases.

We can use `useId` instead which is available since React 18.

Keep in mind that the whole hook is not safe in concurrent rendering. It increments `render` during render but only decrements in an effect cleanup. React may render multiple times before actually committing. The keys would leak in those scenarios (e.g. when a sibling suspends).

Closes https://github.com/tailwindlabs/headlessui/issues/3167