### PR TITLE
use native `useId` from Vue.js 3.5 when available

### DIFF
--- a/packages/@headlessui-vue/CHANGELOG.md
+++ b/packages/@headlessui-vue/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- use native `useId` from Vue.js 3.5 when available ([#3458](https://github.com/tailwindlabs/headlessui/pull/3458))
 
 ## [1.7.22] - 2024-05-08
 

--- a/packages/@headlessui-vue/package.json
+++ b/packages/@headlessui-vue/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@testing-library/vue": "^5.8.2",
     "@vue/test-utils": "^2.0.0-rc.18",
-    "vue": "^3.2.29"
+    "vue": "^3.5.0"
   },
   "dependencies": {
     "@tanstack/vue-virtual": "^3.0.0-beta.60"

--- a/packages/@headlessui-vue/package.json
+++ b/packages/@headlessui-vue/package.json
@@ -42,7 +42,7 @@
     "clean": "rimraf ./dist"
   },
   "peerDependencies": {
-    "vue": "^3.2.0"
+    "vue": "^3.5.0"
   },
   "devDependencies": {
     "@testing-library/vue": "^5.8.2",

--- a/packages/@headlessui-vue/package.json
+++ b/packages/@headlessui-vue/package.json
@@ -42,12 +42,12 @@
     "clean": "rimraf ./dist"
   },
   "peerDependencies": {
-    "vue": "^3.5.0"
+    "vue": "^3.2.0"
   },
   "devDependencies": {
     "@testing-library/vue": "^5.8.2",
     "@vue/test-utils": "^2.0.0-rc.18",
-    "vue": "^3.5.0"
+    "vue": "^3.2.29"
   },
   "dependencies": {
     "@tanstack/vue-virtual": "^3.0.0-beta.60"

--- a/packages/@headlessui-vue/src/hooks/use-id.ts
+++ b/packages/@headlessui-vue/src/hooks/use-id.ts
@@ -1,15 +1,22 @@
-import { inject, InjectionKey, provide, useId as vueUseId } from 'vue'
+import * as Vue from 'vue'
 
-const GENERATE_ID: InjectionKey<() => string> = Symbol('headlessui.useid')
+let GENERATE_ID: Vue.InjectionKey<() => string> = Symbol('headlessui.useid')
+let globalId = 0
 
-export function useId() {
-  const generateId = inject(GENERATE_ID, vueUseId)
-  return generateId()
-}
+export const useId =
+  // Prefer Vue's `useId` if it's available.
+  // @ts-expect-error - `useId` doesn't exist in Vue < 3.5.
+  Vue.useId ??
+  function useId() {
+    let generateId = Vue.inject(GENERATE_ID, () => {
+      return `${++globalId}`
+    })
 
+    return generateId()
+  }
 /**
  * This function allows users to provide a custom ID generator.
  */
 export function provideUseId(fn: () => string) {
-  provide(GENERATE_ID, fn)
+  Vue.provide(GENERATE_ID, fn)
 }

--- a/packages/@headlessui-vue/src/hooks/use-id.ts
+++ b/packages/@headlessui-vue/src/hooks/use-id.ts
@@ -1,23 +1,15 @@
-import { inject, InjectionKey, provide } from 'vue'
+import { inject, InjectionKey, provide, useId as vueUseId } from 'vue'
 
-let GENERATE_ID: InjectionKey<() => string> = Symbol('headlessui.useid')
-
-let globalId = 0
+const GENERATE_ID: InjectionKey<() => string> = Symbol('headlessui.useid')
 
 export function useId() {
-  let generateId = inject(GENERATE_ID, () => {
-    return `${++globalId}`
+  return inject(GENERATE_ID, () => {
+    return vueUseId()
   })
-
-  return generateId()
 }
 
 /**
- * This function allows users to provide a custom ID generator
- * as a workaround for the lack of stable SSR IDs in Vue 3.x.
- *
- * This Nuxt users use the Nuxt provided `useId` function
- * which is stable across SSR and client.
+ * This function allows users to provide a custom ID generator.
  */
 export function provideUseId(fn: () => string) {
   provide(GENERATE_ID, fn)

--- a/packages/@headlessui-vue/src/hooks/use-id.ts
+++ b/packages/@headlessui-vue/src/hooks/use-id.ts
@@ -3,9 +3,8 @@ import { inject, InjectionKey, provide, useId as vueUseId } from 'vue'
 const GENERATE_ID: InjectionKey<() => string> = Symbol('headlessui.useid')
 
 export function useId() {
-  return inject(GENERATE_ID, () => {
-    return vueUseId()
-  })
+  const generateId = inject(GENERATE_ID, vueUseId)
+  return generateId()
 }
 
 /**


### PR DESCRIPTION
https://github.com/tailwindlabs/headlessui/discussions/3457

Vue 3.5 added a native SSR-safe `useId` function. This PR updates the code to use that function by default if no custom function has been provided.

Theoretically this is a breaking change, as versions prior to Vue 3.5 are no longer supported.
However, package managers should emit a warning or an error when the peer dependency range is no longer satisfied.