### PR TITLE
Fix `@headlessui/tailwindcss` exports map

### DIFF
--- a/packages/@headlessui-tailwindcss/CHANGELOG.md
+++ b/packages/@headlessui-tailwindcss/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Ensure the npm package `export` map is correct ([#3539](https://github.com/tailwindlabs/headlessui/pull/3539))
 
 ## [0.2.1] - 2024-05-29
 

--- a/packages/@headlessui-tailwindcss/package.json
+++ b/packages/@headlessui-tailwindcss/package.json
@@ -17,7 +17,8 @@
       "require": "./dist/index.d.cts"
     },
     "import": "./dist/headlessui.esm.js",
-    "require": "./dist/index.cjs"
+    "require": "./dist/index.cjs",
+    "default": "./dist/headlessui.esm.js"
   },
   "sideEffects": false,
   "engines": {


### PR DESCRIPTION
When trying to load the `@headlessui/tailwindcss` package from a v4 project via:

```css
@import '@headlessui/tailwindcss';
```

we run into the following runtime error:

```
[plugin:@tailwindcss/vite:generate:serve] Package path . is not exported from package /Users/philipp/dev/tailwindcss/playgrounds/vite/node_modules/@headlessui/tailwindcss (see exports field in /Users/philipp/dev/tailwindcss/playgrounds/vite/node_modules/@headlessui/tailwindcss/package.json)
```

I think this is caused by unexpected content in the exports map. This changes the contents to be similar to what we do for the `tailwindcss` package.