### PR TITLE
Improve performance of `Listbox` and `Menu` when closing

### DIFF
--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -849,9 +849,7 @@ function OptionFn<
   useIsoMorphicEffect(() => {
     if (usedInSelectedOption) return
     machine.actions.registerOption(id, bag)
-    return () => {
-      machine.send({ type: ActionTypes.UnregisterOption, id })
-    }
+    return () => machine.actions.unregisterOption(id)
   }, [bag, id, usedInSelectedOption])
 
   let handleClick = useEvent((event: { preventDefault: Function }) => {

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -619,7 +619,7 @@ function ItemFn<TTag extends ElementType = typeof DEFAULT_ITEM_TAG>(
 
   useIsoMorphicEffect(() => {
     machine.actions.registerItem(id, bag)
-    return () => machine.send({ type: ActionTypes.UnregisterItem, id })
+    return () => machine.actions.unregisterItem(id)
   }, [bag, id])
 
   let close = useEvent(() => {


### PR DESCRIPTION
In a previous PR, we already batched registering options. This PR also batches unregistering options to make the closing behavior smoother when there are a lot of items rendered. 