### PR TITLE
add emit ComboboxOption 

### DIFF
--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -1432,8 +1432,9 @@ export let ComboboxOption = defineComponent({
     },
     disabled: { type: Boolean, default: false },
     order: { type: [Number], default: null },
+    emits: { 'optionSelected': (_value: any) => true },
   },
-  setup(props, { slots, attrs, expose }) {
+  setup(props, { slots, attrs, expose, emit }) {
     let api = useComboboxContext('ComboboxOption')
     let id = `headlessui-combobox-option-${useId()}`
     let internalOptionRef = ref<HTMLElement | null>(null)
@@ -1495,6 +1496,8 @@ export let ComboboxOption = defineComponent({
 
       if (disabled.value) return
       api.selectOption(id)
+
+      emit('optionSelected', props.value)
 
       // We want to make sure that we don't accidentally trigger the virtual
       // keyboard.


### PR DESCRIPTION
This PR is used to add emit when selecting an option in the ComboboxOption component.

This is very useful when we need to receive and validate the option click before it is even selected.