### PR TITLE
chore: usage trend of packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,24 @@ You can install the insiders version (which points to whatever the latest commit
 | [`@headlessui/vue`](https://github.com/tailwindlabs/headlessui/tree/main/packages/%40headlessui-vue)                 |         [![npm version](https://img.shields.io/npm/v/@headlessui/vue.svg)](https://www.npmjs.com/package/@headlessui/vue)         |         [![npm downloads](https://img.shields.io/npm/dt/@headlessui/vue.svg)](https://www.npmjs.com/package/@headlessui/vue)         |
 | [`@headlessui/tailwindcss`](https://github.com/tailwindlabs/headlessui/tree/main/packages/%40headlessui-tailwindcss) | [![npm version](https://img.shields.io/npm/v/@headlessui/tailwindcss.svg)](https://www.npmjs.com/package/@headlessui/tailwindcss) | [![npm downloads](https://img.shields.io/npm/dt/@headlessui/tailwindcss.svg)](https://www.npmjs.com/package/@headlessui/tailwindcss) |
 
+[Usage Trend of @headlessui/react](https://npm-compare.com/@headlessui/react#timeRange=THREE_YEARS):
+  
+<a href="https://npm-compare.com/@headlessui/react#timeRange=THREE_YEARS" target="_blank">
+  <img src="https://npm-compare.com/img/npm-trend/THREE_YEARS/@headlessui/react.png" width="50%" alt="NPM Usage Trend of @headlessui/react" />
+</a>
+
+[Usage Trend of @headlessui/vue](https://npm-compare.com/@headlessui/vue#timeRange=THREE_YEARS):
+  
+<a href="https://npm-compare.com/@headlessui/vue#timeRange=THREE_YEARS" target="_blank">
+  <img src="https://npm-compare.com/img/npm-trend/THREE_YEARS/@headlessui/vue.png" width="50%" alt="NPM Usage Trend of @headlessui/vue" />
+</a>
+
+[Usage Trend of @headlessui/tailwindcss](https://npm-compare.com/@headlessui/tailwindcss#timeRange=THREE_YEARS):
+  
+<a href="https://npm-compare.com/@headlessui/tailwindcss#timeRange=THREE_YEARS" target="_blank">
+  <img src="https://npm-compare.com/img/npm-trend/THREE_YEARS/@headlessui/tailwindcss.png" width="50%" alt="NPM Usage Trend of @headlessui/tailwindcss" />
+</a>
+
 ## Community
 
 For help, discussion about best practices, or any other conversation that would benefit from being searchable:


### PR DESCRIPTION
Hi, I hope this message finds you well! I’d like to propose adding usage trend charts for the following Headless UI packages to the README.

Each chart is dynamically updated and visually highlights the growing usage trend of Headless UI packages. By including this data, I believe we can help potential users better understand the popularity these packages, giving them more confidence in choosing Headless UI for their projects.

As a maintainer of npm-compare.com, a platform dedicated to providing actionable insights into NPM packages, I’d be happy to collaborate further if there are other features or improvements you feel could add value to this project.

Thank you for considering my suggestion. I’m excited about the opportunity to contribute to this fantastic library and look forward to your feedback!