### PR TITLE
fix: remove readonly from hidden input to pass W3C validation

### DIFF
--- a/packages/@headlessui-vue/src/components/radio-group/radio-group.ts
+++ b/packages/@headlessui-vue/src/components/radio-group/radio-group.ts
@@ -260,7 +260,6 @@ export let RadioGroup = defineComponent({
                   as: 'input',
                   type: 'hidden',
                   hidden: true,
-                  readOnly: true,
                   form,
                   disabled,
                   name,


### PR DESCRIPTION
The `readonly` attribute is not allowed on `input` elements of type `hidden`, as per W3C HTML validation standards. This was causing a validation error in the W3C validator:

Error: Attribute readonly not allowed on element input at this point.

The `readonly` attribute has been removed from hidden inputs to resolve the issue and ensure better HTML compliance.