### PR TITLE
Ensure `Transition` component state doesn't change when it becomes hidden

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Ensure `Transition` component state doesn't change when it becomes hidden ([#3372](https://github.com/tailwindlabs/headlessui/pull/3372))
 
 ## [2.1.2] - 2024-07-05
 

--- a/packages/@headlessui-react/src/components/transition/transition.tsx
+++ b/packages/@headlessui-react/src/components/transition/transition.tsx
@@ -17,7 +17,6 @@ import { useEvent } from '../../hooks/use-event'
 import { useIsMounted } from '../../hooks/use-is-mounted'
 import { useIsoMorphicEffect } from '../../hooks/use-iso-morphic-effect'
 import { useLatestValue } from '../../hooks/use-latest-value'
-import { useOnDisappear } from '../../hooks/use-on-disappear'
 import { useServerHandoffComplete } from '../../hooks/use-server-handoff-complete'
 import { useSyncRefs } from '../../hooks/use-sync-refs'
 import { transitionDataAttributes, useTransition } from '../../hooks/use-transition'
@@ -548,9 +547,6 @@ function TransitionRootFn<TTag extends ElementType = typeof DEFAULT_TRANSITION_C
     () => ({ show, appear, initial }),
     [show, appear, initial]
   )
-
-  // Ensure we change the tree state to hidden once the transition becomes hidden
-  useOnDisappear(show, internalTransitionRef, () => setState(TreeStates.Hidden))
 
   useIsoMorphicEffect(() => {
     if (show) {


### PR DESCRIPTION
This was originally introduced in https://github.com/tailwindlabs/headlessui/pull/1519 to fix an issue where some enter transitions where broken: https://github.com/tailwindlabs/headlessui/issues/1503

However, since we refactored the `Transition` component to make use of the `useTransition` hook, I can't seem to reproduce this issue anymore.

In fact, removing this code fixes an issue.

The bigger issue here is that when the component becomes hidden, that we always set the state to hidden as well. But if it becomes visible again, we don't show it again.

Right now, since I couldn't reproduce any of the other issue, I opted to just removing the code entirely. But if we ever need it again, we probably have to make sure that it becomes visible in the other scenario as well.

Fixes: #3328
