### PR TITLE
Add value type generic to ComboboxOptionsProp

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -1589,17 +1589,20 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
 // ---
 
 let DEFAULT_OPTIONS_TAG = 'div' as const
-type OptionsRenderPropArg = {
+type OptionsRenderPropArg<TValue = any> = {
   open: boolean
-  option: any
+  option: TValue
 }
 type OptionsPropsWeControl = 'aria-labelledby' | 'aria-multiselectable' | 'role' | 'tabIndex'
 
 let OptionsRenderFeatures = RenderFeatures.RenderStrategy | RenderFeatures.Static
 
-export type ComboboxOptionsProps<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG> = Props<
+export type ComboboxOptionsProps<
+  TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG,
+  TValue = any,
+> = Props<
   TTag,
-  OptionsRenderPropArg,
+  OptionsRenderPropArg<TValue>,
   OptionsPropsWeControl,
   PropsForFeatures<typeof OptionsRenderFeatures> & {
     hold?: boolean


### PR DESCRIPTION
Hi I'm back :wave:, another small typescript tweak, no functionality change.

## Summary
Adding a generic here lets consuming code specify a type for an option. This is useful when operating in virtual mode and passing a callback as a child. To get it to be well typed consumers would do something like:

```tsx
type Person = { name: string };

<ComboboxOptions<'div', Person>>
  {({ option }) => <div>{option.name}</div>}
</ComboboxOptions>
```

Getting nice strong typing on option. Slightly nicer to specify a generic type then force a cast in the callback imo. Also in situations where somebody is combining multiple combobox components in some generic component they can very logically apply TValue here and in other places too.

## Notes
I defaulted this new generic type to `unknown` which is definitely a type "breaking" change. someone upgrading will possibly experience a compiler error. As the old type for `option` was `any`. imo `unknown` is definitely the correct choice here to force the consumer to make a decision on what their thing is.. but I can also appreciate not wanting to break backwards compatibility. So feel free to update it to default to `any` (in both places) or I can, if that is what you want.

We have this in our codebase right now:
```typescript
/**
 * Slightly better version of headless ui's internal OptionsRenderPropArg type. This way we can
 * provide a generic type parameter
 */
interface ComboboxOptionRenderProps<T> {
  open: boolean;
  option: T;
}
type ComboboxOptionsProps<TValue = unknown> = Omit<
  HeadlessComboboxOptionsProps,
  "children"
> & {
  children?:
    | ReactNode
    | ((bag: ComboboxOptionRenderProps<TValue>) => ReactElement);
};
```

And it would be pretty nice to support this in headlessui-react! thank you!