### PR TITLE
Improve UX by freezing `<ComboboxOptions />` component while closing

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure `ComboboxInput` does not sync with current value while typing ([#3259](https://github.com/tailwindlabs/headlessui/pull/3259))
 - Cancel outside click behavior on touch devices when scrolling ([#3266](https://github.com/tailwindlabs/headlessui/pull/3266))
 - Correctly apply conditional classses when using `<Transition />` and `<TransitionChild />` components ([#3303](https://github.com/tailwindlabs/headlessui/pull/3303))
+- Improve UX by freezing `ComboboxOptions` while closing ([#3304](https://github.com/tailwindlabs/headlessui/pull/3304))
 
 ### Changed
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -54,6 +54,7 @@ import {
   type AnchorProps,
 } from '../../internal/floating'
 import { FormFields } from '../../internal/form-fields'
+import { Frozen, useFrozenData } from '../../internal/frozen'
 import { useProvidedId } from '../../internal/id'
 import { OpenClosedProvider, State, useOpenClosed } from '../../internal/open-closed'
 import type { EnsureArray, Props } from '../../types'
@@ -1707,23 +1708,39 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
     onMouseDown: handleMouseDown,
   })
 
+  // We should freeze when the `visible` state is true and if the `visible`
+  // state and the `comboboxState` are not in sync. This means that a transition
+  // is happening and the component is still visible (for the transition effect)
+  // but closed from a functionality perspective.
+  let shouldFreeze = visible && data.comboboxState === ComboboxState.Closed
+
+  let options = useFrozenData(shouldFreeze, data.virtual?.options)
+
   // Map the children in a scrollable container when virtualization is enabled
-  if (data.virtual && visible) {
+  if (data.virtual) {
+    if (options === undefined) throw new Error('Missing `options` in virtual mode')
+
     Object.assign(theirProps, {
-      // @ts-expect-error The `children` prop now is a callback function that receives `{ option }`.
-      children: <VirtualProvider slot={slot}>{theirProps.children}</VirtualProvider>,
+      children: (
+        <ComboboxDataContext.Provider
+          value={
+            options !== data.virtual.options
+              ? { ...data, virtual: { ...data.virtual, options } }
+              : data
+          }
+        >
+          {/* @ts-expect-error The `children` prop now is a callback function that receives `{option}` */}
+          <VirtualProvider slot={slot}>{theirProps.children}</VirtualProvider>
+        </ComboboxDataContext.Provider>
+      ),
     })
   }
 
   // Frozen state, the selected value will only update visually when the user re-opens the <Combobox />
-  let [frozenValue, setFrozenValue] = useState(data.value)
-  if (
-    data.value !== frozenValue &&
-    data.comboboxState === ComboboxState.Open &&
-    data.mode !== ValueMode.Multi
-  ) {
-    setFrozenValue(data.value)
-  }
+  let frozenValue = useFrozenData(
+    !(data.comboboxState === ComboboxState.Open && data.mode !== ValueMode.Multi),
+    data.value
+  )
 
   let isSelected = useEvent((compareValue: unknown) => {
     return data.compare(frozenValue, compareValue)
@@ -1736,7 +1753,17 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
       >
         {render({
           ourProps,
-          theirProps,
+          theirProps: {
+            ...theirProps,
+            children: (
+              <Frozen freeze={visible && data.comboboxState === ComboboxState.Closed}>
+                {typeof theirProps.children === 'function'
+                  ? // @ts-expect-error The `children` prop now is a callback function
+                    theirProps.children?.(slot)
+                  : theirProps.children}
+              </Frozen>
+            ),
+          },
           slot,
           defaultTag: DEFAULT_OPTIONS_TAG,
           features: OptionsRenderFeatures,

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1715,6 +1715,11 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
 
   let options = useFrozenData(shouldFreeze, data.virtual?.options)
 
+  // Frozen state, the selected value will only update visually when the user re-opens the <Combobox />
+  let frozenValue = useFrozenData(shouldFreeze, data.value)
+
+  let isSelected = useEvent((compareValue) => data.compare(frozenValue, compareValue))
+
   // Map the children in a scrollable container when virtualization is enabled
   if (data.virtual) {
     if (options === undefined) throw new Error('Missing `options` in virtual mode')
@@ -1734,16 +1739,6 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
       ),
     })
   }
-
-  // Frozen state, the selected value will only update visually when the user re-opens the <Combobox />
-  let frozenValue = useFrozenData(
-    !(data.comboboxState === ComboboxState.Open && data.mode !== ValueMode.Multi),
-    data.value
-  )
-
-  let isSelected = useEvent((compareValue: unknown) => {
-    return data.compare(frozenValue, compareValue)
-  })
 
   return (
     <Portal enabled={portal ? props.static || visible : false}>

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1750,7 +1750,7 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
           theirProps: {
             ...theirProps,
             children: (
-              <Frozen freeze={visible && data.comboboxState === ComboboxState.Closed}>
+              <Frozen freeze={shouldFreeze}>
                 {typeof theirProps.children === 'function'
                   ? // @ts-expect-error The `children` prop now is a callback function
                     theirProps.children?.(slot)

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1708,10 +1708,9 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
     onMouseDown: handleMouseDown,
   })
 
-  // We should freeze when the `visible` state is true and if the `visible`
-  // state and the `comboboxState` are not in sync. This means that a transition
-  // is happening and the component is still visible (for the transition effect)
-  // but closed from a functionality perspective.
+  // We should freeze when the combobox is visible but "closed". This means that
+  // a transition is currently happening and the component is still visible (for
+  // the transition) but closed from a functionality perspective.
   let shouldFreeze = visible && data.comboboxState === ComboboxState.Closed
 
   let options = useFrozenData(shouldFreeze, data.virtual?.options)

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -1115,15 +1115,15 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
     } as CSSProperties,
   })
 
-  // Frozen state, the selected value will only update visually when the user re-opens the <Listbox />
-  let frozenValue = useFrozenData(
-    !(data.listboxState === ListboxStates.Open && data.mode !== ValueMode.Multi),
-    data.value
-  )
+  // We should freeze when the listbox is visible but "closed". This means that
+  // a transition is currently happening and the component is still visible (for
+  // the transition) but closed from a functionality perspective.
+  let shouldFreeze = visible && data.listboxState === ListboxStates.Closed
 
-  let isSelected = useEvent((compareValue: unknown) => {
-    return data.compare(frozenValue, compareValue)
-  })
+  // Frozen state, the selected value will only update visually when the user re-opens the <Listbox />
+  let frozenValue = useFrozenData(shouldFreeze, data.value)
+
+  let isSelected = useEvent((compareValue: unknown) => data.compare(frozenValue, compareValue))
 
   return (
     <Portal enabled={portal ? props.static || visible : false}>

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -12,7 +12,6 @@ import React, {
   useMemo,
   useReducer,
   useRef,
-  useState,
   type CSSProperties,
   type ElementType,
   type MutableRefObject,
@@ -54,6 +53,7 @@ import {
   type AnchorPropsWithSelection,
 } from '../../internal/floating'
 import { FormFields } from '../../internal/form-fields'
+import { useFrozenData } from '../../internal/frozen'
 import { useProvidedId } from '../../internal/id'
 import { OpenClosedProvider, State, useOpenClosed } from '../../internal/open-closed'
 import type { EnsureArray, Props } from '../../types'
@@ -1116,14 +1116,11 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
   })
 
   // Frozen state, the selected value will only update visually when the user re-opens the <Listbox />
-  let [frozenValue, setFrozenValue] = useState(data.value)
-  if (
-    data.value !== frozenValue &&
-    data.listboxState === ListboxStates.Open &&
-    data.mode !== ValueMode.Multi
-  ) {
-    setFrozenValue(data.value)
-  }
+  let frozenValue = useFrozenData(
+    !(data.listboxState === ListboxStates.Open && data.mode !== ValueMode.Multi),
+    data.value
+  )
+
   let isSelected = useEvent((compareValue: unknown) => {
     return data.compare(frozenValue, compareValue)
   })

--- a/packages/@headlessui-react/src/internal/frozen.tsx
+++ b/packages/@headlessui-react/src/internal/frozen.tsx
@@ -1,0 +1,19 @@
+import React, { useState } from 'react'
+
+export function Frozen({ children, freeze }: { children: React.ReactNode; freeze: boolean }) {
+  let contents = useFrozenData(freeze, children)
+  return <>{contents}</>
+}
+
+export function useFrozenData<T>(freeze: boolean, data: T) {
+  let [frozenValue, setFrozenValue] = useState(data)
+
+  // We should keep updating the frozen value, as long as we shouldn't freeze
+  // the value yet. The moment we should freeze the value we stop updating it
+  // which allows us to reference the "previous" (thus frozen) value.
+  if (!freeze && frozenValue !== data) {
+    setFrozenValue(data)
+  }
+
+  return freeze ? frozenValue : data
+}

--- a/playgrounds/react/pages/combobox/combobox-countries.tsx
+++ b/playgrounds/react/pages/combobox/combobox-countries.tsx
@@ -72,51 +72,53 @@ export default function Home() {
                 </Combobox.Button>
               </span>
 
-              <div className="absolute mt-1 rounded-md bg-white shadow-lg">
-                <Combobox.Options className="shadow-xs max-h-60 w-[calc(var(--input-width)+var(--button-width))] overflow-auto rounded-md py-1 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5">
-                  {countries.map((country) => (
-                    <Combobox.Option
-                      key={country}
-                      value={country}
-                      className={({ active }) => {
-                        return classNames(
-                          'relative cursor-default select-none py-2 pl-3 pr-9 focus:outline-none',
-                          active ? 'bg-indigo-600 text-white' : 'text-gray-900'
-                        )
-                      }}
-                    >
-                      {({ active, selected }) => (
-                        <>
+              <Combobox.Options
+                transition
+                anchor="bottom start"
+                className="w-[calc(var(--input-width)+var(--button-width))] overflow-auto rounded-md bg-white py-1 text-base leading-6 shadow-lg transition duration-1000 [--anchor-gap:theme(spacing.1)] [--anchor-max-height:theme(spacing.60)] focus:outline-none data-[closed]:opacity-0 sm:text-sm sm:leading-5"
+              >
+                {countries.map((country) => (
+                  <Combobox.Option
+                    key={country}
+                    value={country}
+                    className={({ active }) => {
+                      return classNames(
+                        'relative cursor-default select-none py-2 pl-3 pr-9 focus:outline-none',
+                        active ? 'bg-indigo-600 text-white' : 'text-gray-900'
+                      )
+                    }}
+                  >
+                    {({ active, selected }) => (
+                      <>
+                        <span
+                          className={classNames(
+                            'block truncate',
+                            selected ? 'font-semibold' : 'font-normal'
+                          )}
+                        >
+                          {country}
+                        </span>
+                        {selected && (
                           <span
                             className={classNames(
-                              'block truncate',
-                              selected ? 'font-semibold' : 'font-normal'
+                              'absolute inset-y-0 right-0 flex items-center pr-4',
+                              active ? 'text-white' : 'text-indigo-600'
                             )}
                           >
-                            {country}
+                            <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                              <path
+                                fillRule="evenodd"
+                                d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                                clipRule="evenodd"
+                              />
+                            </svg>
                           </span>
-                          {selected && (
-                            <span
-                              className={classNames(
-                                'absolute inset-y-0 right-0 flex items-center pr-4',
-                                active ? 'text-white' : 'text-indigo-600'
-                              )}
-                            >
-                              <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                                <path
-                                  fillRule="evenodd"
-                                  d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                                  clipRule="evenodd"
-                                />
-                              </svg>
-                            </span>
-                          )}
-                        </>
-                      )}
-                    </Combobox.Option>
-                  ))}
-                </Combobox.Options>
-              </div>
+                        )}
+                      </>
+                    )}
+                  </Combobox.Option>
+                ))}
+              </Combobox.Options>
             </div>
           </Combobox>
         </div>

--- a/playgrounds/react/pages/combobox/combobox-virtualized.tsx
+++ b/playgrounds/react/pages/combobox/combobox-virtualized.tsx
@@ -104,101 +104,107 @@ function Example({ virtual = true, data, initial }: { virtual?: boolean; data; i
                 </Combobox.Button>
               </span>
 
-              <div className="absolute mt-1 w-full rounded-md bg-white shadow-lg">
-                {virtual ? (
-                  <Combobox.Options className="shadow-xs max-h-60 overflow-auto rounded-md py-1 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5">
-                    {({ option }) => {
-                      return (
-                        <Combobox.Option
-                          value={option}
-                          className={({ active }) => {
-                            return classNames(
-                              'relative w-full cursor-default select-none py-2 pl-3 pr-9 focus:outline-none',
-                              active ? 'bg-indigo-600 text-white' : 'text-gray-900'
-                            )
-                          }}
-                        >
-                          {({ active, selected }) => (
-                            <>
+              {virtual ? (
+                <Combobox.Options
+                  transition
+                  anchor="bottom start"
+                  className="w-[calc(var(--input-width)+var(--button-width))] overflow-auto rounded-md bg-white py-1 text-base leading-6 shadow-lg transition duration-1000 [--anchor-gap:theme(spacing.1)] [--anchor-max-height:theme(spacing.60)] focus:outline-none data-[closed]:opacity-0 sm:text-sm sm:leading-5"
+                >
+                  {({ option }) => {
+                    return (
+                      <Combobox.Option
+                        value={option}
+                        className={({ active }) => {
+                          return classNames(
+                            'relative w-full cursor-default select-none py-2 pl-3 pr-9 focus:outline-none',
+                            active ? 'bg-indigo-600 text-white' : 'text-gray-900'
+                          )
+                        }}
+                      >
+                        {({ active, selected }) => (
+                          <>
+                            <span
+                              className={classNames(
+                                'block truncate',
+                                selected ? 'font-semibold' : 'font-normal'
+                              )}
+                            >
+                              {option as any}
+                            </span>
+                            {selected && (
                               <span
                                 className={classNames(
-                                  'block truncate',
-                                  selected ? 'font-semibold' : 'font-normal'
+                                  'absolute inset-y-0 right-0 flex items-center pr-4',
+                                  active ? 'text-white' : 'text-indigo-600'
                                 )}
                               >
-                                {option as any}
+                                <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                                  <path
+                                    fillRule="evenodd"
+                                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                                    clipRule="evenodd"
+                                  />
+                                </svg>
                               </span>
-                              {selected && (
-                                <span
-                                  className={classNames(
-                                    'absolute inset-y-0 right-0 flex items-center pr-4',
-                                    active ? 'text-white' : 'text-indigo-600'
-                                  )}
-                                >
-                                  <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                                    <path
-                                      fillRule="evenodd"
-                                      d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                                      clipRule="evenodd"
-                                    />
-                                  </svg>
-                                </span>
+                            )}
+                          </>
+                        )}
+                      </Combobox.Option>
+                    )
+                  }}
+                </Combobox.Options>
+              ) : (
+                <Combobox.Options
+                  transition
+                  anchor="bottom start"
+                  className="w-[calc(var(--input-width)+var(--button-width))] overflow-auto rounded-md bg-white py-1 text-base leading-6 shadow-lg transition duration-1000 [--anchor-gap:theme(spacing.1)] [--anchor-max-height:theme(spacing.60)] focus:outline-none data-[closed]:opacity-0 sm:text-sm sm:leading-5"
+                >
+                  {timezones.map((timezone, idx) => {
+                    return (
+                      <Combobox.Option
+                        key={timezone}
+                        order={virtual ? idx : undefined}
+                        value={timezone}
+                        className={({ active }) => {
+                          return classNames(
+                            'relative w-full cursor-default select-none py-2 pl-3 pr-9 focus:outline-none',
+                            active ? 'bg-indigo-600 text-white' : 'text-gray-900'
+                          )
+                        }}
+                      >
+                        {({ active, selected }) => (
+                          <>
+                            <span
+                              className={classNames(
+                                'block truncate',
+                                selected ? 'font-semibold' : 'font-normal'
                               )}
-                            </>
-                          )}
-                        </Combobox.Option>
-                      )
-                    }}
-                  </Combobox.Options>
-                ) : (
-                  <Combobox.Options className="shadow-xs max-h-60 overflow-auto rounded-md py-1 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5">
-                    {timezones.map((timezone, idx) => {
-                      return (
-                        <Combobox.Option
-                          key={timezone}
-                          order={virtual ? idx : undefined}
-                          value={timezone}
-                          className={({ active }) => {
-                            return classNames(
-                              'relative w-full cursor-default select-none py-2 pl-3 pr-9 focus:outline-none',
-                              active ? 'bg-indigo-600 text-white' : 'text-gray-900'
-                            )
-                          }}
-                        >
-                          {({ active, selected }) => (
-                            <>
+                            >
+                              {timezone}
+                            </span>
+                            {selected && (
                               <span
                                 className={classNames(
-                                  'block truncate',
-                                  selected ? 'font-semibold' : 'font-normal'
+                                  'absolute inset-y-0 right-0 flex items-center pr-4',
+                                  active ? 'text-white' : 'text-indigo-600'
                                 )}
                               >
-                                {timezone}
+                                <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                                  <path
+                                    fillRule="evenodd"
+                                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                                    clipRule="evenodd"
+                                  />
+                                </svg>
                               </span>
-                              {selected && (
-                                <span
-                                  className={classNames(
-                                    'absolute inset-y-0 right-0 flex items-center pr-4',
-                                    active ? 'text-white' : 'text-indigo-600'
-                                  )}
-                                >
-                                  <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                                    <path
-                                      fillRule="evenodd"
-                                      d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                                      clipRule="evenodd"
-                                    />
-                                  </svg>
-                                </span>
-                              )}
-                            </>
-                          )}
-                        </Combobox.Option>
-                      )
-                    })}
-                  </Combobox.Options>
-                )}
-              </div>
+                            )}
+                          </>
+                        )}
+                      </Combobox.Option>
+                    )
+                  })}
+                </Combobox.Options>
+              )}
             </div>
           </Combobox>
         </div>

--- a/playgrounds/react/pages/listbox/listbox-with-pure-tailwind.tsx
+++ b/playgrounds/react/pages/listbox/listbox-with-pure-tailwind.tsx
@@ -73,12 +73,12 @@ export default function Home() {
                       <Listbox.Option
                         key={name}
                         value={name}
-                        className="ui-active:bg-indigo-600 ui-active:text-white ui-not-active:text-gray-900 relative cursor-default select-none py-2 pl-3 pr-9 focus:outline-none"
+                        className="group relative cursor-default select-none py-2 pl-3 pr-9 text-gray-900 focus:outline-none data-[active]:bg-indigo-600 data-[active]:text-white"
                       >
-                        <span className="ui-selected:font-semibold ui-not-selected:font-normal block truncate">
+                        <span className="block truncate font-normal group-data-[selected]:font-semibold">
                           {name}
                         </span>
-                        <span className="ui-not-selected:hidden ui-selected:flex ui-active:text-white ui-not-active:text-indigo-600 absolute inset-y-0 right-0 items-center pr-4">
+                        <span className="absolute inset-y-0 right-0 hidden items-center pr-4 text-indigo-600 group-data-[selected]:flex group-data-[active]:text-white">
                           <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                             <path
                               fillRule="evenodd"


### PR DESCRIPTION
This PR improves the UX when you are closing a `Combobox` that uses a `Transition` while closing.

Typically the `Combobox` component is used with a filtered list based on the value of the `ComboboxInput`. When the `Combobox` closes then the `onClose` will be called. In this function you typically reset the search query state as well:

```tsx
import { Combobox, ComboboxInput, ComboboxOption, ComboboxOptions } from '@headlessui/react'
import { useState } from 'react'

const people = [
  { id: 1, name: 'Durward Reynolds' },
  { id: 2, name: 'Kenton Towne' },
  { id: 3, name: 'Therese Wunsch' },
  { id: 4, name: 'Benedict Kessler' },
  { id: 5, name: 'Katelyn Rohan' },
]

function Example() {
  const [selectedPerson, setSelectedPerson] = useState(people[0])
  const [query, setQuery] = useState('')

  const filteredPeople =
    query === ''
      ? people
      : people.filter((person) => {
          return person.name.toLowerCase().includes(query.toLowerCase())
        })

  return (
    <Combobox value={selectedPerson} onChange={setSelectedPerson} onClose={() => setQuery('')}>
      <ComboboxInput
        aria-label="Assignee"
        displayValue={(person) => person?.name}
        onChange={(event) => setQuery(event.target.value)}
      />
      <ComboboxOptions anchor="bottom" className="empty:hidden">
        {filteredPeople.map((person) => (
          <ComboboxOption key={person.id} value={person} className="data-[focus]:bg-blue-100">
            {person.name}
          </ComboboxOption>
        ))}
      </ComboboxOptions>
    </Combobox>
  )
}
```

Notice that we use `setQuery('')` in the `onClose`.

If you are using a transition, then the following things will happen:

1. The `Combobox` is closed
2. The `onClose` is triggered, the `ComboboxOptions` are transitioning out
3. The `query` is reset
4. The `filteredPeople` list is updated (not filtered yet)
5. The `ComboboxOptions` re-renders with the "full" list instead of the filtered list.
6. The `Transition` completes after this.


This now means that *while* transitioning out, the `ComboboxOptions` is re-rendering with a new list of options even though you just selected an option.

This PR now will "freeze" that state so that we show the contents at the time of closing the `Combobox`.
