### PR TITLE
Internal refactor: use `flushSync()` instead of `d.nextFrame()`

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1190,9 +1190,7 @@ function InputFn<
         return match(data.comboboxState, {
           [ComboboxState.Open]: () => actions.goToOption(Focus.Previous),
           [ComboboxState.Closed]: () => {
-            flushSync(() => {
-              actions.openCombobox()
-            })
+            flushSync(() => actions.openCombobox())
             if (!data.value) actions.goToOption(Focus.Last)
           },
         })
@@ -1319,9 +1317,7 @@ function InputFn<
     if (!data.immediate) return
     if (data.comboboxState === ComboboxState.Open) return
 
-    flushSync(() => {
-      actions.openCombobox()
-    })
+    flushSync(() => actions.openCombobox())
 
     // We need to make sure that tabbing through a form doesn't result in incorrectly setting the
     // value of the combobox. We will set the activation trigger to `Focus`, and we will ignore
@@ -1450,9 +1446,7 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
         event.preventDefault()
         event.stopPropagation()
         if (data.comboboxState === ComboboxState.Closed) {
-          flushSync(() => {
-            actions.openCombobox()
-          })
+          flushSync(() => actions.openCombobox())
         }
         refocusInput()
         return
@@ -1461,9 +1455,7 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
         event.preventDefault()
         event.stopPropagation()
         if (data.comboboxState === ComboboxState.Closed) {
-          flushSync(() => {
-            actions.openCombobox()
-          })
+          flushSync(() => actions.openCombobox())
           if (!data.value) actions.goToOption(Focus.First)
         }
         refocusInput()
@@ -1473,9 +1465,7 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
         event.preventDefault()
         event.stopPropagation()
         if (data.comboboxState === ComboboxState.Closed) {
-          flushSync(() => {
-            actions.openCombobox()
-          })
+          flushSync(() => actions.openCombobox())
           if (!data.value) actions.goToOption(Focus.Last)
         }
         refocusInput()
@@ -1487,9 +1477,7 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
         if (data.optionsRef.current && !data.optionsPropsRef.current.static) {
           event.stopPropagation()
         }
-        flushSync(() => {
-          actions.closeCombobox()
-        })
+        flushSync(() => actions.closeCombobox())
         refocusInput()
         return
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1193,10 +1193,7 @@ function InputFn<
             flushSync(() => {
               actions.openCombobox()
             })
-
-            if (!data.value) {
-              actions.goToOption(Focus.Last)
-            }
+            if (!data.value) actions.goToOption(Focus.Last)
           },
         })
 
@@ -1467,9 +1464,7 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
           flushSync(() => {
             actions.openCombobox()
           })
-          if (!data.value) {
-            actions.goToOption(Focus.First)
-          }
+          if (!data.value) actions.goToOption(Focus.First)
         }
         refocusInput()
         return
@@ -1481,9 +1476,7 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
           flushSync(() => {
             actions.openCombobox()
           })
-          if (!data.value) {
-            actions.goToOption(Focus.Last)
-          }
+          if (!data.value) actions.goToOption(Focus.Last)
         }
         refocusInput()
         return

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -20,6 +20,7 @@ import React, {
   type MouseEvent as ReactMouseEvent,
   type Ref,
 } from 'react'
+import { flushSync } from 'react-dom'
 import { useActivePress } from '../../hooks/use-active-press'
 import { useByComparator, type ByComparator } from '../../hooks/use-by-comparator'
 import { useComputed } from '../../hooks/use-computed'
@@ -755,8 +756,6 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
   let buttonRef = useSyncRefs(data.buttonRef, ref, useFloatingReference())
   let getFloatingReferenceProps = useFloatingReferenceProps()
 
