### PR TITLE
Fix `transition` and `focus` prop combination for `PopoverPanel` component

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure `unmount` on `Dialog` works in combination with the `transition` prop on `DialogBackdrop` and `DialogPanel` components ([#3352](https://github.com/tailwindlabs/headlessui/pull/3352))
 - Fix crash in `Combobox` component when in `virtual` mode when options are empty ([#3356](https://github.com/tailwindlabs/headlessui/pull/3356))
 - Fix hanging tests when using `anchor` prop ([#3357](https://github.com/tailwindlabs/headlessui/pull/3357))
+- Fix `transition` and `focus` prop combination for `PopoverPanel` component ([#3361](https://github.com/tailwindlabs/headlessui/pull/3361))
 
 ## [2.1.1] - 2024-06-26
 

--- a/packages/@headlessui-react/src/components/popover/popover.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.tsx
@@ -930,7 +930,7 @@ function PanelFn<TTag extends ElementType = typeof DEFAULT_PANEL_TAG>(
     if (internalPanelRef.current.contains(activeElement)) return // Already focused within Dialog
 
     focusIn(internalPanelRef.current, Focus.First)
-  }, [state.__demoMode, focus, internalPanelRef, state.popoverState])
+  }, [state.__demoMode, focus, internalPanelRef.current, state.popoverState])
 
   let slot = useMemo(() => {
     return {


### PR DESCRIPTION
This PR fixes an issue where the combination of the `focus` and `transition` prop on the `PopoverPanel` component didn't work as expected.

The issue is that we moved focus inside the `PopoverPanel` in an effect, and we relied on a `useRef` to get access to the `PopoverPanel` DOM node. However, due to the transition, this ref wasn't filled in. The moment the ref is filled in, it's too late and the effect doesn't re-run anymore.

Instead, we rely on the DOM element that's coming from state. This one is updated and will re-render the component because we update the state when the ref is available.

Fixes: #3358
