### PR TITLE
React: Fix performance issue with `useTopLayer` in causing re-renders of all consumers on page whenever a single one changes

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -659,7 +659,7 @@ export type ComboboxProps<
     } | null
 
     onClose?(): void
-
+    outsideClickScope?: string
     __demoMode?: boolean
   }
 >
@@ -685,6 +685,7 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
     // Deprecated, but let's pluck it from the props such that it doesn't end up
     // on the `Fragment`
     nullable: _nullable,
+    outsideClickScope,
     ...theirProps
   } = props
   let defaultValue = useDefaultValue(_defaultValue)
@@ -806,7 +807,8 @@ function ComboboxFn<TValue, TTag extends ElementType = typeof DEFAULT_COMBOBOX_T
   useOutsideClick(
     outsideClickEnabled,
     [data.buttonElement, data.inputElement, data.optionsElement],
-    () => actions.closeCombobox()
+    () => actions.closeCombobox(),
+    outsideClickScope
   )
 
   let slot = useMemo(() => {

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -126,6 +126,7 @@ let InternalDialog = forwardRefWithAs(function InternalDialog<
     autoFocus = true,
     __demoMode = false,
     unmount = false,
+    outsideClickScope,
     ...theirProps
   } = props
 
@@ -213,10 +214,15 @@ let InternalDialog = forwardRefWithAs(function InternalDialog<
   })
 
   // Close Dialog on outside click
-  useOutsideClick(enabled, resolveRootContainers, (event) => {
-    event.preventDefault()
-    close()
-  })
+  useOutsideClick(
+    enabled,
+    resolveRootContainers,
+    (event) => {
+      event.preventDefault()
+      close()
+    },
+    outsideClickScope
+  )
 
   // Handle `Escape` to close
   useEscape(enabled, ownerDocument?.defaultView, (event) => {
@@ -347,6 +353,7 @@ export type DialogProps<TTag extends ElementType = typeof DEFAULT_DIALOG_TAG> = 
     role?: 'dialog' | 'alertdialog'
     autoFocus?: boolean
     transition?: boolean
+    outsideClickScope?: string
     __demoMode?: boolean
   }
 >

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -492,7 +492,7 @@ export type ListboxProps<
     form?: string
     name?: string
     multiple?: boolean
-
+    outsideClickScope?: string
     __demoMode?: boolean
   }
 >
@@ -515,6 +515,7 @@ function ListboxFn<
     horizontal = false,
     multiple = false,
     __demoMode = false,
+    outsideClickScope,
     ...theirProps
   } = props
 
@@ -592,7 +593,8 @@ function ListboxFn<
         event.preventDefault()
         data.buttonElement?.focus()
       }
