### PR TITLE
Feat: `NewRefProp`

### DIFF
--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -70,6 +70,7 @@ import {
   render,
   useMergeRefsFn,
   type HasDisplayName,
+  type NewRefProp,
   type RefProp,
 } from '../../utils/render'
 import { useDescriptions } from '../description/description'
@@ -1096,7 +1097,7 @@ function SeparatorFn<TTag extends ElementType = typeof DEFAULT_SEPARATOR_TAG>(
 
 export interface _internal_ComponentMenu extends HasDisplayName {
   <TTag extends ElementType = typeof DEFAULT_MENU_TAG>(
-    props: MenuProps<TTag> & RefProp<typeof MenuFn>
+    props: MenuProps<TTag> & NewRefProp<TTag>
   ): JSX.Element
 }
 

--- a/packages/@headlessui-react/src/utils/render.ts
+++ b/packages/@headlessui-react/src/utils/render.ts
@@ -6,6 +6,7 @@ import {
   isValidElement,
   useCallback,
   useRef,
+  type ComponentPropsWithRef,
   type ElementType,
   type MutableRefObject,
   type ReactElement,
@@ -385,6 +386,10 @@ export type HasDisplayName = {
 export type RefProp<T extends Function> = T extends (props: any, ref: Ref<infer RefType>) => any
   ? { ref?: Ref<RefType> }
   : never
+
+export type NewRefProp<T extends ElementType> = unknown extends ComponentPropsWithRef<T>['ref']
+  ? {}
+  : { ref?: ComponentPropsWithRef<T>['ref'] }
 
 // TODO: add proper return type, but this is not exposed as public API so it's fine for now
 export function mergeProps<T extends Props<any, any>[]>(...listOfProps: T) {

--- a/playgrounds/react/pages/menu/test-menu.tsx
+++ b/playgrounds/react/pages/menu/test-menu.tsx
@@ -1,0 +1,60 @@
+// TODO: delete this file
+
+import { ComponentPropsWithRef, ElementType, Fragment, forwardRef, useRef } from 'react'
+
+// Example components that `Menu` will be used `as`
+
+const MenuWithRef = ({}: { ref: React.RefObject<HTMLButtonElement> }) => null
+const MenuWithoutRef = ({}: {}) => null
+const MenuWithCustomRef = ({}: { ref: React.RefObject<{ onOpen?: () => void }> }) => null
+const MenuWithForwardRef = forwardRef<HTMLButtonElement, {}>((props, ref) => null)
+const MenuWithForwardRefWithCustomRef = forwardRef<{ onOpen: () => void }, {}>((props, ref) => null)
+
+/**
+ * The `as` prop can be a few things:
+ * - A regular HTML tag
+ * - Another component
+ * - A React fragment
+ *
+ * So, the ref can also point to different things:
+ * - A reference to an HTML tag
+ * - A ForwardRef, which could be for an HTML tag or a custom one
+ * - A component with a `ref` prop (React v19+), pointing to either an HTML tag or a custom ref
+ */
+
+type RefProp<T extends ElementType> = unknown extends ComponentPropsWithRef<T>['ref']
+  ? {}
+  : { ref?: ComponentPropsWithRef<T>['ref'] }
+
+type Menu = {
+  <TTag extends ElementType = 'div'>(
+    props: {
+      as?: TTag
+    } & RefProp<TTag>
+  ): JSX.Element
+}
+
+const MenuAs = forwardRef(({ as }: any, ref) => {
+  const Component = as || 'div'
+
+  return <Component ref={ref} />
+}) as Menu
+
+export default function MenuExample() {
+  const divRef = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const customRef = useRef<{ onOpen: () => void }>(null)
+
+  return (
+    <Fragment>
+      <MenuAs ref={divRef} /> {/* Default `as` is a div */}
+      <MenuAs as="button" ref={buttonRef} />
+      <MenuAs as={Fragment} /> {/* ref is `never` */}
+      <MenuAs as={MenuWithRef} ref={buttonRef} />
+      <MenuAs as={MenuWithoutRef} /> {/* ref is `never` */}
+      <MenuAs as={MenuWithCustomRef} ref={customRef} />
+      <MenuAs as={MenuWithForwardRef} ref={buttonRef} />
+      <MenuAs as={MenuWithForwardRefWithCustomRef} ref={customRef} />
+    </Fragment>
+  )
+}


### PR DESCRIPTION
Resolves #3483 

Playground: `playgrounds/react/pages/menu/test-menu.tsx`

<img width="622" alt="image" src="https://github.com/user-attachments/assets/4d0a28ab-344a-4fe1-9f5b-51cce6a1597d">

### How

I created a new `NewRefProp` type, but we could easily refactor the existing `RefProp` type.

```typescript
export type NewRefProp<T extends ElementType> = unknown extends ComponentPropsWithRef<T>['ref']
  ? {}
  : { ref?: ComponentPropsWithRef<T>['ref'] }
```

1. While checking for unknown helps to hide ref from potential props when it's not applicable, this approach might not cover all cases. If ref appears as unknown but the component actually expects it, our method might not work as intended. In such scenarios, we may need to consider removing the condition from the type. I personally think it's okay to force typing components properly.

2. I'm currently using `React.ComponentWithRef`. While I could manually construct the type, adding support for ref callbacks triggers a warning from React.

### Important to note

For cases where ref is used as a regular prop (e.g., `({ ref }: { ref: boolean }) => null`), React overrides the prop to be optional `ref?: boolean`. Additionally, using ref as a string causes issues. This problem also exists with the current implementation. As a best practice, users should avoid naming props `ref` unless they're used as refs.

@RobinMalfait 