### PR TITLE
Bump @tanstack/react-virtual

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2393,25 +2393,27 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.8.1.tgz",
-      "integrity": "sha512-dP5a7giEM4BQWLJ7K07ToZv8rF51mzbrBMkf0scg1QNYuFx3utnPUBPUHdzaowZhIez1K2XS78amuzD+YGRA5Q==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.11.1.tgz",
+      "integrity": "sha512-orn2QNe5tF6SqjucHJ6cKTKcRDe3GG7bcYqPNn72Yejj7noECdzgAyRfGt2pGDPemhYim3d1HIR/dgruCnLfUA==",
+      "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.8.1"
+        "@tanstack/virtual-core": "3.10.9"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@tanstack/react-virtual/node_modules/@tanstack/virtual-core": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.8.1.tgz",
-      "integrity": "sha512-uNtAwenT276M9QYCjTBoHZ8X3MUeCRoGK59zPi92hMIxdfS9AyHjkDWJ94WroDxnv48UE+hIeo21BU84jKc8aQ==",
+      "version": "3.10.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.10.9.tgz",
+      "integrity": "sha512-kBknKOKzmeR7lN+vSadaKWXaLS0SZZG+oqpQ/k80Q6g9REn6zRHS/ZYdrIzHnpHgy/eWs00SujveUN/GJT2qTw==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -11506,7 +11508,7 @@
         "@floating-ui/react": "^0.26.16",
         "@react-aria/focus": "^3.17.1",
         "@react-aria/interactions": "^3.21.3",
-        "@tanstack/react-virtual": "^3.8.1"
+        "@tanstack/react-virtual": "^3.11.1"
       },
       "devDependencies": {
         "@testing-library/react": "^15.0.7",

--- a/packages/@headlessui-react/package.json
+++ b/packages/@headlessui-react/package.json
@@ -58,6 +58,6 @@
     "@floating-ui/react": "^0.26.16",
     "@react-aria/focus": "^3.17.1",
     "@react-aria/interactions": "^3.21.3",
-    "@tanstack/react-virtual": "^3.8.1"
+    "@tanstack/react-virtual": "^3.11.1"
   }
 }


### PR DESCRIPTION
`@tanstack/react-virtual` added peer deps support for React 19 in [v3.11.0](https://github.com/TanStack/virtual/releases/tag/v3.11.0) (https://github.com/TanStack/virtual/pull/893)

This PR upgrades the packages. This can resolve some warnings on some React 19 projects, e.g.:

```
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @tanstack/react-virtual@3.10.9
npm warn Found: react@19.0.0
npm warn node_modules/react
npm warn   peer react@"^18 || ^19 || ^19.0.0-rc" from @headlessui/react@2.2.0
npm warn   node_modules/@headlessui/react
npm warn     @headlessui/react@"^2.2.0" from the root project
npm warn   15 more (@floating-ui/react, @floating-ui/react-dom, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"^16.8.0 || ^17.0.0 || ^18.0.0" from @tanstack/react-virtual@3.10.9
npm warn node_modules/@headlessui/react/node_modules/@tanstack/react-virtual
npm warn   @tanstack/react-virtual@"^3.8.1" from @headlessui/react@2.2.0
npm warn   node_modules/@headlessui/react
npm warn
npm warn Conflicting peer dependency: react@18.3.1
npm warn node_modules/react
npm warn   peer react@"^16.8.0 || ^17.0.0 || ^18.0.0" from @tanstack/react-virtual@3.10.9
npm warn   node_modules/@headlessui/react/node_modules/@tanstack/react-virtual
npm warn     @tanstack/react-virtual@"^3.8.1" from @headlessui/react@2.2.0
npm warn     node_modules/@headlessui/react
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @tanstack/react-virtual@3.10.9
npm warn Found: react-dom@19.0.0
npm warn node_modules/react-dom
npm warn   peer react-dom@"^18 || ^19 || ^19.0.0-rc" from @headlessui/react@2.2.0
npm warn   node_modules/@headlessui/react
npm warn     @headlessui/react@"^2.2.0" from the root project
npm warn   5 more (@floating-ui/react, @floating-ui/react-dom, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react-dom@"^16.8.0 || ^17.0.0 || ^18.0.0" from @tanstack/react-virtual@3.10.9
npm warn node_modules/@headlessui/react/node_modules/@tanstack/react-virtual
npm warn   @tanstack/react-virtual@"^3.8.1" from @headlessui/react@2.2.0
npm warn   node_modules/@headlessui/react
npm warn
npm warn Conflicting peer dependency: react-dom@18.3.1
npm warn node_modules/react-dom
npm warn   peer react-dom@"^16.8.0 || ^17.0.0 || ^18.0.0" from @tanstack/react-virtual@3.10.9
npm warn   node_modules/@headlessui/react/node_modules/@tanstack/react-virtual
npm warn     @tanstack/react-virtual@"^3.8.1" from @headlessui/react@2.2.0
npm warn     node_modules/@headlessui/react
```