### PR TITLE
Fix `Combobox` `virtual` mode types for `multiple`

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -636,8 +636,10 @@ export type ComboboxProps<
     name?: string
     immediate?: boolean
     virtual?: {
-      options: NoInfer<TValue>[]
-      disabled?: (value: NoInfer<TValue>) => boolean
+      options: TMultiple extends true ? EnsureArray<NoInfer<TValue>> : NoInfer<TValue>[]
+      disabled?: (
+        value: TMultiple extends true ? EnsureArray<NoInfer<TValue>>[number] : NoInfer<TValue>
+      ) => boolean
     } | null
 
     onClose?(): void


### PR DESCRIPTION
Fixes: https://github.com/tailwindlabs/headlessui/issues/3391

When multiple is specified we expect TValue to already be an array, so lets just ensure its an array and use it as the type for virtual.options. Similarly the disabled callback gets passed a TValue, but when multiple is true it is passed something of type element of TValue.

Behaviour in javascript lines up with this fine, just a type level fix afaik.