### PR TITLE
iOS: scroll lock should still allow pinch-to-zoom

### DIFF
--- a/packages/@headlessui-react/src/hooks/document-overflow/handle-ios-locking.ts
+++ b/packages/@headlessui-react/src/hooks/document-overflow/handle-ios-locking.ts
@@ -83,7 +83,9 @@ export function handleIOSLocking(): ScrollLockStep<ContainerMetadata> {
 
               d.style(rootContainer, 'overscrollBehavior', 'contain')
             } else {
-              d.style(e.target, 'touchAction', 'none')
+              // Disable all touch actions related to scrolling,
+              // but still allow pinch-to-zoom.
+              d.style(e.target, 'touchAction', 'pinch-zoom')
             }
           }
         })

--- a/packages/@headlessui-vue/src/hooks/document-overflow/handle-ios-locking.ts
+++ b/packages/@headlessui-vue/src/hooks/document-overflow/handle-ios-locking.ts
@@ -83,7 +83,9 @@ export function handleIOSLocking(): ScrollLockStep<ContainerMetadata> {
 
               d.style(rootContainer, 'overscrollBehavior', 'contain')
             } else {
-              d.style(e.target, 'touchAction', 'none')
+              // Disable all touch actions related to scrolling,
+              // but still allow pinch-to-zoom.
+              d.style(e.target, 'touchAction', 'pinch-zoom')
             }
           }
         })


### PR DESCRIPTION
Some components require scroll-locking for accessibility purposes; however, it seems that on iOS, this scroll locking was going one step too far, and preventing users from being able to use the pinch-to-zoom gesture. Pinch-to-zoom is important, especially for people with low vision conditions; zooming in helps them read and understand the web page.

On iOS, we we are using the [`touch-action`](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action) CSS property to disable scrolling around the page. However, instead of setting this property to `none` to disable _all_ touch interaction, we can set it to `pinch-zoom`, which should disable all _scrolling_ touch interactions, but still allow the user to zoom in and out as necessary.

I discovered this accessibility issue when trying to use a `<Dialog>` component from Headless UI. The dialog showed an image, and I wanted to zoom in on the image in order to view it in greater detail, but I discovered that I could not. This change fixes that problem.