### PR TITLE
Introduce CSS based transitions

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add ability to render multiple `<Dialog />` components at once (without nesting them) ([#3242](https://github.com/tailwindlabs/headlessui/pull/3242))
+- Add CSS based transitions using `data-*` attributes ([#3273](https://github.com/tailwindlabs/headlessui/pull/3273))
 
 ### Fixed
 

--- a/packages/@headlessui-react/src/components/disclosure/disclosure.tsx
+++ b/packages/@headlessui-react/src/components/disclosure/disclosure.tsx
@@ -24,6 +24,7 @@ import { useEvent } from '../../hooks/use-event'
 import { useId } from '../../hooks/use-id'
 import { useResolveButtonType } from '../../hooks/use-resolve-button-type'
 import { optionalRef, useSyncRefs } from '../../hooks/use-sync-refs'
+import { useTransitionData, type TransitionData } from '../../hooks/use-transition-data'
 import { CloseProvider } from '../../internal/close-provider'
 import { OpenClosedProvider, State, useOpenClosed } from '../../internal/open-closed'
 import type { Props } from '../../types'
@@ -419,7 +420,7 @@ let DEFAULT_PANEL_TAG = 'div' as const
 type PanelRenderPropArg = {
   open: boolean
   close: (focusableElement?: HTMLElement | MutableRefObject<HTMLElement | null>) => void
-}
+} & TransitionData
 type DisclosurePanelPropsWeControl = never
 
 let PanelRenderFeatures = RenderFeatures.RenderStrategy | RenderFeatures.Static
@@ -428,7 +429,7 @@ export type DisclosurePanelProps<TTag extends ElementType = typeof DEFAULT_PANEL
   TTag,
   PanelRenderPropArg,
   DisclosurePanelPropsWeControl,
-  PropsForFeatures<typeof PanelRenderFeatures>
+  { transition?: boolean } & PropsForFeatures<typeof PanelRenderFeatures>
 >
 
 function PanelFn<TTag extends ElementType = typeof DEFAULT_PANEL_TAG>(
@@ -436,7 +437,11 @@ function PanelFn<TTag extends ElementType = typeof DEFAULT_PANEL_TAG>(
   ref: Ref<HTMLElement>
 ) {
   let internalId = useId()
-  let { id = `headlessui-disclosure-panel-${internalId}`, ...theirProps } = props
+  let {
+    id = `headlessui-disclosure-panel-${internalId}`,
+    transition = false,
+    ...theirProps
+  } = props
   let [state, dispatch] = useDisclosureContext('Disclosure.Panel')
   let { close } = useDisclosureAPIContext('Disclosure.Panel')
   let mergeRefs = useMergeRefsFn()
@@ -453,20 +458,21 @@ function PanelFn<TTag extends ElementType = typeof DEFAULT_PANEL_TAG>(
   }, [id, dispatch])
 
   let usesOpenClosedState = useOpenClosed()
-  let visible = (() => {
-    if (usesOpenClosedState !== null) {
-      return (usesOpenClosedState & State.Open) === State.Open
-    }
-
-    return state.disclosureState === DisclosureStates.Open
-  })()
+  let [visible, transitionData] = useTransitionData(
+    transition,
+    state.panelRef,
+    usesOpenClosedState !== null
+      ? (usesOpenClosedState & State.Open) === State.Open
+      : state.disclosureState === DisclosureStates.Open
+  )
 
   let slot = useMemo(() => {
     return {
       open: state.disclosureState === DisclosureStates.Open,
       close,
+      ...transitionData,
     } satisfies PanelRenderPropArg
-  }, [state, close])
+  }, [state.disclosureState, close, transitionData])
 
   let ourProps = {
     ref: panelRef,

--- a/packages/@headlessui-react/src/components/transition/__snapshots__/transition.test.tsx.snap
+++ b/packages/@headlessui-react/src/components/transition/__snapshots__/transition.test.tsx.snap
@@ -4,11 +4,29 @@ exports[`Setup API nested should be possible to change the underlying DOM tag of
 <div
   class="My Page"
 >
-  <article>
-    <aside>
+  <article
+    data-enter=""
+    data-from=""
+    data-headlessui-state="from enter transition"
+    data-transition=""
+    style=""
+  >
+    <aside
+      data-enter=""
+      data-from=""
+      data-headlessui-state="from enter transition"
+      data-transition=""
+      style=""
+    >
       Sidebar
     </aside>
-    <section>
+    <section
+      data-enter=""
+      data-from=""
+      data-headlessui-state="from enter transition"
+      data-transition=""
+      style=""
+    >
       Content
     </section>
   </article>
@@ -19,11 +37,29 @@ exports[`Setup API nested should be possible to change the underlying DOM tag of
 <div
   class="My Page"
 >
-  <div>
-    <aside>
+  <div
+    data-enter=""
+    data-from=""
+    data-headlessui-state="from enter transition"
+    data-transition=""
+    style=""
+  >
+    <aside
+      data-enter=""
+      data-from=""
+      data-headlessui-state="from enter transition"
+      data-transition=""
+      style=""
+    >
       Sidebar
     </aside>
-    <section>
+    <section
+      data-enter=""
+      data-from=""
+      data-headlessui-state="from enter transition"
+      data-transition=""
+      style=""
+    >
       Content
     </section>
   </div>
@@ -34,11 +70,29 @@ exports[`Setup API nested should be possible to nest transition components 1`] =
 <div
   class="My Page"
 >
-  <div>
-    <div>
+  <div
+    data-enter=""
+    data-from=""
+    data-headlessui-state="from enter transition"
+    data-transition=""
+    style=""
+  >
+    <div
+      data-enter=""
+      data-from=""
+      data-headlessui-state="from enter transition"
+      data-transition=""
+      style=""
+    >
       Sidebar
     </div>
-    <div>
+    <div
+      data-enter=""
+      data-from=""
+      data-headlessui-state="from enter transition"
+      data-transition=""
+      style=""
+    >
       Content
     </div>
   </div>
@@ -49,11 +103,26 @@ exports[`Setup API nested should be possible to use render props on the Transiti
 <div
   class="My Page"
 >
-  <article>
-    <aside>
+  <article
+    data-enter=""
+    data-from=""
+    data-headlessui-state="from enter transition"
+    data-transition=""
+  >
+    <aside
+      data-enter=""
+      data-from=""
+      data-headlessui-state="from enter transition"
+      data-transition=""
+    >
       Sidebar
     </aside>
-    <section>
+    <section
+      data-enter=""
+      data-from=""
+      data-headlessui-state="from enter transition"
+      data-transition=""
+    >
       Content
     </section>
   </article>
@@ -64,11 +133,27 @@ exports[`Setup API nested should be possible to use render props on the Transiti
 <div
   class="My Page"
 >
-  <div>
-    <aside>
+  <div
+    data-enter=""
+    data-from=""
+    data-headlessui-state="from enter transition"
+    data-transition=""
+    style=""
+  >
+    <aside
+      data-enter=""
+      data-from=""
+      data-headlessui-state="from enter transition"
+      data-transition=""
+    >
       Sidebar
     </aside>
-    <section>
+    <section
+      data-enter=""
+      data-from=""
+      data-headlessui-state="from enter transition"
+      data-transition=""
+    >
       Content
     </section>
   </div>
@@ -82,13 +167,24 @@ exports[`Setup API nested should yell at us when we forgot to forward a ref on t
 exports[`Setup API nested should yell at us when we forgot to forward the ref on one of the Transition.Child components 1`] = `"Did you forget to passthrough the \`ref\` to the actual DOM node?"`;
 
 exports[`Setup API shallow should be possible to change the underlying DOM tag 1`] = `
-<span>
+<span
+  data-enter=""
+  data-from=""
+  data-headlessui-state="from enter transition"
+  data-transition=""
+  style=""
+>
   Children
 </span>
 `;
 
 exports[`Setup API shallow should be possible to use a render prop 1`] = `
-<span>
+<span
+  data-enter=""
+  data-from=""
+  data-headlessui-state="from enter transition"
+  data-transition=""
+>
   Children
 </span>
 `;
@@ -96,7 +192,12 @@ exports[`Setup API shallow should be possible to use a render prop 1`] = `
 exports[`Setup API shallow should passthrough all the props (that we do not use internally) 1`] = `
 <div
   class="text-blue-400"
+  data-enter=""
+  data-from=""
+  data-headlessui-state="from enter transition"
+  data-transition=""
   id="root"
+  style=""
 >
   Children
 </div>
@@ -105,14 +206,25 @@ exports[`Setup API shallow should passthrough all the props (that we do not use 
 exports[`Setup API shallow should passthrough all the props (that we do not use internally) even when using an \`as\` prop 1`] = `
 <a
   class="text-blue-400"
+  data-enter=""
+  data-from=""
+  data-headlessui-state="from enter transition"
+  data-transition=""
   href="/"
+  style=""
 >
   Children
 </a>
 `;
 
 exports[`Setup API shallow should render another component if the \`as\` prop is used and its children by default 1`] = `
-<a>
+<a
+  data-enter=""
+  data-from=""
+  data-headlessui-state="from enter transition"
+  data-transition=""
+  style=""
+>
   Children
 </a>
 `;
@@ -122,7 +234,13 @@ exports[`Setup API shallow should render nothing when the show prop is false 1`]
 exports[`Setup API shallow should yell at us when we forget to forward the ref when using a render prop 1`] = `"Did you forget to passthrough the \`ref\` to the actual DOM node?"`;
 
 exports[`Setup API transition classes should be possible to passthrough the transition classes 1`] = `
-<div>
+<div
+  data-enter=""
+  data-from=""
+  data-headlessui-state="from enter transition"
+  data-transition=""
+  style=""
+>
   Children
 </div>
 `;
@@ -130,6 +248,8 @@ exports[`Setup API transition classes should be possible to passthrough the tran
 exports[`Setup API transition classes should be possible to passthrough the transition classes and immediately apply the enter transitions when appear is set to true 1`] = `
 <div
   class="enter enter-from"
+  data-from=""
+  data-headlessui-state="from"
   style=""
 >
   Children

--- a/packages/@headlessui-react/src/components/transition/transition.test.tsx
+++ b/packages/@headlessui-react/src/components/transition/transition.test.tsx
@@ -358,6 +358,11 @@ describe('Setup API', () => {
           <div
             class="foo1
         foo2"
+            data-enter=""
+            data-from=""
+            data-headlessui-state="from enter transition"
+            data-transition=""
+            style=""
           >
             Children
           </div>
@@ -370,18 +375,22 @@ describe('Setup API', () => {
       // The `foo1\nfoo2` should be gone
       // I think this is a quirk of JSDOM
       expect(container.firstChild).toMatchInlineSnapshot(`
-        <div>
-          <button>
-            toggle
-          </button>
-          <div
-            class="foo1
-        foo2 foo1 foo2 leave"
-            style=""
-          >
-            Children
-          </div>
-        </div>
+         <div>
+           <button>
+             toggle
+           </button>
+           <div
+             class="foo1
+         foo2 foo1 foo2 leave"
+             data-enter=""
+             data-from=""
+             data-headlessui-state="from enter transition"
+             data-transition=""
+             style=""
+           >
+             Children
+           </div>
+         </div>
       `)
     })
 

--- a/packages/@headlessui-react/src/components/transition/transition.tsx
+++ b/packages/@headlessui-react/src/components/transition/transition.tsx
@@ -21,6 +21,7 @@ import { useOnDisappear } from '../../hooks/use-on-disappear'
 import { useServerHandoffComplete } from '../../hooks/use-server-handoff-complete'
 import { useSyncRefs } from '../../hooks/use-sync-refs'
 import { useTransition } from '../../hooks/use-transition'
+import { useTransitionData } from '../../hooks/use-transition-data'
 import { OpenClosedProvider, State, useOpenClosed } from '../../internal/open-closed'
 import type { Props, ReactTag } from '../../types'
 import { classNames } from '../../utils/class-names'
@@ -501,6 +502,8 @@ function TransitionChildFn<TTag extends ElementType = typeof DEFAULT_TRANSITION_
     if (theirProps.className === '') delete theirProps.className
   }
 
+  let [, slot] = useTransitionData(ready, container, show)
+
   return (
     <NestingContext.Provider value={nesting}>
       <OpenClosedProvider
@@ -514,6 +517,7 @@ function TransitionChildFn<TTag extends ElementType = typeof DEFAULT_TRANSITION_
         {render({
           ourProps,
           theirProps,
+          slot,
           defaultTag: DEFAULT_TRANSITION_CHILD_TAG,
           features: TransitionChildRenderFeatures,
           visible: state === TreeStates.Visible,

--- a/packages/@headlessui-react/src/components/transition/utils/transition.ts
+++ b/packages/@headlessui-react/src/components/transition/utils/transition.ts
@@ -11,7 +11,7 @@ function removeClasses(node: HTMLElement, ...classes: string[]) {
   node && classes.length > 0 && node.classList.remove(...classes)
 }
 
-function waitForTransition(node: HTMLElement, _done: () => void) {
+export function waitForTransition(node: HTMLElement, _done: () => void) {
   let done = once(_done)
   let d = disposables()
 

--- a/packages/@headlessui-react/src/components/transition/utils/transition.ts
+++ b/packages/@headlessui-react/src/components/transition/utils/transition.ts
@@ -184,7 +184,7 @@ export function transition(
   return d.dispose
 }
 
-function prepareTransition(
+export function prepareTransition(
   node: HTMLElement,
   { inFlight, prepare }: { inFlight?: MutableRefObject<boolean>; prepare: () => void }
 ) {

--- a/packages/@headlessui-react/src/hooks/use-flags.ts
+++ b/packages/@headlessui-react/src/hooks/use-flags.ts
@@ -1,32 +1,14 @@
 import { useCallback, useState } from 'react'
-import { useIsMounted } from './use-is-mounted'
 
 export function useFlags(initialFlags = 0) {
   let [flags, setFlags] = useState(initialFlags)
-  let mounted = useIsMounted()
 
-  let addFlag = useCallback(
-    (flag: number) => {
-      if (!mounted.current) return
-      setFlags((flags) => flags | flag)
-    },
-    [flags, mounted]
-  )
-  let hasFlag = useCallback((flag: number) => Boolean(flags & flag), [flags])
-  let removeFlag = useCallback(
-    (flag: number) => {
-      if (!mounted.current) return
-      setFlags((flags) => flags & ~flag)
-    },
-    [setFlags, mounted]
-  )
-  let toggleFlag = useCallback(
-    (flag: number) => {
-      if (!mounted.current) return
-      setFlags((flags) => flags ^ flag)
-    },
-    [setFlags]
-  )
+  let setFlag = useCallback((flag: number) => setFlags(flag), [flags])
 
-  return { flags, addFlag, hasFlag, removeFlag, toggleFlag }
+  let addFlag = useCallback((flag: number) => setFlags((flags) => flags | flag), [flags])
+  let hasFlag = useCallback((flag: number) => (flags & flag) === flag, [flags])
+  let removeFlag = useCallback((flag: number) => setFlags((flags) => flags & ~flag), [setFlags])
+  let toggleFlag = useCallback((flag: number) => setFlags((flags) => flags ^ flag), [setFlags])
+
+  return { flags, setFlag, addFlag, hasFlag, removeFlag, toggleFlag }
 }

--- a/packages/@headlessui-react/src/hooks/use-transition-data.ts
+++ b/packages/@headlessui-react/src/hooks/use-transition-data.ts
@@ -1,0 +1,204 @@
+import { useRef, useState, type MutableRefObject } from 'react'
+import { waitForTransition } from '../components/transition/utils/transition'
+import { disposables } from '../utils/disposables'
+import { useDisposables } from './use-disposables'
+import { useFlags } from './use-flags'
+import { useIsoMorphicEffect } from './use-iso-morphic-effect'
+
+/**
+ * ```
+ * ┌─────┐              │       ┌────────────┐
+ * │From │              │       │From        │
+ * └─────┘              │       └────────────┘
+ * ┌─────┐┌─────┐┌─────┐│┌─────┐┌─────┐┌─────┐
+ * │Frame││Frame││Frame│││Frame││Frame││Frame│
+ * └─────┘└─────┘└─────┘│└─────┘└─────┘└─────┘
+ * ┌───────────────────┐│┌───────────────────┐
+ * │Enter              │││Exit               │
+ * └───────────────────┘│└───────────────────┘
+ * ┌───────────────────┐│┌───────────────────┐
+ * │Transition         │││Transition         │
+ * ├───────────────────┘│└───────────────────┘
+ * │
+ * └─ Applied when `Enter` or `Exit` is applied.
+ * ```
+ */
+enum TransitionState {
+  None = 0,
+
+  From = 1 << 0,
+
+  Enter = 1 << 1,
+  Exit = 1 << 2,
+}
+
+export type TransitionData = {
+  from?: boolean
+  enter?: boolean
+  exit?: boolean
+  transition?: boolean
+}
+
+export function useTransitionData(
+  enabled: boolean,
+  elementRef: MutableRefObject<HTMLElement | null>,
+  show: boolean
+): [visible: boolean, data: TransitionData] {
+  let [visible, setVisible] = useState(show)
+
+  let { hasFlag, addFlag, removeFlag } = useFlags(
+    visible ? TransitionState.From : TransitionState.None
+  )
+  let inFlight = useRef(false)
+
+  let d = useDisposables()
+
+  useIsoMorphicEffect(
+    function retry() {
+      if (!enabled) return
+
+      if (show) {
+        setVisible(true)
+      }
+
+      let node = elementRef.current
+      if (!node) {
+        // Retry if the DOM node isn't available yet
+        if (show) {
+          addFlag(TransitionState.Enter | TransitionState.From)
+          return d.nextFrame(() => retry())
+        }
+        return
+      }
+
+      return transition(node, {
+        inFlight,
+        prepare() {
+          inFlight.current = true
+
+          if (show) {
+            addFlag(TransitionState.Enter | TransitionState.From)
+            removeFlag(TransitionState.Exit)
+          } else {
+            addFlag(TransitionState.Exit)
+            removeFlag(TransitionState.Enter)
+          }
+        },
+        run() {
+          if (show) {
+            removeFlag(TransitionState.From)
+          } else {
+            addFlag(TransitionState.From)
+          }
+        },
+        done() {
+          inFlight.current = false
+
+          removeFlag(TransitionState.Enter | TransitionState.Exit | TransitionState.From)
+
+          if (!show) {
+            setVisible(false)
+          }
+        },
+      })
+    },
+    [enabled, show, elementRef, d]
+  )
+
+  if (!enabled) {
+    return [
+      show,
+      {
+        from: undefined,
+        enter: undefined,
+        exit: undefined,
+        transition: undefined,
+      },
+    ] as const
+  }
+
+  return [
+    visible,
+    {
+      from: hasFlag(TransitionState.From),
+      enter: hasFlag(TransitionState.Enter),
+      exit: hasFlag(TransitionState.Exit),
+      transition: hasFlag(TransitionState.Enter) || hasFlag(TransitionState.Exit),
+    },
+  ] as const
+}
+
+function transition(
+  node: HTMLElement,
+  {
+    prepare,
+    run,
+    done,
+    inFlight,
+  }: {
+    prepare: () => void
+    run: () => void
+    done: () => void
+    inFlight: MutableRefObject<boolean>
+  }
+) {
+  let d = disposables()
+
+  // Prepare the transitions by ensuring that all the "before" classes are
+  // applied and flushed to the DOM.
+  prepareTransition(node, {
+    prepare,
+    inFlight,
+  })
+
+  // This is a workaround for a bug in all major browsers.
+  //
+  // 1. When an element is just mounted
+  // 2. And you apply a transition to it (e.g.: via a class)
+  // 3. And you're using `getComputedStyle` and read any returned value
+  // 4. Then the `transition` immediately jumps to the end state
+  //
+  // This means that no transition happens at all. To fix this, we delay the
+  // actual transition by one frame.
+  d.nextFrame(() => {
+    // Wait for the transition, once the transition is complete we can cleanup.
+    // This is registered first to prevent race conditions, otherwise it could
+    // happen that the transition is already done before we start waiting for
+    // the actual event.
+    d.add(waitForTransition(node, done))
+
+    // Initiate the transition by applying the new classes.
+    run()
+  })
+
+  return d.dispose
+}
+
+function prepareTransition(
+  node: HTMLElement,
+  {
+    prepare,
+    inFlight,
+  }: {
+    prepare: () => void
+    inFlight: MutableRefObject<boolean>
+  }
+) {
+  if (inFlight.current) {
+    prepare()
+    return
+  }
+
+  let previous = node.style.transition
+
+  // Force cancel current transition
+  node.style.transition = 'none'
+
+  prepare()
+
+  // Trigger a reflow, flushing the CSS changes
+  node.offsetHeight
+
+  // Reset the transition to what it was before
+  node.style.transition = previous
+}

--- a/packages/@headlessui-react/src/hooks/use-transition-data.ts
+++ b/packages/@headlessui-react/src/hooks/use-transition-data.ts
@@ -1,5 +1,5 @@
 import { useRef, useState, type MutableRefObject } from 'react'
-import { waitForTransition } from '../components/transition/utils/transition'
+import { prepareTransition, waitForTransition } from '../components/transition/utils/transition'
 import { disposables } from '../utils/disposables'
 import { useDisposables } from './use-disposables'
 import { useFlags } from './use-flags'
@@ -208,33 +208,4 @@ function transition(
   })
 
   return d.dispose
-}
-
-function prepareTransition(
-  node: HTMLElement,
-  {
-    prepare,
-    inFlight,
-  }: {
-    prepare: () => void
-    inFlight: MutableRefObject<boolean>
-  }
-) {
-  if (inFlight.current) {
-    prepare()
-    return
-  }
-
-  let previous = node.style.transition
-
-  // Force cancel current transition
-  node.style.transition = 'none'
-
-  prepare()
-
-  // Trigger a reflow, flushing the CSS changes
-  node.offsetHeight
-
-  // Reset the transition to what it was before
-  node.style.transition = previous
 }

--- a/packages/@headlessui-react/src/hooks/use-transition-data.ts
+++ b/packages/@headlessui-react/src/hooks/use-transition-data.ts
@@ -124,8 +124,10 @@ export function useTransitionData(
           }
         },
         done() {
-          if (cancelledRef.current && node.getAnimations().length > 0) {
-            return
+          if (cancelledRef.current) {
+            if (typeof node.getAnimations === 'function' && node.getAnimations().length > 0) {
+              return
+            }
           }
 
           inFlight.current = false


### PR DESCRIPTION
This PR adds a new way of dealing with transitions. Instead of using the `<Transition />` component and using the `enter`, `enterFrom`, `enterTo`, `leave`, `leaveFrom` and `leaveTo` props, we can now define all of that in CSS.

Most components that are rendered conditionally based on the state of the component:

- `ComboboxOptions`
- `DisclosurePanel`
- `ListboxOptions`
- `MenuItems`
- `PopoverPanel`

Will now accept a `transition` prop. The moment that is enabled then we will expose `data-from`, `data-enter`, `data-exit` and `data-transition` data attributes at the correct time. You can use these data attributes in your CSS or Tailwind Classes to style these components.

The lifecycle of the data attributes look like this:

```
┌─────┐              │       ┌────────────┐
│From │              │       │From        │
└─────┘              │       └────────────┘
┌─────┐┌─────┐┌─────┐│┌─────┐┌─────┐┌─────┐
│Frame││Frame││Frame│││Frame││Frame││Frame│
└─────┘└─────┘└─────┘│└─────┘└─────┘└─────┘
┌───────────────────┐│┌───────────────────┐
│Enter              │││Exit               │
└───────────────────┘│└───────────────────┘
┌───────────────────┐│┌───────────────────┐
│Transition         │││Transition         │
├───────────────────┘│└───────────────────┘
│
└─ Applied when `Enter` or `Exit` is applied.
```

- The `data-transition` attribute is added if an `enter` or `exit` transition is happening.
- The `data-enter` attribute is added during the full `enter` transition from start to finish.
- The `data-exit` attribute is added during the full `exit` transition from start to finish.

The `data-from` attribute is applied at different times depending on the `enter` or `exit` transition. The styles applied using `data-from` are for describing the `from` state or the `initial` state.

- When there is an `enter` transition we will add the `data-from` attribute briefly to make sure that state is present in the DOM. Then, we take it away and let the browser transition the DOM node to it's default state (e.g.: opacity-100).
- When there is an `exit` transition we will add the `data-from` attribute (and keep it there) _after_ the transition starts because then we can go from the current state to the `data-from` state until finished. Once finished, we will unmount the DOM node.

For example, let's say you want to fade in the `MenuItems`, previously you would use the `<Transition />` component for that:

```tsx
<Transition
  enter="transition duration-200 ease-out"
  enterFrom="opacity-0"
  enterTo="opacity-100"
  leave="transition duration-200 ease-out"
  leaveFrom="opacity-100"
  leaveTo="opacity-0"
>
  <MenuItems />
</Transition>
```

There are a few things you might notice:

1. The `enterFrom` and `leaveTo` are the same
2. The `enterTo` and `leaveFrom` are the same
3. The `enterTo` and `leaveFrom` are the default state of an element
4. The `enter` and `leave` are the same

To use the data attribute approach, you can represent this like:

```tsx
<MenuItems transition className="transition duration-200 ease-out data-[from]:opacity-0" />
```

The `transition duration-200 ease-out` were the same, so we can always define them.

The `data-from` data attribute represents the initial state, so we can define it once and it will be applied at the correct time.

If the `duration` or `easing` function is different depending on whether we are
`entering` or `exiting`, then we can do that explicitly as well:

Before:

```tsx
<Transition
  enter="transition duration-200 ease-out"
  enterFrom="opacity-0"
  enterTo="opacity-100"
  leave="transition duration-75 ease-in"
  leaveFrom="opacity-100"
  leaveTo="opacity-0"
>
  <MenuItems />
</Transition>
```

After:

```tsx
<MenuItems
  transition
  className="transition data-[from]:opacity-0 data-[enter]:duration-200 data-[exit]:duration-75 data-[enter]:ease-out data-[exit]:ease-in"
/>
```

If the `enter` and `leave` states are different, e.g.: when entering from the left, and exiting to the right. Then we can combine the data attributes:

```tsx
<Transition
  enter="transition duration-200 ease-out"
  enterFrom="-translate-x-full"
  enterTo="translate-x-0"
  leave="transition duration-200 ease-out"
  leaveFrom="translate-x-0"
  leaveTo="translate-x-full"
>
  <MenuItems />
</Transition>
```

After:

```tsx
<MenuItems
  transition
  className={clsx([
    // Defaults
    'transition duration-200 ease-out',

    // Enter specific
    'data-[enter]:data-[from]:-translate-x-full',

    // Exit specific
    'data-[exit]:data-[from]:translate-x-full',
  ])}
/>
```

Notice that we didn't specify the `translate-x-0` case because that's again the default state of an element.

---

The existing `<Transition>` and `<TransitionChild>` will also expose these data attributes to the underlying DOM node so that you can use them in your CSS for components or elements that don't have a `transition` prop.
