### PR TITLE
Fix initial `anchor="selection"` state

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix issues spreading omitted props onto components ([#3313](https://github.com/tailwindlabs/headlessui/pull/3313))
+- Fix initial `anchor="selection"` positioning ([#3324](https://github.com/tailwindlabs/headlessui/pull/3324))
 
 ## [2.1.0] - 2024-06-21
 


### PR DESCRIPTION
This PR fixes a bug where using the `anchor="selection"` results in an incorrectly positioned anchor panel.

This happened because we computed the `index` too late and didn't re-render to fix up the UI.

To solve this, this PR computes it based on actual state instead of DOM nodes.

We will also compute the selected option based on the frozen state. This will prevent UI glitches while closing the `Listbox`.
