### PR TITLE
Fix incorrect behavior of `isTyping`

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -848,6 +848,7 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
 
   let closeCombobox = useEvent(() => {
     dispatch({ type: ActionTypes.CloseCombobox })
+    actions.setIsTyping(false)
     defaultToFirstOption.current = false
     onClose?.()
   })
@@ -1282,6 +1283,7 @@ function InputFn<
         return actions.closeCombobox()
 
       case Keys.Tab:
+        actions.setIsTyping(false)
         if (data.comboboxState !== ComboboxState.Open) return
         if (data.mode === ValueMode.Single && data.activationTrigger !== ActivationTrigger.Focus) {
           actions.selectActiveOption()


### PR DESCRIPTION
This PR fixes an issue where navigating from one `Combobox` to another using the Tab key blocked the `displayValue` from updating in the next render.

The issue was partially introduced in this PR: [https://github.com/tailwindlabs/headlessui/pull/3259](https://github.com/tailwindlabs/headlessui/pull/3259).

Currently, any interaction with the keyboard activates a mode that prevents the value from being updated.

My fix is a straightforward solution, but as maintainers of this library, you may have a better idea of how to address this bug. I’d be happy to implement any suggestions you provide.

Thank you for your work — this library truly helps make my interfaces better

Fixes: #3595