### PR TITLE
Add props for controlling close behavior of Dialog

### DIFF
--- a/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
@@ -768,6 +768,47 @@ describe('Keyboard interactions', () => {
     )
 
     it(
+      'should be not close the dialog with Escape if closeOnEscape is false',
+      suppressConsoleLogs(async () => {
+        function Example() {
+          let [isOpen, setIsOpen] = useState(false)
+          return (
+            <>
+              <button id="trigger" onClick={() => setIsOpen((v) => !v)}>
+                Trigger
+              </button>
+              <Dialog autoFocus={false} open={isOpen} onClose={setIsOpen} closeOnEscape={false}>
+                Contents
+                <TabSentinel />
+              </Dialog>
+            </>
+          )
+        }
+        render(<Example />)
+
+        assertDialog({ state: DialogState.InvisibleUnmounted })
+
+        // Open dialog
+        await click(document.getElementById('trigger'))
+
+        // Verify it is open
+        assertDialog({
+          state: DialogState.Visible,
+          attributes: { id: 'headlessui-dialog-1' },
+        })
+
+        // Press escape key
+        await press(Keys.Escape)
+
+        // Verify it is still open
+        assertDialog({
+          state: DialogState.Visible,
+          attributes: { id: 'headlessui-dialog-1' },
+        })
+      })
+    )
+
+    it(
       'should be possible to close the dialog with Escape, when a field is focused',
       suppressConsoleLogs(async () => {
         function Example() {
@@ -1041,6 +1082,37 @@ describe('Mouse interactions', () => {
 
       // Verify the button is focused
       assertActiveElement(getByText('Trigger'))
+    })
+  )
+
+  it(
+    'should not close the dialog when we click outside on the body element if closeOnOutsideClick is false',
+    suppressConsoleLogs(async () => {
+      function Example() {
+        let [isOpen, setIsOpen] = useState(false)
+        return (
+          <>
+            <button onClick={() => setIsOpen((v) => !v)}>Trigger</button>
+            <Dialog autoFocus={false} open={isOpen} onClose={setIsOpen} closeOnOutsideClick={false}>
+              Contents
+              <TabSentinel />
+            </Dialog>
+          </>
+        )
+      }
+      render(<Example />)
+
+      // Open dialog
+      await click(getByText('Trigger'))
+
+      // Verify it is open
+      assertDialog({ state: DialogState.Visible })
+
+      // Click the body
+      await click(document.body)
+
+      // Verify it is still open
+      assertDialog({ state: DialogState.Visible })
     })
   )
 

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -126,6 +126,8 @@ let InternalDialog = forwardRefWithAs(function InternalDialog<
     autoFocus = true,
     __demoMode = false,
     unmount = false,
+    closeOnOutsideClick = true,
+    closeOnEscape = true,
     ...theirProps
   } = props
 
@@ -213,13 +215,13 @@ let InternalDialog = forwardRefWithAs(function InternalDialog<
   })
 
   // Close Dialog on outside click
-  useOutsideClick(enabled, resolveRootContainers, (event) => {
+  useOutsideClick(enabled && closeOnOutsideClick, resolveRootContainers, (event) => {
     event.preventDefault()
     close()
   })
 
   // Handle `Escape` to close
-  useEscape(enabled, ownerDocument?.defaultView, (event) => {
+  useEscape(enabled && closeOnEscape, ownerDocument?.defaultView, (event) => {
     event.preventDefault()
     event.stopPropagation()
 
@@ -347,6 +349,8 @@ export type DialogProps<TTag extends ElementType = typeof DEFAULT_DIALOG_TAG> = 
     role?: 'dialog' | 'alertdialog'
     autoFocus?: boolean
     transition?: boolean
+    closeOnOutsideClick?: boolean
+    closeOnEscape?: boolean
     __demoMode?: boolean
   }
 >

--- a/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.test.ts
@@ -1171,6 +1171,57 @@ describe('Keyboard interactions', () => {
     )
 
     it(
+      'should not close the dialog with Escape when closeOnEscape is false',
+      suppressConsoleLogs(async () => {
+        renderTemplate({
+          template: `
+            <div>
+              <button id="trigger" @click="toggleOpen">
+                Trigger
+              </button>
+              <Dialog :open="isOpen" @close="setIsOpen" :close-on-escape="false">
+                Contents
+                <TabSentinel />
+              </Dialog>
+            </div>
+          `,
+          setup() {
+            let isOpen = ref(false)
+            return {
+              isOpen,
+              setIsOpen(value: boolean) {
+                isOpen.value = value
+              },
+              toggleOpen() {
+                isOpen.value = !isOpen.value
+              },
+            }
+          },
+        })
+
+        assertDialog({ state: DialogState.InvisibleUnmounted })
+
+        // Open dialog
+        await click(document.getElementById('trigger'))
+
+        // Verify it is open
+        assertDialog({
+          state: DialogState.Visible,
+          attributes: { id: 'headlessui-dialog-1' },
+        })
+
+        // Press escape key
+        await press(Keys.Escape)
+
+        // Verify it is still open
+        assertDialog({
+          state: DialogState.Visible,
+          attributes: { id: 'headlessui-dialog-1' },
+        })
+      })
+    )
+
+    it(
       'should be possible to close the dialog with Escape, when a field is focused',
       suppressConsoleLogs(async () => {
         renderTemplate({
@@ -1658,6 +1709,44 @@ describe('Mouse interactions', () => {
 
       // Verify the button is focused
       assertActiveElement(getByText('Trigger'))
+    })
+  )
+
+  it(
+    'should not close the dialog when we click outside on the body element if closeOnClickOutside is false',
+    suppressConsoleLogs(async () => {
+      renderTemplate({
+        template: `
+          <div>
+            <button @click="isOpen = !isOpen">Trigger</button>
+            <Dialog :open="isOpen" @close="setIsOpen" :close-on-outside-click="false">
+              Contents
+              <TabSentinel />
+            </Dialog>
+          </div>
+        `,
+        setup() {
+          let isOpen = ref(false)
+          return {
+            isOpen,
+            setIsOpen(value: boolean) {
+              isOpen.value = value
+            },
+          }
+        },
+      })
+
+      // Open dialog
+      await click(getByText('Trigger'))
+
+      // Verify it is open
+      assertDialog({ state: DialogState.Visible })
+
+      // Click the body
+      await click(document.body)
+
+      // Verify it is still open
+      assertDialog({ state: DialogState.Visible })
     })
   )
 

--- a/packages/@headlessui-vue/src/components/dialog/dialog.ts
+++ b/packages/@headlessui-vue/src/components/dialog/dialog.ts
@@ -75,6 +75,8 @@ export let Dialog = defineComponent({
     initialFocus: { type: Object as PropType<HTMLElement | null>, default: null },
     id: { type: String, default: () => `headlessui-dialog-${useId()}` },
     role: { type: String as PropType<'dialog' | 'alertdialog'>, default: 'dialog' },
+    closeOnOutsideClick: { type: Boolean, default: true },
+    closeOnEscape: { type: Boolean, default: true },
   },
   emits: { close: (_close: boolean) => true },
   setup(props, { emit, attrs, slots, expose }) {
@@ -233,6 +235,7 @@ export let Dialog = defineComponent({
     let outsideClickEnabled = computed(() => {
       if (!enabled.value) return false
       if (hasNestedDialogs.value) return false
+      if (props.closeOnOutsideClick === false) return false
       return true
     })
     useOutsideClick(
@@ -249,6 +252,7 @@ export let Dialog = defineComponent({
     let escapeToCloseEnabled = computed(() => {
       if (hasNestedDialogs.value) return false
       if (dialogState.value !== DialogStates.Open) return false
+      if (props.closeOnEscape === false) return false
       return true
     })
     useEventListener(ownerDocument.value?.defaultView, 'keydown', (event) => {


### PR DESCRIPTION
Added two new props to `Dialog`
- `closeOnOutsideClick`, defaults to `true` to match current behavior but allows passing `false` to prevent closing the dialog when clicking outside
- `closeOnEscape`, defaults to `true` to match current behavior but allows passing `false` to prevent closing the dialog when pressing the Escape key

The other option I considered was to pass an argument to `onClose` indicating what action is causing the close. But this would be a backwards incompatible change, since `onClose` is currently called with `false`. Possibly the reason could be the 2nd argument to `onClose`, so it would be `onClose: (open: false, reason: "escape" | "click-outside")`