### PR TITLE
Fix prematurely added anchoring styles on `ListboxOptions`

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Fix prematurely added anchoring styles on `ListboxOptions` ([#3337](https://github.com/tailwindlabs/headlessui/pull/3337))
 
 ## [2.1.1] - 2024-06-26
 

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -983,6 +983,7 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
   }, [anchor, data.options])
 
   let anchorOptions = (() => {
+    if (anchor == null) return undefined
     if (selectedOptionIndex === null) return { ...anchor, inner: undefined }
 
     let elements = Array.from(data.listRef.current.values())


### PR DESCRIPTION
This PR fixes an issue where anchoring related styles were applied to the `ListboxOptions` even without using the `anchor` prop.

Fixes: #3336

