### PR TITLE
Fix outside click in nested portalled `Popover` components

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix crash in `Combobox` component when in `virtual` mode when options are empty ([#3356](https://github.com/tailwindlabs/headlessui/pull/3356))
 - Fix hanging tests when using `anchor` prop ([#3357](https://github.com/tailwindlabs/headlessui/pull/3357))
 - Fix `transition` and `focus` prop combination for `PopoverPanel` component ([#3361](https://github.com/tailwindlabs/headlessui/pull/3361))
+- Fix outside click in nested portalled `Popover` components ([#3362](https://github.com/tailwindlabs/headlessui/pull/3362))
 
 ## [2.1.1] - 2024-06-26
 

--- a/packages/@headlessui-react/src/components/tabs/tabs.tsx
+++ b/packages/@headlessui-react/src/components/tabs/tabs.tsx
@@ -649,7 +649,7 @@ function PanelFn<TTag extends ElementType = typeof DEFAULT_PANEL_TAG>(
   )
 
   if (!selected && (theirProps.unmount ?? true) && !(theirProps.static ?? false)) {
-    return <Hidden as="span" aria-hidden="true" {...ourProps} />
+    return <Hidden aria-hidden="true" {...ourProps} />
   }
 
   return render({

--- a/packages/@headlessui-react/src/hooks/use-root-containers.tsx
+++ b/packages/@headlessui-react/src/hooks/use-root-containers.tsx
@@ -117,7 +117,7 @@ export function MainTreeProvider({
             if (el) {
               // We will only render this when no `mainTreeNode` is found. This
               // means that if we render this element and use it as the
-              // `mainTreeNode` that we will be unmounting it later again.
+              // `mainTreeNode` that we will be unmounting it later.
               //
               // However, we can resolve the actual root container of the main
               // tree node and use that instead.

--- a/packages/@headlessui-react/src/hooks/use-root-containers.tsx
+++ b/packages/@headlessui-react/src/hooks/use-root-containers.tsx
@@ -73,7 +73,7 @@ let MainTreeContext = createContext<HTMLElement | null>(null)
  * components that need it.
  *
  * The main tree node is used for features such as outside click behavior, where
- * we allow clicks in 3rd party contains, but not in the parent of the "main
+ * we allow clicks in 3rd party containers, but not in the parent of the "main
  * tree".
  *
  * In case of a `Popover`, we can use the `PopoverButton` as a marker in the

--- a/packages/@headlessui-react/src/hooks/use-root-containers.tsx
+++ b/packages/@headlessui-react/src/hooks/use-root-containers.tsx
@@ -114,22 +114,22 @@ export function MainTreeProvider({
         <Hidden
           features={HiddenFeatures.Hidden}
           ref={(el) => {
-            if (el) {
-              // We will only render this when no `mainTreeNode` is found. This
-              // means that if we render this element and use it as the
-              // `mainTreeNode` that we will be unmounting it later.
-              //
-              // However, we can resolve the actual root container of the main
-              // tree node and use that instead.
-              for (let container of getOwnerDocument(el)?.querySelectorAll('html > *, body > *') ??
-                []) {
-                if (container === document.body) continue // Skip `<body>`
-                if (container === document.head) continue // Skip `<head>`
-                if (!(container instanceof HTMLElement)) continue // Skip non-HTMLElements
-                if (container?.contains(el)) {
-                  setMainTreeNode(container)
-                  break
-                }
+            if (!el) return
+
+            // We will only render this when no `mainTreeNode` is found. This
+            // means that if we render this element and use it as the
+            // `mainTreeNode` that we will be unmounting it later.
+            //
+            // However, we can resolve the actual root container of the main
+            // tree node and use that instead.
+            for (let container of getOwnerDocument(el)?.querySelectorAll('html > *, body > *') ??
+              []) {
+              if (container === document.body) continue // Skip `<body>`
+              if (container === document.head) continue // Skip `<head>`
+              if (!(container instanceof HTMLElement)) continue // Skip non-HTMLElements
+              if (container?.contains(el)) {
+                setMainTreeNode(container)
+                break
               }
             }
           }}

--- a/packages/@headlessui-react/src/hooks/use-root-containers.tsx
+++ b/packages/@headlessui-react/src/hooks/use-root-containers.tsx
@@ -86,7 +86,7 @@ let MainTreeContext = createContext<HTMLElement | null>(null)
  *
  * This is where the `MainTreeProvider` comes in. It will find the "main tree"
  * node and pass it on. The top-level `PopoverButton` will be used as a marker
- * in the "main tree" and nested `Popover` use this button as well.
+ * in the "main tree" and nested `Popover` will use this button as well.
  */
 export function MainTreeProvider({
   children,

--- a/packages/@headlessui-react/src/hooks/use-root-containers.tsx
+++ b/packages/@headlessui-react/src/hooks/use-root-containers.tsx
@@ -81,8 +81,8 @@ let MainTreeContext = createContext<HTMLElement | null>(null)
  * a `Portal` (e.g. when using the `anchor` props).
  *
  * However, we can't use the `PopoverButton` when it's nested inside of another
- * `Popover`'s `PopoverPanel` component (if that parent `PopoverPanel` is
- * rendered in a `Portal`).
+ * `Popover`'s `PopoverPanel` component if the parent `PopoverPanel` is
+ * rendered in a `Portal`.
  *
  * This is where the `MainTreeProvider` comes in. It will find the "main tree"
  * node and pass it on. The top-level `PopoverButton` will be used as a marker

--- a/packages/@headlessui-react/src/hooks/use-root-containers.tsx
+++ b/packages/@headlessui-react/src/hooks/use-root-containers.tsx
@@ -78,7 +78,7 @@ let MainTreeContext = createContext<HTMLElement | null>(null)
  *
  * In case of a `Popover`, we can use the `PopoverButton` as a marker in the
  * "main tree", the `PopoverPanel` can't be used because it could be rendered in
- * a `Portal` (e.g.: when using the `anchor` props).
+ * a `Portal` (e.g. when using the `anchor` props).
  *
  * However, we can't use the `PopoverButton` when it's nested inside of another
  * `Popover`'s `PopoverPanel` component (if that parent `PopoverPanel` is

--- a/packages/@headlessui-react/src/internal/hidden.tsx
+++ b/packages/@headlessui-react/src/internal/hidden.tsx
@@ -2,7 +2,7 @@ import type { ElementType, Ref } from 'react'
 import type { Props } from '../types'
 import { forwardRefWithAs, render, type HasDisplayName, type RefProp } from '../utils/render'
 
-let DEFAULT_VISUALLY_HIDDEN_TAG = 'div' as const
+let DEFAULT_VISUALLY_HIDDEN_TAG = 'span' as const
 
 export enum HiddenFeatures {
   // The default, no features.


### PR DESCRIPTION
This PR fixes an issue where nested `Popover` components that are using the `anchor` prop (and thus are portalled) are not correctly closed when clicking outside.

The issue stems from incorrect DOM node references to know whether we are allowed to click on a certain DOM element or not.

As a general recap, when an outside click happens, we need to react to it and typically use the `useOutsideClick` hook for this.

We also require the context of "allowed root containers", this means that clicking on a 3rd party toast when a dialog is open, that we allow this even though we are technically clicking outside of the dialog. This is simply because we don't have control over these elements.

We also need a reference to know what the "main tree" container is, because this is the container where your application lives and we _know_ that we are not allowed to click on anything in this container. The complex part is getting a reference to this element.

```html
<html>
  <head>
    <title></title>
  </head>
  <body>
    <div id="app"> <-- main root container -->
      <div></div>
      <div>
        <Popover></Popover> <!-- Current component -->
      </div>
      <div></div>
    </div>

    <!-- Allowed container #1 -->
    <third-party-toast-container></third-party-toast-container>
  </body>

  <!-- Allowed container #2 -->
  <grammarly-extension></grammarly-extension>
</html>
```

Some examples:

- In case of a `Dialog`, the `Dialog` is rendered in a `Portal` which means that a DOM ref to the `Dialog` or anything inside will not point to the "main tree" node.
- In case of a `Popover` we can use the `PopoverButton` as an element that lives in the main tree. However, if you work with nested `Popover` components, and the outer `PopoverPanel` uses the `anchor` or `portal` props, then the inner `PortalButton` will not be in the main tree either because it will live in the portalled `PopoverPanel` of the parent.

This is where the `MainTreeProvider` comes in handy. This component will use the passed in `node` as the main tree node reference and pass this via the context through the React tree. This means that a nested `Popover` will still use a reference from the parent `Popover`.

In case of the `Dialog`, we wrap the `Dialog` itself with this provider which means that the provider will be in the main tree and can be used inside the portalled `Dialog`.

Another part of the `MainTreeProvider` is that if no node exists in the parent (reading from context), and no node is provided via props, then we will briefly render a hidden element, find the root node of the main tree (aka, the parent element that is a direct child of the body, `body > *`). Once we found it, we remove the hidden element again. This way we don't keep unnecessary DOM nodes around.

This also fixes another issue #3319, because we will now briefly render the hidden element to determine the main tree node.

Fixes: #3332
Fixes: #3319
