### PR TITLE
Add `transition` prop to `<Dialog />` component

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add ability to render multiple `<Dialog />` components at once (without nesting them) ([#3242](https://github.com/tailwindlabs/headlessui/pull/3242))
 - Add CSS based transitions using `data-*` attributes ([#3273](https://github.com/tailwindlabs/headlessui/pull/3273), [#3285](https://github.com/tailwindlabs/headlessui/pull/3285))
+- Add a `transition` prop to `<Dialog />` component ([#3307](https://github.com/tailwindlabs/headlessui/pull/3307))
+- Re-introduce `<DialogBackdrop />` component ([#3307](https://github.com/tailwindlabs/headlessui/pull/3307))
 
 ### Fixed
 
@@ -21,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `useId` instead of React internals (for React 19 compatibility) ([#3254](https://github.com/tailwindlabs/headlessui/pull/3254))
 - Ensure `ComboboxInput` does not sync with current value while typing ([#3259](https://github.com/tailwindlabs/headlessui/pull/3259))
 - Cancel outside click behavior on touch devices when scrolling ([#3266](https://github.com/tailwindlabs/headlessui/pull/3266))
-- Correctly apply conditional classses when using `<Transition />` and `<TransitionChild />` components ([#3303](https://github.com/tailwindlabs/headlessui/pull/3303))
+- Correctly apply conditional classes when using `<Transition />` and `<TransitionChild />` components ([#3303](https://github.com/tailwindlabs/headlessui/pull/3303))
 - Improve UX by freezing `ComboboxOptions` while closing ([#3304](https://github.com/tailwindlabs/headlessui/pull/3304))
 
 ### Changed

--- a/packages/@headlessui-react/src/index.test.ts
+++ b/packages/@headlessui-react/src/index.test.ts
@@ -24,6 +24,7 @@ it('should expose the correct components', () => {
     'Description',
 
     'Dialog',
+    'DialogBackdrop',
     'DialogDescription',
     'DialogPanel',
     'DialogTitle',

--- a/playgrounds/react/pages/dialog/dialog-built-in-transition.tsx
+++ b/playgrounds/react/pages/dialog/dialog-built-in-transition.tsx
@@ -1,0 +1,47 @@
+import { Dialog, DialogBackdrop, DialogPanel } from '@headlessui/react'
+import { useState } from 'react'
+import { Button } from '../../components/button'
+import { classNames } from '../../utils/class-names'
+
+export default function Home() {
+  let [isOpen, setIsOpen] = useState(false)
+  let [transition, setTransition] = useState(true)
+
+  return (
+    <>
+      <div className="flex gap-4 p-12">
+        <Button onClick={() => setIsOpen((v) => !v)}>Toggle!</Button>
+        <Button onClick={() => setTransition((v) => !v)}>
+          <span>Toggle transition</span>
+          <span
+            className={classNames(
+              'ml-2 inline-flex size-4 rounded-md',
+              transition ? 'bg-green-500' : 'bg-red-500'
+            )}
+          ></span>
+        </Button>
+      </div>
+
+      <Dialog
+        open={isOpen}
+        transition={transition}
+        onClose={() => setIsOpen(false)}
+        className="relative z-50"
+      >
+        <DialogBackdrop className="fixed inset-0 bg-black/30 duration-500 ease-out data-[closed]:opacity-0" />
+        <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
+          <DialogPanel className="w-full max-w-lg space-y-4 bg-white p-12 duration-500 ease-out data-[closed]:scale-95 data-[closed]:opacity-0">
+            <h1 className="text-2xl font-bold">Dialog</h1>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed pulvinar, nunc nec
+              vehicula fermentum, nunc sapien tristique ipsum, nec facilisis dolor sapien non dui.
+              Nullam vel sapien ultrices, lacinia felis sit amet, fermentum odio. Nullam vel sapien
+              ultrices, lacinia felis sit amet, fermentum odio.
+            </p>
+            <Button onClick={() => setIsOpen(false)}>Close</Button>
+          </DialogPanel>
+        </div>
+      </Dialog>
+    </>
+  )
+}


### PR DESCRIPTION
This PR adds a `transition` prop to the `<Dialog />` component. Internally it uses the `<Transition />` and `<TransitionChild />` components to coordinate the transitions.

The `<Dialog />` itself will be wrapped in a `<Transition />`, the `<DialogPanel />` will be wrapped in a `<TransitionChild />`, and to make the backdrop transition happen we re-introduced the `<DialogBackdrop />` component which is a `div` wrapped in a `<TransitionChild />`.

Recently we introduced `data-*` attribute based transitions (#3273) to simplify transitions. This also introduced the `transition` prop on components such as:

- `ComboboxOptions`
- `DisclosurePanel`
- `ListboxOptions`
- `MenuItems`
- `PopoverPanel`

This PR now also adds it to the `<Dialog />` component. This is what a migration could look like:

```tsx
<Transition show={open}>
  <Dialog onClose={setOpen}>
    <TransitionChild
      enter="ease-in-out duration-300"
      enterFrom="opacity-0"
      enterTo="opacity-100"
      leave="ease-in-out duration-300"
      leaveFrom="opacity-100"
      leaveTo="opacity-0"
    >
      <div />
    </TransitionChild>

     <TransitionChild
       enter="ease-in-out duration-300"
       enterFrom="opacity-0 scale-95"
       enterTo="opacity-100 scale-100"
       leave="ease-in-out duration-300"
       leaveFrom="opacity-100 scale-100"
       leaveTo="opacity-0 scale-95"
     >
       <DialogPanel>
         {/* … */}
       </DialogPanel>
     </TransitionChild>
  </Dialog>
</Transition>
```

↓↓↓↓↓ Converted to use `data-*` attributes

```tsx
<Transition show={open}>
  <Dialog onClose={setOpen}>
    <TransitionChild>
      <div className="ease-in-out duration-300 data-[closed]:opacity-0 data-[closed]:scale-95" />
    </TransitionChild>

     <TransitionChild>
       <DialogPanel className="ease-in-out duration-300 data-[closed]:opacity-0 data-[closed]:scale-95 bg-white">
         {/* … */}
       </DialogPanel>
     </TransitionChild>
  </Dialog>
</Transition>
```

↓↓↓↓↓ Using the new `transition` prop

```tsx
<Dialog transition open={open} onClose={setOpen}>
  <DialogBackdrop className="ease-in-out duration-300 data-[closed]:opacity-0 data-[closed]:scale-95" />

  <DialogPanel className="ease-in-out duration-300 data-[closed]:opacity-0 data-[closed]:scale-95 bg-white">
    {/* … */}
  </DialogPanel>
</Dialog>
```
