### PR TITLE
Update link to Vue docs

### DIFF
--- a/packages/@headlessui-vue/README.md
+++ b/packages/@headlessui-vue/README.md
@@ -23,7 +23,7 @@ npm install @headlessui/vue
 
 ## Documentation
 
-For full documentation, visit [headlessui.dev](https://headlessui.dev/vue/menu).
+For full documentation, visit [headlessui.com](https://headlessui.com/v1/vue).
 
 ## Community
 


### PR DESCRIPTION
This PR updates the link to the Vue docs for Headlessui.