-  let d = useDisposables()
-
   let handleKeyDown = useEvent((event: ReactKeyboardEvent<HTMLButtonElement>) => {
     switch (event.key) {
       // Ref: https://www.w3.org/WAI/ARIA/apg/patterns/menubutton/#keyboard-interaction-13
@@ -768,18 +767,18 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
       case Keys.Space:
       case Keys.ArrowDown:
         event.preventDefault()
-        actions.openListbox()
-        d.nextFrame(() => {
-          if (!data.value) actions.goToOption(Focus.First)
+        flushSync(() => {
+          actions.openListbox()
         })
+        if (!data.value) actions.goToOption(Focus.First)
         break
 
       case Keys.ArrowUp:
         event.preventDefault()
-        actions.openListbox()
-        d.nextFrame(() => {
-          if (!data.value) actions.goToOption(Focus.Last)
+        flushSync(() => {
+          actions.openListbox()
         })
+        if (!data.value) actions.goToOption(Focus.Last)
         break
     }
   })
@@ -798,8 +797,10 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
   let handleClick = useEvent((event: ReactMouseEvent) => {
     if (isDisabledReactIssue7711(event.currentTarget)) return event.preventDefault()
     if (data.listboxState === ListboxStates.Open) {
-      actions.closeListbox()
-      d.nextFrame(() => data.buttonRef.current?.focus({ preventScroll: true }))
+      flushSync(() => {
+        actions.closeListbox()
+      })
+      data.buttonRef.current?.focus({ preventScroll: true })
     } else {
       event.preventDefault()
       actions.openListbox()
@@ -995,7 +996,6 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
   let getFloatingPanelProps = useFloatingPanelProps()
   let optionsRef = useSyncRefs(data.optionsRef, ref, anchor ? floatingRef : null)
 
-  let d = useDisposables()
   let searchDisposables = useDisposables()
 
   useEffect(() => {
@@ -1030,8 +1030,10 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
           actions.onChange(dataRef.current.value)
         }
         if (data.mode === ValueMode.Single) {
-          actions.closeListbox()
-          disposables().nextFrame(() => data.buttonRef.current?.focus({ preventScroll: true }))
+          flushSync(() => {
+            actions.closeListbox()
+          })
+          data.buttonRef.current?.focus({ preventScroll: true })
         }
         break
 
@@ -1060,8 +1062,11 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
       case Keys.Escape:
         event.preventDefault()
         event.stopPropagation()
-        actions.closeListbox()
-        return d.nextFrame(() => data.buttonRef.current?.focus({ preventScroll: true }))
+        flushSync(() => {
+          actions.closeListbox()
+        })
+        data.buttonRef.current?.focus({ preventScroll: true })
+        return
 
       case Keys.Tab:
         event.preventDefault()
@@ -1228,8 +1233,10 @@ function OptionFn<
     if (disabled) return event.preventDefault()
     actions.onChange(value)
     if (data.mode === ValueMode.Single) {
-      actions.closeListbox()
-      disposables().nextFrame(() => data.buttonRef.current?.focus({ preventScroll: true }))
+      flushSync(() => {
+        actions.closeListbox()
+      })
+      data.buttonRef.current?.focus({ preventScroll: true })
     }
   })
 

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -1210,11 +1210,9 @@ function OptionFn<
     if (data.listboxState !== ListboxStates.Open) return
     if (!active) return
     if (data.activationTrigger === ActivationTrigger.Pointer) return
-    let d = disposables()
-    d.requestAnimationFrame(() => {
+    return disposables().requestAnimationFrame(() => {
       internalOptionRef.current?.scrollIntoView?.({ block: 'nearest' })
     })
-    return d.dispose
   }, [
     internalOptionRef,
     active,

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -767,17 +767,13 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
       case Keys.Space:
       case Keys.ArrowDown:
         event.preventDefault()
-        flushSync(() => {
-          actions.openListbox()
-        })
+        flushSync(() => actions.openListbox())
         if (!data.value) actions.goToOption(Focus.First)
         break
 
       case Keys.ArrowUp:
         event.preventDefault()
-        flushSync(() => {
-          actions.openListbox()
-        })
+        flushSync(() => actions.openListbox())
         if (!data.value) actions.goToOption(Focus.Last)
         break
     }
@@ -797,9 +793,7 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
   let handleClick = useEvent((event: ReactMouseEvent) => {
     if (isDisabledReactIssue7711(event.currentTarget)) return event.preventDefault()
     if (data.listboxState === ListboxStates.Open) {
-      flushSync(() => {
-        actions.closeListbox()
-      })
+      flushSync(() => actions.closeListbox())
       data.buttonRef.current?.focus({ preventScroll: true })
     } else {
       event.preventDefault()
@@ -1030,9 +1024,7 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
           actions.onChange(dataRef.current.value)
         }
         if (data.mode === ValueMode.Single) {
-          flushSync(() => {
-            actions.closeListbox()
-          })
+          flushSync(() => actions.closeListbox())
           data.buttonRef.current?.focus({ preventScroll: true })
         }
         break
@@ -1062,9 +1054,7 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
       case Keys.Escape:
         event.preventDefault()
         event.stopPropagation()
-        flushSync(() => {
-          actions.closeListbox()
-        })
+        flushSync(() => actions.closeListbox())
         data.buttonRef.current?.focus({ preventScroll: true })
         return
 
@@ -1231,9 +1221,7 @@ function OptionFn<
     if (disabled) return event.preventDefault()
     actions.onChange(value)
     if (data.mode === ValueMode.Single) {
-      flushSync(() => {
-        actions.closeListbox()
-      })
+      flushSync(() => actions.closeListbox())
       data.buttonRef.current?.focus({ preventScroll: true })
     }
   })

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -844,11 +844,9 @@ function ItemFn<TTag extends ElementType = typeof DEFAULT_ITEM_TAG>(
     if (state.menuState !== MenuStates.Open) return
     if (!active) return
     if (state.activationTrigger === ActivationTrigger.Pointer) return
-    let d = disposables()
-    d.requestAnimationFrame(() => {
+    return disposables().requestAnimationFrame(() => {
       internalItemRef.current?.scrollIntoView?.({ block: 'nearest' })
     })
-    return d.dispose
   }, [
     state.__demoMode,
     internalItemRef,

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -20,6 +20,7 @@ import React, {
   type MouseEvent as ReactMouseEvent,
   type Ref,
 } from 'react'
+import { flushSync } from 'react-dom'
 import { useActivePress } from '../../hooks/use-active-press'
 import { useDidElementMove } from '../../hooks/use-did-element-move'
 import { useDisposables } from '../../hooks/use-disposables'
@@ -469,8 +470,6 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
   let getFloatingReferenceProps = useFloatingReferenceProps()
   let buttonRef = useSyncRefs(state.buttonRef, ref, useFloatingReference())
 
-  let d = useDisposables()
-
   let handleKeyDown = useEvent((event: ReactKeyboardEvent<HTMLButtonElement>) => {
     switch (event.key) {
       // Ref: https://www.w3.org/WAI/ARIA/apg/patterns/menubutton/#keyboard-interaction-13
@@ -480,15 +479,19 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
       case Keys.ArrowDown:
         event.preventDefault()
         event.stopPropagation()
-        dispatch({ type: ActionTypes.OpenMenu })
-        d.nextFrame(() => dispatch({ type: ActionTypes.GoToItem, focus: Focus.First }))
+        flushSync(() => {
+          dispatch({ type: ActionTypes.OpenMenu })
+        })
+        dispatch({ type: ActionTypes.GoToItem, focus: Focus.First })
         break
 
       case Keys.ArrowUp:
         event.preventDefault()
         event.stopPropagation()
-        dispatch({ type: ActionTypes.OpenMenu })
-        d.nextFrame(() => dispatch({ type: ActionTypes.GoToItem, focus: Focus.Last }))
+        flushSync(() => {
+          dispatch({ type: ActionTypes.OpenMenu })
+        })
+        dispatch({ type: ActionTypes.GoToItem, focus: Focus.Last })
         break
     }
   })
@@ -508,8 +511,10 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
     if (isDisabledReactIssue7711(event.currentTarget)) return event.preventDefault()
     if (disabled) return
     if (state.menuState === MenuStates.Open) {
-      dispatch({ type: ActionTypes.CloseMenu })
-      d.nextFrame(() => state.buttonRef.current?.focus({ preventScroll: true }))
+      flushSync(() => {
+        dispatch({ type: ActionTypes.CloseMenu })
+      })
+      state.buttonRef.current?.focus({ preventScroll: true })
     } else {
       event.preventDefault()
       dispatch({ type: ActionTypes.OpenMenu })
@@ -722,20 +727,22 @@ function ItemsFn<TTag extends ElementType = typeof DEFAULT_ITEMS_TAG>(
       case Keys.Escape:
         event.preventDefault()
         event.stopPropagation()
-        dispatch({ type: ActionTypes.CloseMenu })
-        disposables().nextFrame(() => state.buttonRef.current?.focus({ preventScroll: true }))
+        flushSync(() => {
+          dispatch({ type: ActionTypes.CloseMenu })
+        })
+        state.buttonRef.current?.focus({ preventScroll: true })
         break
 
       case Keys.Tab:
         event.preventDefault()
         event.stopPropagation()
-        dispatch({ type: ActionTypes.CloseMenu })
-        disposables().microTask(() => {
-          focusFrom(
-            state.buttonRef.current!,
-            event.shiftKey ? FocusManagementFocus.Previous : FocusManagementFocus.Next
-          )
+        flushSync(() => {
+          dispatch({ type: ActionTypes.CloseMenu })
         })
+        focusFrom(
+          state.buttonRef.current!,
+          event.shiftKey ? FocusManagementFocus.Previous : FocusManagementFocus.Next
+        )
         break
 
       default:

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -479,18 +479,14 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
       case Keys.ArrowDown:
         event.preventDefault()
         event.stopPropagation()
-        flushSync(() => {
-          dispatch({ type: ActionTypes.OpenMenu })
-        })
+        flushSync(() => dispatch({ type: ActionTypes.OpenMenu }))
         dispatch({ type: ActionTypes.GoToItem, focus: Focus.First })
         break
 
       case Keys.ArrowUp:
         event.preventDefault()
         event.stopPropagation()
-        flushSync(() => {
-          dispatch({ type: ActionTypes.OpenMenu })
-        })
+        flushSync(() => dispatch({ type: ActionTypes.OpenMenu }))
         dispatch({ type: ActionTypes.GoToItem, focus: Focus.Last })
         break
     }
@@ -511,9 +507,7 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
     if (isDisabledReactIssue7711(event.currentTarget)) return event.preventDefault()
     if (disabled) return
     if (state.menuState === MenuStates.Open) {
-      flushSync(() => {
-        dispatch({ type: ActionTypes.CloseMenu })
-      })
+      flushSync(() => dispatch({ type: ActionTypes.CloseMenu }))
       state.buttonRef.current?.focus({ preventScroll: true })
     } else {
       event.preventDefault()
@@ -727,18 +721,14 @@ function ItemsFn<TTag extends ElementType = typeof DEFAULT_ITEMS_TAG>(
       case Keys.Escape:
         event.preventDefault()
         event.stopPropagation()
-        flushSync(() => {
-          dispatch({ type: ActionTypes.CloseMenu })
-        })
+        flushSync(() => dispatch({ type: ActionTypes.CloseMenu }))
         state.buttonRef.current?.focus({ preventScroll: true })
         break
 
       case Keys.Tab:
         event.preventDefault()
         event.stopPropagation()
-        flushSync(() => {
-          dispatch({ type: ActionTypes.CloseMenu })
-        })
+        flushSync(() => dispatch({ type: ActionTypes.CloseMenu }))
         focusFrom(
           state.buttonRef.current!,
           event.shiftKey ? FocusManagementFocus.Previous : FocusManagementFocus.Next


### PR DESCRIPTION
This PR improves some internals by using `flushSync()` instead of our `d.nextFrame()` calls.

The benefit is that `flushSync()` guarantees that the DOM is updated after this call finishes. This means that we don't have to schedule a callback in the future and _hope_ that the DOM is updated by that time.