-    }
+    },
+    outsideClickScope
   )
 
   let slot = useMemo(() => {

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -382,6 +382,7 @@ export type MenuProps<TTag extends ElementType = typeof DEFAULT_MENU_TAG> = Prop
   MenuPropsWeControl,
   {
     __demoMode?: boolean
+    outsideClickScope?: string
   }
 >
 
@@ -389,7 +390,7 @@ function MenuFn<TTag extends ElementType = typeof DEFAULT_MENU_TAG>(
   props: MenuProps<TTag>,
   ref: Ref<HTMLElement>
 ) {
-  let { __demoMode = false, ...theirProps } = props
+  let { __demoMode = false, outsideClickScope, ...theirProps } = props
   let reducerBag = useReducer(stateReducer, {
     __demoMode,
     menuState: __demoMode ? MenuStates.Open : MenuStates.Closed,
@@ -405,14 +406,19 @@ function MenuFn<TTag extends ElementType = typeof DEFAULT_MENU_TAG>(
 
   // Handle outside click
   let outsideClickEnabled = menuState === MenuStates.Open
-  useOutsideClick(outsideClickEnabled, [buttonElement, itemsElement], (event, target) => {
-    dispatch({ type: ActionTypes.CloseMenu })
+  useOutsideClick(
+    outsideClickEnabled,
+    [buttonElement, itemsElement],
+    (event, target) => {
+      dispatch({ type: ActionTypes.CloseMenu })
 
-    if (!isFocusableElement(target, FocusableMode.Loose)) {
-      event.preventDefault()
-      buttonElement?.focus()
-    }
-  })
+      if (!isFocusableElement(target, FocusableMode.Loose)) {
+        event.preventDefault()
+        buttonElement?.focus()
+      }
+    },
+    outsideClickScope
+  )
 
   let close = useEvent(() => {
     dispatch({ type: ActionTypes.CloseMenu })

--- a/packages/@headlessui-react/src/components/popover/popover.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.tsx
@@ -238,6 +238,7 @@ export type PopoverProps<TTag extends ElementType = typeof DEFAULT_POPOVER_TAG> 
   PopoverPropsWeControl,
   {
     __demoMode?: boolean
+    outsideClickScope?: string
   }
 >
 
@@ -245,7 +246,7 @@ function PopoverFn<TTag extends ElementType = typeof DEFAULT_POPOVER_TAG>(
   props: PopoverProps<TTag>,
   ref: Ref<HTMLElement>
 ) {
-  let { __demoMode = false, ...theirProps } = props
+  let { __demoMode = false, outsideClickScope, ...theirProps } = props
   let internalPopoverRef = useRef<HTMLElement | null>(null)
   let popoverRef = useSyncRefs(
     ref,
@@ -375,14 +376,19 @@ function PopoverFn<TTag extends ElementType = typeof DEFAULT_POPOVER_TAG>(
 
   // Handle outside click
   let outsideClickEnabled = popoverState === PopoverStates.Open
-  useOutsideClick(outsideClickEnabled, root.resolveContainers, (event, target) => {
-    dispatch({ type: ActionTypes.ClosePopover })
+  useOutsideClick(
+    outsideClickEnabled,
+    root.resolveContainers,
+    (event, target) => {
+      dispatch({ type: ActionTypes.ClosePopover })
 
-    if (!isFocusableElement(target, FocusableMode.Loose)) {
-      event.preventDefault()
-      button?.focus()
-    }
-  })
+      if (!isFocusableElement(target, FocusableMode.Loose)) {
+        event.preventDefault()
+        button?.focus()
+      }
+    },
+    outsideClickScope
+  )
 
   let close = useEvent(
     (

--- a/packages/@headlessui-react/src/hooks/use-outside-click.ts
+++ b/packages/@headlessui-react/src/hooks/use-outside-click.ts
@@ -21,9 +21,10 @@ const MOVE_THRESHOLD_PX = 30
 export function useOutsideClick(
   enabled: boolean,
   containers: ContainerInput | (() => ContainerInput),
-  cb: (event: MouseEvent | PointerEvent | FocusEvent | TouchEvent, target: HTMLElement) => void
+  cb: (event: MouseEvent | PointerEvent | FocusEvent | TouchEvent, target: HTMLElement) => void,
+  topLayerScope = 'outside-click'
 ) {
-  let isTopLayer = useIsTopLayer(enabled, 'outside-click')
+  let isTopLayer = useIsTopLayer(enabled, topLayerScope)
   let cbRef = useLatestValue(cb)
 
   let handleOutsideClick = useCallback(


### PR DESCRIPTION
Fixes https://github.com/tailwindlabs/headlessui/issues/3630

---

First off, Headless UI is great!! I love that I have full control over the visual display of all components within. Thank you so much for your effort in creating and maintaining this!! 🙏 

---

## My understanding of the problem:

All of the current `useOutsideClick` components (i.e., [Menu](https://github.com/rkoval/headlessui/blob/b22874f71567425037782a68d3518b1229678a3f/packages/@headlessui-react/src/components/menu/menu.tsx#L409-L421), Combobox, Dialog, Listbox, and Popover) rely on [the underlying `useIsTopLayer` hook](https://github.com/rkoval/headlessui/blob/b22874f71567425037782a68d3518b1229678a3f/packages/@headlessui-react/src/hooks/use-outside-click.ts#L26-L27) to know what position of the visual stack each component. As each component renders, they are pushed on top of this `useIsTopLayer` stack. This stack is then used to determine which component to dismiss when clicking off of the menu or pressing "Escape". This is explained better in [this comment](https://github.com/rkoval/headlessui/blob/6ac6930116c47cbd72402c33bfe327698c8e2780/packages/@headlessui-react/src/hooks/use-is-top-layer.ts#L26-L48). 

However, the problem is that each component gets pushed into the stack even if the menu is not being displayed on screen; it is the component trigger that determines what gets added or removed from the stack because it applies to the top-level component. For example, you still must render a top-level `Popover` component to wrap `PopoverButton` even `PopoverPanel` will not be visible until `PopoverButton` is interacted with. This becomes problematic because `useOutsideClick` uses the same bucket key internally for all components that consume it. That means that every time a consuming component renders, it causes the `useIsTopLayer` bucket to add/remove, which triggers re-renders from every component that uses `useOutsideClick`. If you have a lot of these components on screen at once (e.g., think having a table with context menus for each row), this can slow down page performance significantly, especially for lower end devices

## My proposed solution:
For each of the consuming components, expose a `outsideClickScope` prop that will allow passing a scope down into `useIsTopLayer` so that each one has its own bucket/stack. If you have menus that require knowledge of other menus to be in the same stack for closing (e.g., a `Listbox` within a `Dialog`), you must pass in the same scope key for both components so that they know how to interact.

This solves our immediate problem, though it does not feel like the most elegant solution for the following reasons:

1. It doesn't completely solve the underlying re-render problem. There are legitimate use cases for components that have the same scope (e.g., again, components within a `Dialog`), so if you have many of those in the same scope, the same problem is still present.
2. For the components within a `Dialog` use case, you must have some context or mechanism that knows when you need to pass in a specific scope so that the outside click logic knows the order by which to hide the components.
3. I do not know the best way to document this. The existing code is "better" from a usability perspective given that users don't need to know about this internal implementation detail; though, the performance issue basically makes the component not practically usable in any products of remote scale.
4. I don't like the naming I used. I'm happy to change these names to whatever makes the most sense
5. It does nothing to address the Vue codebase, if the problem exists there. I have no experience with Vue, so I cannot help there

All of this said, this solution will solve all practical cases outside of the nested use case, and it's only one I can think of without a broader refactoring of how `useOutsideClick`/`useIsTopLayer` works. Being that I am a first time contributor to this codebase, I know that I do not have the context necessary to make such a sweeping change efficiently and effectively 😅. 

If we want to hold on this PR for a broader/better solution to be implemented, I would love for it to at least be merged as undocumented so that immediate usage is unblocked, and we don't have to maintain our own fork.

I am open to thoughts for how best to proceed!


