### PR TITLE
Fix closing components using the `transition` prop, and after scrolling the page

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ensure `Transition` component state doesn't change when it becomes hidden ([#3372](https://github.com/tailwindlabs/headlessui/pull/3372))
+- Fix closing components using the `transition` prop, and after scrolling the page ([#3407](https://github.com/tailwindlabs/headlessui/pull/3407))
 
 ## [2.1.2] - 2024-07-05
 

--- a/packages/@headlessui-react/src/components/disclosure/disclosure.tsx
+++ b/packages/@headlessui-react/src/components/disclosure/disclosure.tsx
@@ -376,7 +376,7 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
     } satisfies ButtonRenderPropArg
   }, [state, hover, active, focus, disabled, autoFocus])
 
-  let type = useResolveButtonType(props, internalButtonRef)
+  let type = useResolveButtonType(props, state.buttonElement)
   let ourProps = isWithinPanel
     ? mergeProps(
         {

--- a/packages/@headlessui-react/src/components/popover/popover.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.tsx
@@ -643,7 +643,7 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
     } satisfies ButtonRenderPropArg
   }, [visible, hover, focus, active, disabled, autoFocus])
 
-  let type = useResolveButtonType(props, internalButtonRef)
+  let type = useResolveButtonType(props, state.button)
   let ourProps = isWithinPanel
     ? mergeProps(
         {

--- a/packages/@headlessui-react/src/components/popover/popover.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.tsx
@@ -537,7 +537,7 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
     useFloatingReference(),
     isWithinPanel
       ? null
-      : (button) => {
+      : useEvent((button) => {
           if (button) {
             state.buttons.current.push(uniqueIdentifier)
           } else {
@@ -552,7 +552,7 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
           }
 
           button && dispatch({ type: ActionTypes.SetButton, button })
-        }
+        })
   )
   let withinPanelButtonRef = useSyncRefs(internalButtonRef, ref)
   let ownerDocument = useOwnerDocument(internalButtonRef)
@@ -763,13 +763,13 @@ function BackdropFn<TTag extends ElementType = typeof DEFAULT_BACKDROP_TAG>(
     ...theirProps
   } = props
   let [{ popoverState }, dispatch] = usePopoverContext('Popover.Backdrop')
-  let internalBackdropRef = useRef<HTMLElement | null>(null)
-  let backdropRef = useSyncRefs(ref, internalBackdropRef)
+  let [backdropElement, setBackdropElement] = useState<HTMLElement | null>(null)
+  let backdropRef = useSyncRefs(ref, setBackdropElement)
 
   let usesOpenClosedState = useOpenClosed()
   let [visible, transitionData] = useTransition(
     transition,
-    internalBackdropRef,
+    backdropElement,
     usesOpenClosedState !== null
       ? (usesOpenClosedState & State.Open) === State.Open
       : popoverState === PopoverStates.Open
@@ -865,9 +865,12 @@ function PanelFn<TTag extends ElementType = typeof DEFAULT_PANEL_TAG>(
     portal = true
   }
 
-  let panelRef = useSyncRefs(internalPanelRef, ref, anchor ? floatingRef : null, (panel) => {
-    dispatch({ type: ActionTypes.SetPanel, panel })
-  })
+  let panelRef = useSyncRefs(
+    internalPanelRef,
+    ref,
+    anchor ? floatingRef : null,
+    useEvent((panel) => dispatch({ type: ActionTypes.SetPanel, panel }))
+  )
   let ownerDocument = useOwnerDocument(internalPanelRef)
   let mergeRefs = useMergeRefsFn()
 
@@ -881,7 +884,7 @@ function PanelFn<TTag extends ElementType = typeof DEFAULT_PANEL_TAG>(
   let usesOpenClosedState = useOpenClosed()
   let [visible, transitionData] = useTransition(
     transition,
-    internalPanelRef,
+    state.panel,
     usesOpenClosedState !== null
       ? (usesOpenClosedState & State.Open) === State.Open
       : state.popoverState === PopoverStates.Open

--- a/packages/@headlessui-react/src/components/switch/switch.tsx
+++ b/packages/@headlessui-react/src/components/switch/switch.tsx
@@ -156,11 +156,13 @@ function SwitchFn<TTag extends ElementType = typeof DEFAULT_SWITCH_TAG>(
     ...theirProps
   } = props
   let groupContext = useContext(GroupContext)
+  let [switchElement, setSwitchElement] = useState<HTMLButtonElement | null>(null)
   let internalSwitchRef = useRef<HTMLButtonElement | null>(null)
   let switchRef = useSyncRefs(
     internalSwitchRef,
     ref,
-    groupContext === null ? null : groupContext.setSwitch
+    groupContext === null ? null : groupContext.setSwitch,
+    setSwitchElement
   )
 
   let defaultChecked = useDefaultValue(_defaultChecked)
@@ -221,7 +223,7 @@ function SwitchFn<TTag extends ElementType = typeof DEFAULT_SWITCH_TAG>(
       id,
       ref: switchRef,
       role: 'switch',
-      type: useResolveButtonType(props, internalSwitchRef),
+      type: useResolveButtonType(props, switchElement),
       tabIndex: props.tabIndex === -1 ? 0 : props.tabIndex ?? 0,
       'aria-checked': checked,
       'aria-labelledby': labelledBy,

--- a/packages/@headlessui-react/src/components/tabs/tabs.tsx
+++ b/packages/@headlessui-react/src/components/tabs/tabs.tsx
@@ -8,6 +8,7 @@ import React, {
   useMemo,
   useReducer,
   useRef,
+  useState,
   type ElementType,
   type MutableRefObject,
   type KeyboardEvent as ReactKeyboardEvent,
@@ -431,8 +432,9 @@ function TabFn<TTag extends ElementType = typeof DEFAULT_TAB_TAG>(
   let actions = useActions('Tab')
   let data = useData('Tab')
 
+  let [tabElement, setTabElement] = useState<HTMLElement | null>(null)
   let internalTabRef = useRef<HTMLElement | null>(null)
-  let tabRef = useSyncRefs(internalTabRef, ref)
+  let tabRef = useSyncRefs(internalTabRef, ref, setTabElement)
 
   useIsoMorphicEffect(() => actions.registerTab(internalTabRef), [actions, internalTabRef])
 
@@ -542,7 +544,7 @@ function TabFn<TTag extends ElementType = typeof DEFAULT_TAB_TAG>(
       onClick: handleSelection,
       id,
       role: 'tab',
-      type: useResolveButtonType(props, internalTabRef),
+      type: useResolveButtonType(props, tabElement),
       'aria-controls': panels[myIndex]?.current?.id,
       'aria-selected': selected,
       tabIndex: selected ? 0 : -1,

--- a/packages/@headlessui-react/src/components/transition/__snapshots__/transition.test.tsx.snap
+++ b/packages/@headlessui-react/src/components/transition/__snapshots__/transition.test.tsx.snap
@@ -133,7 +133,6 @@ exports[`Setup API transition classes should be possible to passthrough the tran
   data-closed=""
   data-enter=""
   data-transition=""
-  style=""
 >
   Children
 </div>

--- a/packages/@headlessui-react/src/components/transition/transition.tsx
+++ b/packages/@headlessui-react/src/components/transition/transition.tsx
@@ -319,10 +319,13 @@ function TransitionChildFn<TTag extends ElementType = typeof DEFAULT_TRANSITION_
 
     ...theirProps
   } = props as typeof props
+  let [containerElement, setContainerElement] = useState<HTMLElement | null>(null)
   let container = useRef<HTMLElement | null>(null)
   let requiresRef = shouldForwardRef(props)
 
-  let transitionRef = useSyncRefs(...(requiresRef ? [container, ref] : ref === null ? [] : [ref]))
+  let transitionRef = useSyncRefs(
+    ...(requiresRef ? [container, ref, setContainerElement] : ref === null ? [] : [ref])
+  )
   let strategy = theirProps.unmount ?? true ? RenderStrategy.Unmount : RenderStrategy.Hidden
 
   let { show, appear, initial } = useTransitionContext()
@@ -435,7 +438,7 @@ function TransitionChildFn<TTag extends ElementType = typeof DEFAULT_TRANSITION_
   // a leave transition on the `<Transition>` is done, but there is still a
   // child `<TransitionChild>` busy, then `visible` would be `false`, while
   // `state` would still be `TreeStates.Visible`.
-  let [, transitionData] = useTransition(enabled, container, show, { start, end })
+  let [, transitionData] = useTransition(enabled, containerElement, show, { start, end })
 
   let ourProps = compact({
     ref: transitionRef,

--- a/packages/@headlessui-react/src/hooks/use-did-element-move.ts
+++ b/packages/@headlessui-react/src/hooks/use-did-element-move.ts
@@ -1,28 +1,16 @@
-import { useRef, type MutableRefObject } from 'react'
+import { useRef } from 'react'
 import { useIsoMorphicEffect } from './use-iso-morphic-effect'
 
-export function useDidElementMove(
-  enabled: boolean,
-  ref: MutableRefObject<HTMLElement | null> | HTMLElement | null
-) {
+export function useDidElementMove(enabled: boolean, element: HTMLElement | null) {
   let elementPosition = useRef({ left: 0, top: 0 })
 
   useIsoMorphicEffect(() => {
-    let el = ref === null ? null : ref instanceof HTMLElement ? ref : ref.current
-    if (!el) return
+    if (!element) return
 
-    let DOMRect = el.getBoundingClientRect()
+    let DOMRect = element.getBoundingClientRect()
     if (DOMRect) elementPosition.current = DOMRect
-  }, [enabled])
+  }, [enabled, element])
 
-  let element =
-    typeof window === 'undefined'
-      ? null
-      : ref === null
-        ? null
-        : ref instanceof HTMLElement
-          ? ref
-          : ref.current
   if (element == null) return false
   if (!enabled) return false
   if (element === document.activeElement) return false

--- a/packages/@headlessui-react/src/hooks/use-did-element-move.ts
+++ b/packages/@headlessui-react/src/hooks/use-did-element-move.ts
@@ -1,21 +1,33 @@
 import { useRef, type MutableRefObject } from 'react'
 import { useIsoMorphicEffect } from './use-iso-morphic-effect'
 
-export function useDidElementMove(enabled: boolean, element: MutableRefObject<HTMLElement | null>) {
+export function useDidElementMove(
+  enabled: boolean,
+  ref: MutableRefObject<HTMLElement | null> | HTMLElement | null
+) {
   let elementPosition = useRef({ left: 0, top: 0 })
+
   useIsoMorphicEffect(() => {
-    let el = element.current
+    let el = ref === null ? null : ref instanceof HTMLElement ? ref : ref.current
     if (!el) return
 
     let DOMRect = el.getBoundingClientRect()
     if (DOMRect) elementPosition.current = DOMRect
   }, [enabled])
 
-  if (element.current == null) return false
+  let element =
+    typeof window === 'undefined'
+      ? null
+      : ref === null
+        ? null
+        : ref instanceof HTMLElement
+          ? ref
+          : ref.current
+  if (element == null) return false
   if (!enabled) return false
-  if (element.current === document.activeElement) return false
+  if (element === document.activeElement) return false
 
-  let buttonRect = element.current.getBoundingClientRect()
+  let buttonRect = element.getBoundingClientRect()
 
   let didElementMove =
     buttonRect.top !== elementPosition.current.top ||

--- a/packages/@headlessui-react/src/hooks/use-element-size.ts
+++ b/packages/@headlessui-react/src/hooks/use-element-size.ts
@@ -7,11 +7,7 @@ function computeSize(element: HTMLElement | null) {
   return { width, height }
 }
 
-export function useElementSize(
-  ref: React.MutableRefObject<HTMLElement | null> | HTMLElement | null,
-  unit = false
-) {
-  let element = ref === null ? null : 'current' in ref ? ref.current : ref
+export function useElementSize(element: HTMLElement | null, unit = false) {
   let [identity, forceRerender] = useReducer(() => ({}), {})
 
   // When the element changes during a re-render, we want to make sure we

--- a/packages/@headlessui-react/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-react/src/hooks/use-outside-click.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, type MutableRefObject } from 'react'
+import { useCallback, useRef } from 'react'
 import { FocusableMode, isFocusableElement } from '../utils/focus-management'
 import { isMobile } from '../utils/platform'
 import { useDocumentEvent } from './use-document-event'
@@ -6,7 +6,7 @@ import { useIsTopLayer } from './use-is-top-layer'
 import { useLatestValue } from './use-latest-value'
 import { useWindowEvent } from './use-window-event'
 
-type Container = MutableRefObject<HTMLElement | null> | HTMLElement | null
+type Container = HTMLElement | null
 type ContainerCollection = Container[] | Set<Container>
 type ContainerInput = Container | ContainerCollection
 
@@ -69,15 +69,14 @@ export function useOutsideClick(
       // Ignore if the target exists in one of the containers
       for (let container of _containers) {
         if (container === null) continue
-        let domNode = container instanceof HTMLElement ? container : container.current
-        if (domNode?.contains(target)) {
+        if (container.contains(target)) {
           return
         }
 
         // If the click crossed a shadow boundary, we need to check if the
         // container is inside the tree by using `composedPath` to "pierce" the
         // shadow boundary
-        if (event.composed && event.composedPath().includes(domNode as EventTarget)) {
+        if (event.composed && event.composedPath().includes(container as EventTarget)) {
           return
         }
       }

--- a/packages/@headlessui-react/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-react/src/hooks/use-outside-click.ts
@@ -101,7 +101,7 @@ export function useOutsideClick(
 
       return cbRef.current(event, target)
     },
-    [cbRef]
+    [cbRef, containers]
   )
 
   let initialClickTarget = useRef<EventTarget | null>(null)

--- a/packages/@headlessui-react/src/hooks/use-refocusable-input.ts
+++ b/packages/@headlessui-react/src/hooks/use-refocusable-input.ts
@@ -8,7 +8,9 @@ import { useEventListener } from './use-event-listener'
  * This hook will also keep the cursor position into account to make sure the
  * cursor is placed at the correct position as-if we didn't loose focus at all.
  */
-export function useRefocusableInput(ref: MutableRefObject<HTMLInputElement | null>) {
+export function useRefocusableInput(
+  ref: MutableRefObject<HTMLInputElement | null> | HTMLInputElement | null
+) {
   // Track the cursor position and the value of the input
   let info = useRef({
     value: '',
@@ -16,7 +18,9 @@ export function useRefocusableInput(ref: MutableRefObject<HTMLInputElement | nul
     selectionEnd: null as number | null,
   })
 
-  useEventListener(ref.current, 'blur', (event) => {
+  let element = ref === null ? null : ref instanceof HTMLInputElement ? ref : ref.current
+
+  useEventListener(element, 'blur', (event) => {
     let target = event.target
     if (!(target instanceof HTMLInputElement)) return
 
@@ -28,7 +32,7 @@ export function useRefocusableInput(ref: MutableRefObject<HTMLInputElement | nul
   })
 
   return useEvent(() => {
-    let input = ref.current
+    let input = ref === null ? null : ref instanceof HTMLInputElement ? ref : ref.current
 
     // If the input is already focused, we don't need to do anything
     if (document.activeElement === input) return

--- a/packages/@headlessui-react/src/hooks/use-refocusable-input.ts
+++ b/packages/@headlessui-react/src/hooks/use-refocusable-input.ts
@@ -1,4 +1,4 @@
-import { useRef, type MutableRefObject } from 'react'
+import { useRef } from 'react'
 import { useEvent } from './use-event'
 import { useEventListener } from './use-event-listener'
 
@@ -8,9 +8,7 @@ import { useEventListener } from './use-event-listener'
  * This hook will also keep the cursor position into account to make sure the
  * cursor is placed at the correct position as-if we didn't loose focus at all.
  */
-export function useRefocusableInput(
-  ref: MutableRefObject<HTMLInputElement | null> | HTMLInputElement | null
-) {
+export function useRefocusableInput(input: HTMLInputElement | null) {
   // Track the cursor position and the value of the input
   let info = useRef({
     value: '',
@@ -18,9 +16,7 @@ export function useRefocusableInput(
     selectionEnd: null as number | null,
   })
 
-  let element = ref === null ? null : ref instanceof HTMLInputElement ? ref : ref.current
-
-  useEventListener(element, 'blur', (event) => {
+  useEventListener(input, 'blur', (event) => {
     let target = event.target
     if (!(target instanceof HTMLInputElement)) return
 
@@ -32,8 +28,6 @@ export function useRefocusableInput(
   })
 
   return useEvent(() => {
-    let input = ref === null ? null : ref instanceof HTMLInputElement ? ref : ref.current
-
     // If the input is already focused, we don't need to do anything
     if (document.activeElement === input) return
 

--- a/packages/@headlessui-react/src/hooks/use-resolve-button-type.ts
+++ b/packages/@headlessui-react/src/hooks/use-resolve-button-type.ts
@@ -13,7 +13,7 @@ export function useResolveButtonType<TTag>(
     if (typeof tag === 'string' && tag.toLowerCase() === 'button') return 'button'
 
     // Resolve the type based on the HTML element
-    if (element instanceof HTMLButtonElement && !element.hasAttribute('type')) return 'button'
+    if (element?.tagName === 'BUTTON' && !element.hasAttribute('type')) return 'button'
 
     // Could not resolve the type
     return undefined

--- a/packages/@headlessui-react/src/hooks/use-resolve-button-type.ts
+++ b/packages/@headlessui-react/src/hooks/use-resolve-button-type.ts
@@ -1,35 +1,21 @@
-import { useState, type MutableRefObject } from 'react'
-import { useIsoMorphicEffect } from './use-iso-morphic-effect'
-
-function resolveType<TTag>(props: { type?: string; as?: TTag }) {
-  if (props.type) return props.type
-
-  let tag = props.as ?? 'button'
-  if (typeof tag === 'string' && tag.toLowerCase() === 'button') return 'button'
-
-  return undefined
-}
+import { useMemo } from 'react'
 
 export function useResolveButtonType<TTag>(
   props: { type?: string; as?: TTag },
-  ref: MutableRefObject<HTMLElement | null> | HTMLElement | null
+  element: HTMLElement | null
 ) {
-  let [type, setType] = useState(() => resolveType(props))
+  return useMemo(() => {
+    // A type was provided
+    if (props.type) return props.type
 
-  useIsoMorphicEffect(() => {
-    setType(resolveType(props))
-  }, [props.type, props.as])
+    // Resolve the type based on the `as` prop
+    let tag = props.as ?? 'button'
+    if (typeof tag === 'string' && tag.toLowerCase() === 'button') return 'button'
 
-  useIsoMorphicEffect(() => {
-    if (type) return
+    // Resolve the type based on the HTML element
+    if (element instanceof HTMLButtonElement && !element.hasAttribute('type')) return 'button'
 
-    let node = ref === null ? null : ref instanceof HTMLElement ? ref : ref.current
-    if (!node) return
-
-    if (node instanceof HTMLButtonElement && !node.hasAttribute('type')) {
-      setType('button')
-    }
-  }, [type, ref])
-
-  return type
+    // Could not resolve the type
+    return undefined
+  }, [props.type, props.as, element])
 }

--- a/packages/@headlessui-react/src/hooks/use-resolve-button-type.ts
+++ b/packages/@headlessui-react/src/hooks/use-resolve-button-type.ts
@@ -12,7 +12,7 @@ function resolveType<TTag>(props: { type?: string; as?: TTag }) {
 
 export function useResolveButtonType<TTag>(
   props: { type?: string; as?: TTag },
-  ref: MutableRefObject<HTMLElement | null>
+  ref: MutableRefObject<HTMLElement | null> | HTMLElement | null
 ) {
   let [type, setType] = useState(() => resolveType(props))
 
@@ -22,9 +22,11 @@ export function useResolveButtonType<TTag>(
 
   useIsoMorphicEffect(() => {
     if (type) return
-    if (!ref.current) return
 
-    if (ref.current instanceof HTMLButtonElement && !ref.current.hasAttribute('type')) {
+    let node = ref === null ? null : ref instanceof HTMLElement ? ref : ref.current
+    if (!node) return
+
+    if (node instanceof HTMLButtonElement && !node.hasAttribute('type')) {
       setType('button')
     }
   }, [type, ref])


### PR DESCRIPTION
This PR fixes an issue where components such as the `MenuItems` and the `ListboxOptions` won't close correctly if these are used in combination with the `transition` prop and _after_ you scrolled the page a little bit.

For some background information: the `Menu` and `Listbox` components can be used with the `transition` prop so that the `MenuItems` and `ListboxOptions` can be transitioned in and out based on the open/closed state.

To make the user experience better, we have some logic to check whether the `MenuButton` or `ListboxButton` moved from its initial position. If it did move when it's closing, then we immediately stop all transitions by unmounting the `MenuItems` or `ListboxOptions` immediately.

A situation this happens in:

1. Open the `Menu` (with the `transition` prop)
2. Press <kbd>tab</kbd> to focus the next element on the page
3. The browser scrolls the page to make the next element visible
4. The `MenuItems` will fade out while moving around (while the page scrolls)
   1. Bonus points, if you also use the `anchor` prop, then the `MenuItems` will reposition itself which makes the UX even worse.

While debugging this issue, I noticed a timing related issue because we are using the DOM element in a `useTransition` hook. Typically you store those DOM elements in a `useRef`. This is good practice because the DOM element will be filled in once you hit the `useEffect` hook, and you don't introduce unnecessary re-renders.

However, if the DOM element changes, then the `useRef` value will update, but the `useEffect` hook doesn't run again (because no state change happened).

There are other places in Headless UI where we also need to re-run effects when the DOM node changes. There are also places where we need access to the DOM element during render.

One of React's rules is to not read / write a ref during render.

So, this PR simplifies a few components and hooks by actually storing the DOM elements in state directly instead of in a ref. This way we can use the DOM element in dependency arrays of `useEffect` hooks, and we can use the DOM element during render.

Maybe a bit of an unorthodox solution, but it works quite well and it simplifies the code quite a bit.

---

It might be easier to review commit by commit. The reason why is that in some hooks I added temporary support for `HTMLElement | null` in places where we wanted `MutableRefObject<HTMLElement | null>`. These now temporary look like `MutableRefObject<HTMLElement | null> | HTMLElement | null`.

This way we can use both versions while refactoring. By the end of the commits those are simplified again such that we only handle `HTMLElement | null` instead of `MutableRefObject<HTMLElement | null>`.

Fixes: #3398
Fixes: #3403


