### PR TITLE
Fix `transition` and `focus` prop combination for `PopoverPanel` component

### DIFF
--- a/packages/@headlessui-react/src/components/popover/popover.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.tsx
@@ -924,13 +924,13 @@ function PanelFn<TTag extends ElementType = typeof DEFAULT_PANEL_TAG>(
     if (state.__demoMode) return
     if (!focus) return
     if (state.popoverState !== PopoverStates.Open) return
-    if (!internalPanelRef.current) return
+    if (!state.panel) return
 
     let activeElement = ownerDocument?.activeElement as HTMLElement
-    if (internalPanelRef.current.contains(activeElement)) return // Already focused within Dialog
+    if (state.panel.contains(activeElement)) return // Already focused within Dialog
 
-    focusIn(internalPanelRef.current, Focus.First)
-  }, [state.__demoMode, focus, internalPanelRef, state.popoverState])
+    focusIn(state.panel, Focus.First)
+  }, [state.__demoMode, focus, state.panel, state.popoverState])
 
   let slot = useMemo(() => {
     return {
@@ -948,8 +948,8 @@ function PanelFn<TTag extends ElementType = typeof DEFAULT_PANEL_TAG>(
         ? (event: ReactFocusEvent) => {
             let el = event.relatedTarget as HTMLElement
             if (!el) return
-            if (!internalPanelRef.current) return
-            if (internalPanelRef.current?.contains(el)) return
+            if (!state.panel) return
+            if (state.panel.contains(el)) return
 
             dispatch({ type: ActionTypes.ClosePopover })
 

--- a/packages/@headlessui-react/src/internal/floating.tsx
+++ b/packages/@headlessui-react/src/internal/floating.tsx
@@ -175,7 +175,6 @@ export function FloatingProvider({
   let overflowRef = useRef(null)
 
   let [floatingEl, setFloatingElement] = useState<HTMLElement | null>(null)
-  useFixScrollingPixel(floatingEl)
 
   let isEnabled = enabled && config !== null && floatingEl !== null
 
@@ -317,7 +316,7 @@ export function FloatingProvider({
           Object.assign(elements.floating.style, {
             overflow: 'auto',
             maxWidth: `${availableWidth}px`,
-            maxHeight: `min(var(--anchor-max-height, 100vh), ${availableHeight}px)`,
+            maxHeight: `round(up, min(var(--anchor-max-height, 100vh), ${availableHeight}px), 1px)`,
           })
         },
       }),
@@ -368,35 +367,6 @@ export function FloatingProvider({
       </FloatingContext.Provider>
     </PlacementContext.Provider>
   )
-}
-
-function useFixScrollingPixel(element: HTMLElement | null) {
-  useIsoMorphicEffect(() => {
-    if (!element) return
-
-    let observer = new MutationObserver(() => {
-      let maxHeight = window.getComputedStyle(element).maxHeight
-
-      let maxHeightFloat = parseFloat(maxHeight)
-      if (isNaN(maxHeightFloat)) return
-
-      let maxHeightInt = parseInt(maxHeight)
-      if (isNaN(maxHeightInt)) return
-
-      if (maxHeightFloat !== maxHeightInt) {
-        element.style.maxHeight = `${Math.ceil(maxHeightFloat)}px`
-      }
-    })
-
-    observer.observe(element, {
-      attributes: true,
-      attributeFilter: ['style'],
-    })
-
-    return () => {
-      observer.disconnect()
-    }
-  }, [element])
 }
 
 function useResolvedConfig(

--- a/packages/@headlessui-react/src/internal/floating.tsx
+++ b/packages/@headlessui-react/src/internal/floating.tsx
@@ -175,6 +175,7 @@ export function FloatingProvider({
   let overflowRef = useRef(null)
 
   let [floatingEl, setFloatingElement] = useState<HTMLElement | null>(null)
+  useFixScrollingPixel(floatingEl)
 
   let isEnabled = enabled && config !== null && floatingEl !== null
 
@@ -316,7 +317,7 @@ export function FloatingProvider({
           Object.assign(elements.floating.style, {
             overflow: 'auto',
             maxWidth: `${availableWidth}px`,
-            maxHeight: `round(up, min(var(--anchor-max-height, 100vh), ${availableHeight}px), 1px)`,
+            maxHeight: `min(var(--anchor-max-height, 100vh), ${availableHeight}px)`,
           })
         },
       }),
@@ -367,6 +368,35 @@ export function FloatingProvider({
       </FloatingContext.Provider>
     </PlacementContext.Provider>
   )
+}
+
+function useFixScrollingPixel(element: HTMLElement | null) {
+  useIsoMorphicEffect(() => {
+    if (!element) return
+
+    let observer = new MutationObserver(() => {
+      let maxHeight = window.getComputedStyle(element).maxHeight
+
+      let maxHeightFloat = parseFloat(maxHeight)
+      if (isNaN(maxHeightFloat)) return
+
+      let maxHeightInt = parseInt(maxHeight)
+      if (isNaN(maxHeightInt)) return
+
+      if (maxHeightFloat !== maxHeightInt) {
+        element.style.maxHeight = `${Math.ceil(maxHeightFloat)}px`
+      }
+    })
+
+    observer.observe(element, {
+      attributes: true,
+      attributeFilter: ['style'],
+    })
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [element])
 }
 
 function useResolvedConfig(


### PR DESCRIPTION
This PR fixes an issue where the combination of the `focus` and `transition` prop on the `PopoverPanel` component didn't work as expected.

The issue is that we moved focus inside the `PopoverPanel` in an effect, and we relied on a `useRef` to get access to the `PopoverPanel` DOM node. However, due to the transition, this ref wasn't filled in. The moment the ref is filled in, it's too late and the effect doesn't re-run anymore.

Instead, we rely on the DOM element that's coming from state. This one is updated and will re-render the component because we update the state when the ref is available.

Fixes: #3339
