### PR TITLE
Support installing with Tailwind CSS v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11557,7 +11557,7 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "tailwindcss": "^3.0"
+        "tailwindcss": "^3.0 || ^4.0"
       }
     },
     "packages/@headlessui-vue": {

--- a/packages/@headlessui-tailwindcss/CHANGELOG.md
+++ b/packages/@headlessui-tailwindcss/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+- Support installing with Tailwind CSS v4 ([#3634](https://github.com/tailwindlabs/headlessui/pull/3634))
 
 ## [0.2.1] - 2024-05-29
 

--- a/packages/@headlessui-tailwindcss/package.json
+++ b/packages/@headlessui-tailwindcss/package.json
@@ -41,7 +41,7 @@
     "clean": "rimraf ./dist"
   },
   "peerDependencies": {
-    "tailwindcss": "^3.0"
+    "tailwindcss": "^3.0 || ^4.0"
   },
   "devDependencies": {
     "tailwindcss": "^3.2.7"


### PR DESCRIPTION
Resolves #3633

Bumps the version range for `@headlessui/tailwindcss` to ensure support with Tailwind CSS v4.