### PR TITLE
Fix `flushSync` warning for `Combobox` component with `immediate` prop enabled

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `transition` and `focus` prop combination for `PopoverPanel` component ([#3361](https://github.com/tailwindlabs/headlessui/pull/3361))
 - Fix outside click in nested portalled `Popover` components ([#3362](https://github.com/tailwindlabs/headlessui/pull/3362))
 - Fix restoring focus to correct element when closing `Dialog` component ([#3365](https://github.com/tailwindlabs/headlessui/pull/3365))
+- Fix `flushSync` warning for `Combobox` component with `immediate` prop enabled ([#3366](https://github.com/tailwindlabs/headlessui/pull/3366))
 
 ## [2.1.1] - 2024-06-26
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1346,9 +1346,10 @@ function InputFn<
     d.microTask(() => {
       flushSync(() => actions.openCombobox())
 
-      // We need to make sure that tabbing through a form doesn't result in incorrectly setting the
-      // value of the combobox. We will set the activation trigger to `Focus`, and we will ignore
-      // selecting the active option when the user tabs away.
+      // We need to make sure that tabbing through a form doesn't result in
+      // incorrectly setting the value of the combobox. We will set the
+      // activation trigger to `Focus`, and we will ignore selecting the active
+      // option when the user tabs away.
       actions.setActivationTrigger(ActivationTrigger.Focus)
     })
   })


### PR DESCRIPTION
This PR fixes an issue where React shows a warning that it is not able to use `flushSync` while it's already rendering.

The recommended solution in that case is to move the `flushSync` call to a scheduler task or micro task.

The scenario where it happens in this case:

```ts
{condition && (
  <Combobox immediate>
    <ComboboxInput autoFocus />
  </Combobox>
)}
```

This will conditionally render the `Combobox` with the `immediate` prop (which means that it will open once the `ComboboxInput` receives focus). But the `ComboboxInput` also has the `autoFocus` prop which means that it will focus immediately when it's rendered.

Fixes: #3334 
