### PR TITLE
Add client hint to close provider

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure `Transition` component state doesn't change when it becomes hidden ([#3372](https://github.com/tailwindlabs/headlessui/pull/3372))
 - Fix closing components using the `transition` prop, and after scrolling the page ([#3407](https://github.com/tailwindlabs/headlessui/pull/3407))
+- Ensure all client components are marked correctly to avoid a crash with React 19 and Turbopack ([#3429](https://github.com/tailwindlabs/headlessui/pull/3429))
 
 ## [2.1.2] - 2024-07-05
 

--- a/packages/@headlessui-react/src/internal/close-provider.tsx
+++ b/packages/@headlessui-react/src/internal/close-provider.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { createContext, useContext } from 'react'
 
 let CloseContext = createContext(() => {})


### PR DESCRIPTION
This PR adds a missing client boundary in the close provider file that was causing crashes when used with Turbopack as reported in the Next.js repo: https://github.com/vercel/next.js/issues/68205

## Test plan

Thanks to @richardasymmetric [fantastic repro](https://github.com/vercel/next.js/issues/68205
) I could check out the example repo and link a tarball build of the updated `@headlessui/react` package to validate that this is enough to resolve the issue. After this change, `next dev` and `next dev --turbo` work in the same way.