### PR TITLE
Add missing `NODE_ENV` checks to `ComboBox`

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -535,7 +535,7 @@ function VirtualProvider(props: {
           // Scroll to the active index
           {
             // Ignore this when we are in a test environment
-            if (typeof process !== 'undefined' && process.env.JEST_WORKER_ID !== undefined) {
+            if (process.env.NODE_ENV === 'test' && process.env.JEST_WORKER_ID !== undefined) {
               return
             }
 

--- a/packages/@headlessui-vue/src/components/combobox/combobox.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.ts
@@ -193,7 +193,7 @@ let VirtualProvider = defineComponent({
               // Scroll to the active index
               {
                 // Ignore this when we are in a test environment
-                if (typeof process !== 'undefined' && process.env.JEST_WORKER_ID !== undefined) {
+                if (process.env.NODE_ENV === 'test' && process.env.JEST_WORKER_ID !== undefined) {
                   return
                 }
 


### PR DESCRIPTION
This PR fixes an issue where a virtualized `ComboBox` crashed if there was global `process` variable without `env` property. The issue was caused by a missing `process.env.NODE_ENV === 'test'` check which caused the branch to end up in the released version.