### PR TITLE
Simplify internal tests

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -52,8 +52,6 @@ import {
 
 let NOOP = () => {}
 
-jest.mock('../../hooks/use-id')
-
 // Mocking the `getBoundingClientRect` method for the virtual tests otherwise
 // the `Virtualizer` from `@tanstack/react-virtual` will not work as expected
 // because it couldn't measure the elements correctly.

--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -114,10 +114,7 @@ describe('safeguards', () => {
         </Combobox>
       )
 
-      assertComboboxButton({
-        state: ComboboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-combobox-button-2' },
-      })
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
       assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
     })
   )
@@ -146,18 +143,12 @@ describe('Rendering', () => {
           </Combobox>
         )
 
-        assertComboboxButton({
-          state: ComboboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-combobox-button-2' },
-        })
+        assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
         assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
         await click(getComboboxButton())
 
-        assertComboboxButton({
-          state: ComboboxState.Visible,
-          attributes: { id: 'headlessui-combobox-button-2' },
-        })
+        assertComboboxButton({ state: ComboboxState.Visible })
         assertComboboxList({ state: ComboboxState.Visible })
       })
     )
@@ -177,32 +168,23 @@ describe('Rendering', () => {
           </Combobox>
         )
 
-        assertComboboxButton({
-          state: ComboboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-combobox-button-2' },
-        })
+        assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
         assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
         await click(getComboboxButton())
 
-        assertComboboxButton({
-          state: ComboboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-combobox-button-2' },
-        })
+        assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
         assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
         await press(Keys.Enter, getComboboxButton())
 
-        assertComboboxButton({
-          state: ComboboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-combobox-button-2' },
-        })
+        assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
         assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
         // The input should also be disabled
         assertComboboxInput({
           state: ComboboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-combobox-input-1', disabled: '' },
+          attributes: { disabled: '' },
         })
 
         // And even if we try to focus it, it should not open the combobox
@@ -950,22 +932,13 @@ describe('Rendering', () => {
           </Combobox>
         )
 
-        assertComboboxButton({
-          state: ComboboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-combobox-button-3' },
-        })
-        assertComboboxLabel({
-          attributes: { id: 'headlessui-label-1' },
-          textContent: JSON.stringify({ open: false, disabled: false }),
-        })
+        assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
+        assertComboboxLabel({ textContent: JSON.stringify({ open: false, disabled: false }) })
         assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
         await click(getComboboxButton())
 
-        assertComboboxLabel({
-          attributes: { id: 'headlessui-label-1' },
-          textContent: JSON.stringify({ open: true, disabled: false }),
-        })
+        assertComboboxLabel({ textContent: JSON.stringify({ open: true, disabled: false }) })
         assertComboboxList({ state: ComboboxState.Visible })
         assertComboboxLabelLinkedWithCombobox()
         assertComboboxButtonLinkedWithComboboxLabel()
@@ -1005,7 +978,6 @@ describe('Rendering', () => {
         )
 
         assertComboboxLabel({
-          attributes: { id: 'headlessui-label-1' },
           textContent: JSON.stringify({ open: false, disabled: false }),
           tag: 'p',
         })
@@ -1013,7 +985,6 @@ describe('Rendering', () => {
 
         await click(getComboboxButton())
         assertComboboxLabel({
-          attributes: { id: 'headlessui-label-1' },
           textContent: JSON.stringify({ open: true, disabled: false }),
           tag: 'p',
         })
@@ -1040,7 +1011,6 @@ describe('Rendering', () => {
 
         assertComboboxButton({
           state: ComboboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-combobox-button-2' },
           textContent: JSON.stringify({
             open: false,
             active: false,
@@ -1057,7 +1027,6 @@ describe('Rendering', () => {
 
         assertComboboxButton({
           state: ComboboxState.Visible,
-          attributes: { id: 'headlessui-combobox-button-2' },
           textContent: JSON.stringify({
             open: true,
             active: true,
@@ -1091,7 +1060,6 @@ describe('Rendering', () => {
 
         assertComboboxButton({
           state: ComboboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-combobox-button-2' },
           textContent: JSON.stringify({
             open: false,
             active: false,
@@ -1108,7 +1076,6 @@ describe('Rendering', () => {
 
         assertComboboxButton({
           state: ComboboxState.Visible,
-          attributes: { id: 'headlessui-combobox-button-2' },
           textContent: JSON.stringify({
             open: true,
             active: true,
@@ -1142,10 +1109,7 @@ describe('Rendering', () => {
         // TODO: Needed to make it similar to vue test implementation?
         // await new Promise(requestAnimationFrame)
 
-        assertComboboxButton({
-          state: ComboboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-combobox-button-3' },
-        })
+        assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
         assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
         assertComboboxButtonLinkedWithComboboxLabel()
       })
@@ -1260,18 +1224,12 @@ describe('Rendering', () => {
           </Combobox>
         )
 
-        assertComboboxButton({
-          state: ComboboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-combobox-button-2' },
-        })
+        assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
         assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
         await click(getComboboxButton())
 
-        assertComboboxButton({
-          state: ComboboxState.Visible,
-          attributes: { id: 'headlessui-combobox-button-2' },
-        })
+        assertComboboxButton({ state: ComboboxState.Visible })
         assertComboboxList({
           state: ComboboxState.Visible,
           textContent: JSON.stringify({ open: true }),
@@ -1333,18 +1291,12 @@ describe('Rendering', () => {
           </Combobox>
         )
 
-        assertComboboxButton({
-          state: ComboboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-combobox-button-2' },
-        })
+        assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
         assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
         await click(getComboboxButton())
 
-        assertComboboxButton({
-          state: ComboboxState.Visible,
-          attributes: { id: 'headlessui-combobox-button-2' },
-        })
+        assertComboboxButton({ state: ComboboxState.Visible })
         assertComboboxList({
           state: ComboboxState.Visible,
           textContent: JSON.stringify({
@@ -1932,10 +1884,7 @@ describe('Rendering composition', () => {
         </Combobox>
       )
 
-      assertComboboxButton({
-        state: ComboboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-combobox-button-2' },
-      })
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
       assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
       // Open Combobox
@@ -2013,10 +1962,7 @@ describe('Rendering composition', () => {
         </Combobox>
       )
 
-      assertComboboxButton({
-        state: ComboboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-combobox-button-2' },
-      })
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
       assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
       // Open Combobox
@@ -2110,18 +2056,12 @@ describe('Composition', () => {
         </Combobox>
       )
 
-      assertComboboxButton({
-        state: ComboboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-combobox-button-2' },
-      })
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
       assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
       await rawClick(getComboboxButton())
 
-      assertComboboxButton({
-        state: ComboboxState.Visible,
-        attributes: { id: 'headlessui-combobox-button-2' },
-      })
+      assertComboboxButton({ state: ComboboxState.Visible })
       assertComboboxList({
         state: ComboboxState.Visible,
         textContent: JSON.stringify({
@@ -2228,10 +2168,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the button
@@ -2245,10 +2182,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             // Verify it is visible
             assertComboboxButton({ state: ComboboxState.Visible })
-            assertComboboxList({
-              state: ComboboxState.Visible,
-              attributes: { id: 'headlessui-combobox-options-3' },
-            })
+            assertComboboxList({ state: ComboboxState.Visible })
             assertActiveElement(getComboboxInput())
             assertComboboxButtonLinkedWithCombobox()
 
@@ -2267,10 +2201,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox comboboxProps={{ disabled: true }} />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Try to focus the button
@@ -2280,10 +2211,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
             await press(Keys.Enter)
 
             // Verify it is still closed
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
           })
         )
@@ -2293,10 +2221,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox comboboxProps={{ value: 'Option B' }} />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the button
@@ -2310,10 +2235,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             // Verify it is visible
             assertComboboxButton({ state: ComboboxState.Visible })
-            assertComboboxList({
-              state: ComboboxState.Visible,
-              attributes: { id: 'headlessui-combobox-options-3' },
-            })
+            assertComboboxList({ state: ComboboxState.Visible })
             assertActiveElement(getComboboxInput())
             assertComboboxButtonLinkedWithCombobox()
 
@@ -2344,10 +2266,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
               </Combobox>
             )
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleHidden,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleHidden })
             assertComboboxList({ state: ComboboxState.InvisibleHidden })
 
             // Focus the button
@@ -2361,10 +2280,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             // Verify it is visible
             assertComboboxButton({ state: ComboboxState.Visible })
-            assertComboboxList({
-              state: ComboboxState.Visible,
-              attributes: { id: 'headlessui-combobox-options-3' },
-            })
+            assertComboboxList({ state: ComboboxState.Visible })
             assertActiveElement(getComboboxInput())
             assertComboboxButtonLinkedWithCombobox()
 
@@ -2399,10 +2315,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox comboboxProps={{ value: 'Option B' }} />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the button
@@ -2416,10 +2329,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             // Verify it is visible
             assertComboboxButton({ state: ComboboxState.Visible })
-            assertComboboxList({
-              state: ComboboxState.Visible,
-              attributes: { id: 'headlessui-combobox-options-3' },
-            })
+            assertComboboxList({ state: ComboboxState.Visible })
             assertActiveElement(getComboboxInput())
             assertComboboxButtonLinkedWithCombobox()
 
@@ -2463,10 +2373,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the button
@@ -2480,10 +2387,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             // Verify it is visible
             assertComboboxButton({ state: ComboboxState.Visible })
-            assertComboboxList({
-              state: ComboboxState.Visible,
-              attributes: { id: 'headlessui-combobox-options-3' },
-            })
+            assertComboboxList({ state: ComboboxState.Visible })
             assertActiveElement(getComboboxInput())
             assertComboboxButtonLinkedWithCombobox()
 
@@ -2500,10 +2404,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox comboboxProps={{ value: undefined, disabled: true }} />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the button
@@ -2513,10 +2414,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
             await press(Keys.Space)
 
             // Verify it is still closed
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
           })
         )
@@ -2526,13 +2424,8 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox comboboxProps={{ value: 'Option B' }} />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
-            assertComboboxList({
-              state: ComboboxState.InvisibleUnmounted,
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
+            assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the button
             await focus(getComboboxButton())
@@ -2542,10 +2435,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             // Verify it is visible
             assertComboboxButton({ state: ComboboxState.Visible })
-            assertComboboxList({
-              state: ComboboxState.Visible,
-              attributes: { id: 'headlessui-combobox-options-3' },
-            })
+            assertComboboxList({ state: ComboboxState.Visible })
             assertActiveElement(getComboboxInput())
             assertComboboxButtonLinkedWithCombobox()
 
@@ -2593,13 +2483,8 @@ describe.each([{ virtual: true }, { virtual: false }])(
               />
             )
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
-            assertComboboxList({
-              state: ComboboxState.InvisibleUnmounted,
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
+            assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the button
             await focus(getComboboxButton())
@@ -2623,10 +2508,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             // Verify it is visible
             assertComboboxButton({ state: ComboboxState.Visible })
-            assertComboboxList({
-              state: ComboboxState.Visible,
-              attributes: { id: 'headlessui-combobox-options-3' },
-            })
+            assertComboboxList({ state: ComboboxState.Visible })
             assertActiveElement(getComboboxInput())
             assertComboboxButtonLinkedWithCombobox()
 
@@ -2695,10 +2577,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the button
@@ -2709,10 +2588,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             // Verify it is visible
             assertComboboxButton({ state: ComboboxState.Visible })
-            assertComboboxList({
-              state: ComboboxState.Visible,
-              attributes: { id: 'headlessui-combobox-options-3' },
-            })
+            assertComboboxList({ state: ComboboxState.Visible })
             assertActiveElement(getComboboxInput())
             assertComboboxButtonLinkedWithCombobox()
 
@@ -2731,10 +2607,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox comboboxProps={{ disabled: true }} />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the button
@@ -2744,10 +2617,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
             await press(Keys.ArrowDown)
 
             // Verify it is still closed
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
           })
         )
@@ -2757,10 +2627,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox comboboxProps={{ value: 'Option B' }} />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the button
@@ -2771,10 +2638,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             // Verify it is visible
             assertComboboxButton({ state: ComboboxState.Visible })
-            assertComboboxList({
-              state: ComboboxState.Visible,
-              attributes: { id: 'headlessui-combobox-options-3' },
-            })
+            assertComboboxList({ state: ComboboxState.Visible })
             assertActiveElement(getComboboxInput())
             assertComboboxButtonLinkedWithCombobox()
 
@@ -2814,10 +2678,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox comboboxProps={{ value: undefined }} />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the button
@@ -2828,10 +2689,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             // Verify it is visible
             assertComboboxButton({ state: ComboboxState.Visible })
-            assertComboboxList({
-              state: ComboboxState.Visible,
-              attributes: { id: 'headlessui-combobox-options-3' },
-            })
+            assertComboboxList({ state: ComboboxState.Visible })
             assertActiveElement(getComboboxInput())
             assertComboboxButtonLinkedWithCombobox()
 
@@ -2850,10 +2708,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox comboboxProps={{ disabled: true }} />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the button
@@ -2863,10 +2718,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
             await press(Keys.ArrowUp)
 
             // Verify it is still closed
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
           })
         )
@@ -2876,10 +2728,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox comboboxProps={{ value: 'Option B' }} />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the button
@@ -2890,10 +2739,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             // Verify it is visible
             assertComboboxButton({ state: ComboboxState.Visible })
-            assertComboboxList({
-              state: ComboboxState.Visible,
-              attributes: { id: 'headlessui-combobox-options-3' },
-            })
+            assertComboboxList({ state: ComboboxState.Visible })
             assertActiveElement(getComboboxInput())
             assertComboboxButtonLinkedWithCombobox()
 
@@ -2941,7 +2787,6 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             assertComboboxButton({
               state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
             })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
@@ -2988,10 +2833,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             render(<Example />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Open combobox
@@ -3128,10 +2970,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             render(<Example />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Open combobox
@@ -3172,10 +3011,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             render(<Example />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Open combobox
@@ -3211,10 +3047,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             // Verify it is visible
             assertComboboxButton({ state: ComboboxState.Visible })
-            assertComboboxList({
-              state: ComboboxState.Visible,
-              attributes: { id: 'headlessui-combobox-options-3' },
-            })
+            assertComboboxList({ state: ComboboxState.Visible })
             assertActiveElement(getComboboxInput())
             assertComboboxButtonLinkedWithCombobox()
 
@@ -3354,10 +3187,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the input
@@ -3368,10 +3198,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             // Verify it is visible
             assertComboboxButton({ state: ComboboxState.Visible })
-            assertComboboxList({
-              state: ComboboxState.Visible,
-              attributes: { id: 'headlessui-combobox-options-3' },
-            })
+            assertComboboxList({ state: ComboboxState.Visible })
             assertActiveElement(getComboboxInput())
             assertComboboxButtonLinkedWithCombobox()
 
@@ -3390,10 +3217,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox comboboxProps={{ value: undefined, disabled: true }} />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the input
@@ -3403,10 +3227,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
             await press(Keys.ArrowDown)
 
             // Verify it is still closed
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
           })
         )
@@ -3416,10 +3237,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox comboboxProps={{ value: 'Option B' }} />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the input
@@ -3430,10 +3248,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             // Verify it is visible
             assertComboboxButton({ state: ComboboxState.Visible })
-            assertComboboxList({
-              state: ComboboxState.Visible,
-              attributes: { id: 'headlessui-combobox-options-3' },
-            })
+            assertComboboxList({ state: ComboboxState.Visible })
             assertActiveElement(getComboboxInput())
             assertComboboxButtonLinkedWithCombobox()
 
@@ -3471,10 +3286,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Open combobox
@@ -3514,10 +3326,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
               />
             )
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Open combobox
@@ -3548,10 +3357,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
               />
             )
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Open combobox
@@ -3574,10 +3380,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox comboboxProps={{ value: null }} />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Open combobox
@@ -3603,10 +3406,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox comboboxProps={{ value: undefined }} />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the input
@@ -3617,10 +3417,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             // Verify it is visible
             assertComboboxButton({ state: ComboboxState.Visible })
-            assertComboboxList({
-              state: ComboboxState.Visible,
-              attributes: { id: 'headlessui-combobox-options-3' },
-            })
+            assertComboboxList({ state: ComboboxState.Visible })
             assertActiveElement(getComboboxInput())
             assertComboboxButtonLinkedWithCombobox()
 
@@ -3639,10 +3436,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox comboboxProps={{ disabled: true }} />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the input
@@ -3652,10 +3446,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
             await press(Keys.ArrowUp)
 
             // Verify it is still closed
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
           })
         )
@@ -3665,10 +3456,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox comboboxProps={{ value: 'Option B' }} />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the input
@@ -3679,10 +3467,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             // Verify it is visible
             assertComboboxButton({ state: ComboboxState.Visible })
-            assertComboboxList({
-              state: ComboboxState.Visible,
-              attributes: { id: 'headlessui-combobox-options-3' },
-            })
+            assertComboboxList({ state: ComboboxState.Visible })
             assertActiveElement(getComboboxInput())
             assertComboboxButtonLinkedWithCombobox()
 
@@ -3728,10 +3513,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
               />
             )
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the input
@@ -3762,10 +3544,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
               />
             )
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Open combobox
@@ -3795,10 +3574,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
           suppressConsoleLogs(async () => {
             render(<MyCombobox comboboxProps={{ value: undefined }} />)
 
-            assertComboboxButton({
-              state: ComboboxState.InvisibleUnmounted,
-              attributes: { id: 'headlessui-combobox-button-2' },
-            })
+            assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
             assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
             // Focus the input
@@ -3809,10 +3585,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
 
             // Verify it is visible
             assertComboboxButton({ state: ComboboxState.Visible })
-            assertComboboxList({
-              state: ComboboxState.Visible,
-              attributes: { id: 'headlessui-combobox-options-3' },
-            })
+            assertComboboxList({ state: ComboboxState.Visible })
             assertActiveElement(getComboboxInput())
             assertComboboxButtonLinkedWithCombobox()
 
@@ -4710,10 +4483,7 @@ describe.each([{ virtual: true }, { virtual: false }])('Mouse interactions %s', 
     suppressConsoleLogs(async () => {
       render(<MyCombobox comboboxProps={{ immediate: true }} label={false} />)
 
-      assertComboboxButton({
-        state: ComboboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-combobox-button-2' },
-      })
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
       assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
       // Focus the input
@@ -4721,10 +4491,7 @@ describe.each([{ virtual: true }, { virtual: false }])('Mouse interactions %s', 
 
       // Verify it is visible
       assertComboboxButton({ state: ComboboxState.Visible })
-      assertComboboxList({
-        state: ComboboxState.Visible,
-        attributes: { id: 'headlessui-combobox-options-3' },
-      })
+      assertComboboxList({ state: ComboboxState.Visible })
       assertActiveElement(getComboboxInput())
       assertComboboxButtonLinkedWithCombobox()
 
@@ -4740,20 +4507,14 @@ describe.each([{ virtual: true }, { virtual: false }])('Mouse interactions %s', 
     suppressConsoleLogs(async () => {
       render(<MyCombobox />)
 
-      assertComboboxButton({
-        state: ComboboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-combobox-button-3' },
-      })
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
       assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
       // Focus the input
       await focus(getComboboxInput())
 
       // Verify it is invisible
-      assertComboboxButton({
-        state: ComboboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-combobox-button-3' },
-      })
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
       assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
     })
   )
@@ -4763,20 +4524,14 @@ describe.each([{ virtual: true }, { virtual: false }])('Mouse interactions %s', 
     suppressConsoleLogs(async () => {
       render(<MyCombobox comboboxProps={{ immediate: true, disabled: true }} />)
 
-      assertComboboxButton({
-        state: ComboboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-combobox-button-3' },
-      })
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
       assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
       // Focus the input
       await focus(getComboboxInput())
 
       // Verify it is invisible
-      assertComboboxButton({
-        state: ComboboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-combobox-button-3' },
-      })
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
       assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
     })
   )
@@ -4830,10 +4585,7 @@ describe.each([{ virtual: true }, { virtual: false }])('Mouse interactions %s', 
     suppressConsoleLogs(async () => {
       render(<MyCombobox label={false} />)
 
-      assertComboboxButton({
-        state: ComboboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-combobox-button-2' },
-      })
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
       assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
       // Open combobox
@@ -4841,10 +4593,7 @@ describe.each([{ virtual: true }, { virtual: false }])('Mouse interactions %s', 
 
       // Verify it is visible
       assertComboboxButton({ state: ComboboxState.Visible })
-      assertComboboxList({
-        state: ComboboxState.Visible,
-        attributes: { id: 'headlessui-combobox-options-3' },
-      })
+      assertComboboxList({ state: ComboboxState.Visible })
       assertActiveElement(getComboboxInput())
       assertComboboxButtonLinkedWithCombobox()
 
@@ -4860,10 +4609,7 @@ describe.each([{ virtual: true }, { virtual: false }])('Mouse interactions %s', 
     suppressConsoleLogs(async () => {
       render(<MyCombobox label={false} />)
 
-      assertComboboxButton({
-        state: ComboboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-combobox-button-2' },
-      })
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
       assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
       // Try to open the combobox
@@ -4879,20 +4625,14 @@ describe.each([{ virtual: true }, { virtual: false }])('Mouse interactions %s', 
     suppressConsoleLogs(async () => {
       render(<MyCombobox comboboxProps={{ value: undefined, disabled: true }} label={false} />)
 
-      assertComboboxButton({
-        state: ComboboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-combobox-button-2' },
-      })
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
       assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
       // Try to open the combobox
       await click(getComboboxButton())
 
       // Verify it is still closed
-      assertComboboxButton({
-        state: ComboboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-combobox-button-2' },
-      })
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
       assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
     })
   )
@@ -4902,10 +4642,7 @@ describe.each([{ virtual: true }, { virtual: false }])('Mouse interactions %s', 
     suppressConsoleLogs(async () => {
       render(<MyCombobox comboboxProps={{ value: 'Option B' }} label={false} />)
 
-      assertComboboxButton({
-        state: ComboboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-combobox-button-2' },
-      })
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
       assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
       // Open combobox
@@ -4913,10 +4650,7 @@ describe.each([{ virtual: true }, { virtual: false }])('Mouse interactions %s', 
 
       // Verify it is visible
       assertComboboxButton({ state: ComboboxState.Visible })
-      assertComboboxList({
-        state: ComboboxState.Visible,
-        attributes: { id: 'headlessui-combobox-options-3' },
-      })
+      assertComboboxList({ state: ComboboxState.Visible })
       assertActiveElement(getComboboxInput())
       assertComboboxButtonLinkedWithCombobox()
 
@@ -5460,18 +5194,12 @@ describe.each([{ virtual: true }, { virtual: false }])('Mouse interactions %s', 
     suppressConsoleLogs(async () => {
       render(<MyCombobox optionsProps={{ hold: true }} label={false} />)
 
-      assertComboboxButton({
-        state: ComboboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-combobox-button-2' },
-      })
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted })
       assertComboboxList({ state: ComboboxState.InvisibleUnmounted })
 
       await click(getComboboxButton())
 
-      assertComboboxButton({
-        state: ComboboxState.Visible,
-        attributes: { id: 'headlessui-combobox-button-2' },
-      })
+      assertComboboxButton({ state: ComboboxState.Visible })
       assertComboboxList({ state: ComboboxState.Visible })
 
       let options = getComboboxOptions()

--- a/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
@@ -21,8 +21,6 @@ import { Popover } from '../popover/popover'
 import { Transition } from '../transition/transition'
 import { Dialog } from './dialog'
 
-jest.mock('../../hooks/use-id')
-
 afterAll(() => jest.restoreAllMocks())
 
 function nextFrame() {

--- a/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.test.tsx
@@ -65,10 +65,7 @@ describe('Safe guards', () => {
         </Dialog>
       )
 
-      assertDialog({
-        state: DialogState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-dialog-1' },
-      })
+      assertDialog({ state: DialogState.InvisibleUnmounted })
     })
   )
 })
@@ -584,10 +581,7 @@ describe('Rendering', () => {
 
         await nextFrame()
 
-        assertDialog({
-          state: DialogState.Visible,
-          attributes: { id: 'headlessui-dialog-1' },
-        })
+        assertDialog({ state: DialogState.Visible })
         assertDialogTitle({
           state: DialogState.Visible,
           textContent: JSON.stringify({ open: true }),
@@ -609,10 +603,7 @@ describe('Rendering', () => {
 
         await nextFrame()
 
-        assertDialog({
-          state: DialogState.Visible,
-          attributes: { id: 'headlessui-dialog-1' },
-        })
+        assertDialog({ state: DialogState.Visible })
         assertDialogDescription({
           state: DialogState.Visible,
           textContent: JSON.stringify({ open: true, disabled: false }),
@@ -754,10 +745,7 @@ describe('Keyboard interactions', () => {
         await click(document.getElementById('trigger'))
 
         // Verify it is open
-        assertDialog({
-          state: DialogState.Visible,
-          attributes: { id: 'headlessui-dialog-1' },
-        })
+        assertDialog({ state: DialogState.Visible })
 
         // Close dialog
         await press(Keys.Escape)
@@ -793,10 +781,7 @@ describe('Keyboard interactions', () => {
         await click(document.getElementById('trigger'))
 
         // Verify it is open
-        assertDialog({
-          state: DialogState.Visible,
-          attributes: { id: 'headlessui-dialog-1' },
-        })
+        assertDialog({ state: DialogState.Visible })
 
         // Close dialog
         await press(Keys.Escape)
@@ -838,10 +823,7 @@ describe('Keyboard interactions', () => {
         await click(document.getElementById('trigger'))
 
         // Verify it is open
-        assertDialog({
-          state: DialogState.Visible,
-          attributes: { id: 'headlessui-dialog-1' },
-        })
+        assertDialog({ state: DialogState.Visible })
 
         // Try to close the dialog
         await press(Keys.Escape)
@@ -885,10 +867,7 @@ describe('Keyboard interactions', () => {
         await click(document.getElementById('trigger'))
 
         // Verify it is open
-        assertDialog({
-          state: DialogState.Visible,
-          attributes: { id: 'headlessui-dialog-1' },
-        })
+        assertDialog({ state: DialogState.Visible })
 
         // Verify that the input field is focused
         assertActiveElement(document.getElementById('b'))
@@ -935,10 +914,7 @@ describe('Keyboard interactions', () => {
         await click(document.getElementById('trigger'))
 
         // Verify it is open
-        assertDialog({
-          state: DialogState.Visible,
-          attributes: { id: 'headlessui-dialog-1' },
-        })
+        assertDialog({ state: DialogState.Visible })
 
         // Verify that the input field is focused
         assertActiveElement(document.getElementById('a'))
@@ -985,10 +961,7 @@ describe('Keyboard interactions', () => {
         await click(document.getElementById('trigger'))
 
         // Verify it is open
-        assertDialog({
-          state: DialogState.Visible,
-          attributes: { id: 'headlessui-dialog-1' },
-        })
+        assertDialog({ state: DialogState.Visible })
 
         // Verify that the input field is focused
         assertActiveElement(document.getElementById('a'))

--- a/packages/@headlessui-react/src/components/disclosure/disclosure.test.tsx
+++ b/packages/@headlessui-react/src/components/disclosure/disclosure.test.tsx
@@ -14,8 +14,6 @@ import { suppressConsoleLogs } from '../../test-utils/suppress-console-logs'
 import { Transition } from '../transition/transition'
 import { Disclosure, DisclosureButton, DisclosurePanel } from './disclosure'
 
-jest.mock('../../hooks/use-id')
-
 afterAll(() => jest.restoreAllMocks())
 
 function nextFrame() {

--- a/packages/@headlessui-react/src/components/disclosure/disclosure.test.tsx
+++ b/packages/@headlessui-react/src/components/disclosure/disclosure.test.tsx
@@ -51,10 +51,7 @@ describe('Safe guards', () => {
         </Disclosure>
       )
 
-      assertDisclosureButton({
-        state: DisclosureState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-disclosure-button-1' },
-      })
+      assertDisclosureButton({ state: DisclosureState.InvisibleUnmounted })
       assertDisclosurePanel({ state: DisclosureState.InvisibleUnmounted })
     })
   )
@@ -76,18 +73,12 @@ describe('Rendering', () => {
           </Disclosure>
         )
 
-        assertDisclosureButton({
-          state: DisclosureState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-disclosure-button-1' },
-        })
+        assertDisclosureButton({ state: DisclosureState.InvisibleUnmounted })
         assertDisclosurePanel({ state: DisclosureState.InvisibleUnmounted })
 
         await click(getDisclosureButton())
 
-        assertDisclosureButton({
-          state: DisclosureState.Visible,
-          attributes: { id: 'headlessui-disclosure-button-1' },
-        })
+        assertDisclosureButton({ state: DisclosureState.Visible })
         assertDisclosurePanel({ state: DisclosureState.Visible, textContent: 'Panel is: open' })
       })
     )
@@ -104,10 +95,7 @@ describe('Rendering', () => {
         </Disclosure>
       )
 
-      assertDisclosureButton({
-        state: DisclosureState.Visible,
-        attributes: { id: 'headlessui-disclosure-button-1' },
-      })
+      assertDisclosureButton({ state: DisclosureState.Visible })
       assertDisclosurePanel({ state: DisclosureState.Visible, textContent: 'Panel is: open' })
 
       await click(getDisclosureButton())
@@ -263,7 +251,6 @@ describe('Rendering', () => {
 
         assertDisclosureButton({
           state: DisclosureState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-disclosure-button-1' },
           textContent: JSON.stringify({
             open: false,
             hover: false,
@@ -279,7 +266,6 @@ describe('Rendering', () => {
 
         assertDisclosureButton({
           state: DisclosureState.Visible,
-          attributes: { id: 'headlessui-disclosure-button-1' },
           textContent: JSON.stringify({
             open: true,
             hover: false,
@@ -307,7 +293,6 @@ describe('Rendering', () => {
 
         assertDisclosureButton({
           state: DisclosureState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-disclosure-button-1' },
           textContent: JSON.stringify({
             open: false,
             hover: false,
@@ -323,7 +308,6 @@ describe('Rendering', () => {
 
         assertDisclosureButton({
           state: DisclosureState.Visible,
-          attributes: { id: 'headlessui-disclosure-button-1' },
           textContent: JSON.stringify({
             open: true,
             hover: false,
@@ -474,18 +458,12 @@ describe('Rendering', () => {
           </Disclosure>
         )
 
-        assertDisclosureButton({
-          state: DisclosureState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-disclosure-button-1' },
-        })
+        assertDisclosureButton({ state: DisclosureState.InvisibleUnmounted })
         assertDisclosurePanel({ state: DisclosureState.InvisibleUnmounted })
 
         await click(getDisclosureButton())
 
-        assertDisclosureButton({
-          state: DisclosureState.Visible,
-          attributes: { id: 'headlessui-disclosure-button-1' },
-        })
+        assertDisclosureButton({ state: DisclosureState.Visible })
         assertDisclosurePanel({
           state: DisclosureState.Visible,
           textContent: JSON.stringify({ open: true }),
@@ -710,10 +688,7 @@ describe('Keyboard interactions', () => {
           </Disclosure>
         )
 
-        assertDisclosureButton({
-          state: DisclosureState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-disclosure-button-1' },
-        })
+        assertDisclosureButton({ state: DisclosureState.InvisibleUnmounted })
         assertDisclosurePanel({ state: DisclosureState.InvisibleUnmounted })
 
         // Focus the button
@@ -724,10 +699,7 @@ describe('Keyboard interactions', () => {
 
         // Verify it is open
         assertDisclosureButton({ state: DisclosureState.Visible })
-        assertDisclosurePanel({
-          state: DisclosureState.Visible,
-          attributes: { id: 'headlessui-disclosure-panel-2' },
-        })
+        assertDisclosurePanel({ state: DisclosureState.Visible })
 
         // Close disclosure
         await press(Keys.Enter)
@@ -745,10 +717,7 @@ describe('Keyboard interactions', () => {
           </Disclosure>
         )
 
-        assertDisclosureButton({
-          state: DisclosureState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-disclosure-button-1' },
-        })
+        assertDisclosureButton({ state: DisclosureState.InvisibleUnmounted })
         assertDisclosurePanel({ state: DisclosureState.InvisibleUnmounted })
 
         // Focus the button
@@ -758,10 +727,7 @@ describe('Keyboard interactions', () => {
         await press(Keys.Enter)
 
         // Verify it is still closed
-        assertDisclosureButton({
-          state: DisclosureState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-disclosure-button-1' },
-        })
+        assertDisclosureButton({ state: DisclosureState.InvisibleUnmounted })
         assertDisclosurePanel({ state: DisclosureState.InvisibleUnmounted })
       })
     )
@@ -776,10 +742,7 @@ describe('Keyboard interactions', () => {
           </Disclosure>
         )
 
-        assertDisclosureButton({
-          state: DisclosureState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-disclosure-button-1' },
-        })
+        assertDisclosureButton({ state: DisclosureState.InvisibleUnmounted })
         assertDisclosurePanel({ state: DisclosureState.InvisibleUnmounted })
 
         // Focus the button
@@ -790,10 +753,7 @@ describe('Keyboard interactions', () => {
 
         // Verify it is open
         assertDisclosureButton({ state: DisclosureState.Visible })
-        assertDisclosurePanel({
-          state: DisclosureState.Visible,
-          attributes: { id: 'headlessui-disclosure-panel-2' },
-        })
+        assertDisclosurePanel({ state: DisclosureState.Visible })
 
         // Close disclosure
         await press(Keys.Enter)
@@ -816,10 +776,7 @@ describe('Keyboard interactions', () => {
           </Disclosure>
         )
 
-        assertDisclosureButton({
-          state: DisclosureState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-disclosure-button-1' },
-        })
+        assertDisclosureButton({ state: DisclosureState.InvisibleUnmounted })
         assertDisclosurePanel({ state: DisclosureState.InvisibleUnmounted })
 
         // Focus the button
@@ -830,10 +787,7 @@ describe('Keyboard interactions', () => {
 
         // Verify it is open
         assertDisclosureButton({ state: DisclosureState.Visible })
-        assertDisclosurePanel({
-          state: DisclosureState.Visible,
-          attributes: { id: 'headlessui-disclosure-panel-2' },
-        })
+        assertDisclosurePanel({ state: DisclosureState.Visible })
       })
     )
 
@@ -847,10 +801,7 @@ describe('Keyboard interactions', () => {
           </Disclosure>
         )
 
-        assertDisclosureButton({
-          state: DisclosureState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-disclosure-button-1' },
-        })
+        assertDisclosureButton({ state: DisclosureState.InvisibleUnmounted })
         assertDisclosurePanel({ state: DisclosureState.InvisibleUnmounted })
 
         // Focus the button
@@ -860,10 +811,7 @@ describe('Keyboard interactions', () => {
         await press(Keys.Space)
 
         // Verify it is still closed
-        assertDisclosureButton({
-          state: DisclosureState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-disclosure-button-1' },
-        })
+        assertDisclosureButton({ state: DisclosureState.InvisibleUnmounted })
         assertDisclosurePanel({ state: DisclosureState.InvisibleUnmounted })
       })
     )
@@ -878,10 +826,7 @@ describe('Keyboard interactions', () => {
           </Disclosure>
         )
 
-        assertDisclosureButton({
-          state: DisclosureState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-disclosure-button-1' },
-        })
+        assertDisclosureButton({ state: DisclosureState.InvisibleUnmounted })
         assertDisclosurePanel({ state: DisclosureState.InvisibleUnmounted })
 
         // Focus the button
@@ -892,10 +837,7 @@ describe('Keyboard interactions', () => {
 
         // Verify it is open
         assertDisclosureButton({ state: DisclosureState.Visible })
-        assertDisclosurePanel({
-          state: DisclosureState.Visible,
-          attributes: { id: 'headlessui-disclosure-panel-2' },
-        })
+        assertDisclosurePanel({ state: DisclosureState.Visible })
 
         // Close disclosure
         await press(Keys.Space)
@@ -919,10 +861,7 @@ describe('Mouse interactions', () => {
         </Disclosure>
       )
 
-      assertDisclosureButton({
-        state: DisclosureState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-disclosure-button-1' },
-      })
+      assertDisclosureButton({ state: DisclosureState.InvisibleUnmounted })
       assertDisclosurePanel({ state: DisclosureState.InvisibleUnmounted })
 
       // Open disclosure
@@ -930,10 +869,7 @@ describe('Mouse interactions', () => {
 
       // Verify it is open
       assertDisclosureButton({ state: DisclosureState.Visible })
-      assertDisclosurePanel({
-        state: DisclosureState.Visible,
-        attributes: { id: 'headlessui-disclosure-panel-2' },
-      })
+      assertDisclosurePanel({ state: DisclosureState.Visible })
     })
   )
 
@@ -947,20 +883,14 @@ describe('Mouse interactions', () => {
         </Disclosure>
       )
 
-      assertDisclosureButton({
-        state: DisclosureState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-disclosure-button-1' },
-      })
+      assertDisclosureButton({ state: DisclosureState.InvisibleUnmounted })
       assertDisclosurePanel({ state: DisclosureState.InvisibleUnmounted })
 
       // Open disclosure
       await click(getDisclosureButton(), MouseButton.Right)
 
       // Verify it is still closed
-      assertDisclosureButton({
-        state: DisclosureState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-disclosure-button-1' },
-      })
+      assertDisclosureButton({ state: DisclosureState.InvisibleUnmounted })
       assertDisclosurePanel({ state: DisclosureState.InvisibleUnmounted })
     })
   )
@@ -975,20 +905,14 @@ describe('Mouse interactions', () => {
         </Disclosure>
       )
 
-      assertDisclosureButton({
-        state: DisclosureState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-disclosure-button-1' },
-      })
+      assertDisclosureButton({ state: DisclosureState.InvisibleUnmounted })
       assertDisclosurePanel({ state: DisclosureState.InvisibleUnmounted })
 
       // Try to open the disclosure
       await click(getDisclosureButton())
 
       // Verify it is still closed
-      assertDisclosureButton({
-        state: DisclosureState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-disclosure-button-1' },
-      })
+      assertDisclosureButton({ state: DisclosureState.InvisibleUnmounted })
       assertDisclosurePanel({ state: DisclosureState.InvisibleUnmounted })
     })
   )

--- a/packages/@headlessui-react/src/components/listbox/listbox.test.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.test.tsx
@@ -37,8 +37,6 @@ import { suppressConsoleLogs } from '../../test-utils/suppress-console-logs'
 import { Transition } from '../transition/transition'
 import { Listbox, ListboxButton, ListboxOption, ListboxOptions } from './listbox'
 
-jest.mock('../../hooks/use-id')
-
 beforeAll(() => {
   jest.spyOn(window, 'requestAnimationFrame').mockImplementation(setImmediate as any)
   jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(clearImmediate as any)

--- a/packages/@headlessui-react/src/components/listbox/listbox.test.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.test.tsx
@@ -83,10 +83,7 @@ describe('safeguards', () => {
         </Listbox>
       )
 
-      assertListboxButton({
-        state: ListboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-listbox-button-1' },
-      })
+      assertListboxButton({ state: ListboxState.InvisibleUnmounted })
       assertListbox({ state: ListboxState.InvisibleUnmounted })
     })
   )
@@ -114,18 +111,12 @@ describe('Rendering', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         await click(getListboxButton())
 
-        assertListboxButton({
-          state: ListboxState.Visible,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.Visible })
         assertListbox({ state: ListboxState.Visible })
       })
     )
@@ -144,26 +135,17 @@ describe('Rendering', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         await click(getListboxButton())
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         await press(Keys.Enter, getListboxButton())
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
       })
     )
@@ -521,22 +503,13 @@ describe('Rendering', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-2' },
-        })
-        assertListboxLabel({
-          attributes: { id: 'headlessui-label-1' },
-          textContent: JSON.stringify({ open: false, disabled: false }),
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
+        assertListboxLabel({ textContent: JSON.stringify({ open: false, disabled: false }) })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         await click(getListboxButton())
 
-        assertListboxLabel({
-          attributes: { id: 'headlessui-label-1' },
-          textContent: JSON.stringify({ open: true, disabled: false }),
-        })
+        assertListboxLabel({ textContent: JSON.stringify({ open: true, disabled: false }) })
         assertListbox({ state: ListboxState.Visible })
         assertListboxButtonLinkedWithListboxLabel()
       })
@@ -558,7 +531,6 @@ describe('Rendering', () => {
         )
 
         assertListboxLabel({
-          attributes: { id: 'headlessui-label-1' },
           textContent: JSON.stringify({ open: false, disabled: false }),
           tag: 'p',
         })
@@ -566,7 +538,6 @@ describe('Rendering', () => {
 
         await click(getListboxButton())
         assertListboxLabel({
-          attributes: { id: 'headlessui-label-1' },
           textContent: JSON.stringify({ open: true, disabled: false }),
           tag: 'p',
         })
@@ -592,7 +563,6 @@ describe('Rendering', () => {
 
         assertListboxButton({
           state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
           textContent: JSON.stringify({
             open: false,
             active: false,
@@ -609,7 +579,6 @@ describe('Rendering', () => {
 
         assertListboxButton({
           state: ListboxState.Visible,
-          attributes: { id: 'headlessui-listbox-button-1' },
           textContent: JSON.stringify({
             open: true,
             active: true,
@@ -642,7 +611,6 @@ describe('Rendering', () => {
 
         assertListboxButton({
           state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
           textContent: JSON.stringify({
             open: false,
             active: false,
@@ -659,7 +627,6 @@ describe('Rendering', () => {
 
         assertListboxButton({
           state: ListboxState.Visible,
-          attributes: { id: 'headlessui-listbox-button-1' },
           textContent: JSON.stringify({
             open: true,
             active: true,
@@ -692,10 +659,7 @@ describe('Rendering', () => {
         // TODO: Needed to make it similar to vue test implementation?
         // await new Promise(requestAnimationFrame)
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-2' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
         assertListboxButtonLinkedWithListboxLabel()
       })
@@ -805,22 +769,13 @@ describe('Rendering', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         await click(getListboxButton())
 
-        assertListboxButton({
-          state: ListboxState.Visible,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
-        assertListbox({
-          state: ListboxState.Visible,
-          textContent: JSON.stringify({ open: true }),
-        })
+        assertListboxButton({ state: ListboxState.Visible })
+        assertListbox({ state: ListboxState.Visible, textContent: JSON.stringify({ open: true }) })
         assertActiveElement(getListbox())
       })
     )
@@ -875,18 +830,12 @@ describe('Rendering', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         await click(getListboxButton())
 
-        assertListboxButton({
-          state: ListboxState.Visible,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.Visible })
         assertListbox({
           state: ListboxState.Visible,
           textContent: JSON.stringify({
@@ -1309,10 +1258,7 @@ describe('Rendering composition', () => {
         </Listbox>
       )
 
-      assertListboxButton({
-        state: ListboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-listbox-button-1' },
-      })
+      assertListboxButton({ state: ListboxState.InvisibleUnmounted })
       assertListbox({ state: ListboxState.InvisibleUnmounted })
 
       // Open Listbox
@@ -1420,10 +1366,7 @@ describe('Rendering composition', () => {
         </Listbox>
       )
 
-      assertListboxButton({
-        state: ListboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-listbox-button-1' },
-      })
+      assertListboxButton({ state: ListboxState.InvisibleUnmounted })
       assertListbox({ state: ListboxState.InvisibleUnmounted })
 
       // Open Listbox
@@ -1470,18 +1413,12 @@ describe('Composition', () => {
         </Listbox>
       )
 
-      assertListboxButton({
-        state: ListboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-listbox-button-1' },
-      })
+      assertListboxButton({ state: ListboxState.InvisibleUnmounted })
       assertListbox({ state: ListboxState.InvisibleUnmounted })
 
       await rawClick(getListboxButton())
 
-      assertListboxButton({
-        state: ListboxState.Visible,
-        attributes: { id: 'headlessui-listbox-button-1' },
-      })
+      assertListboxButton({ state: ListboxState.Visible })
       assertListbox({
         state: ListboxState.Visible,
         textContent: JSON.stringify({
@@ -1523,10 +1460,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Open listbox
@@ -1575,10 +1509,7 @@ describe('Keyboard interactions', () => {
 
         render(<Example />)
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Open listbox
@@ -1629,10 +1560,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -1643,10 +1571,7 @@ describe('Keyboard interactions', () => {
 
         // Verify it is visible
         assertListboxButton({ state: ListboxState.Visible })
-        assertListbox({
-          state: ListboxState.Visible,
-          attributes: { id: 'headlessui-listbox-options-2' },
-        })
+        assertListbox({ state: ListboxState.Visible })
         assertActiveElement(getListbox())
         assertListboxButtonLinkedWithListbox()
 
@@ -1672,10 +1597,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -1685,10 +1607,7 @@ describe('Keyboard interactions', () => {
         await press(Keys.Space)
 
         // Verify it is still closed
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
       })
     )
@@ -1707,10 +1626,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -1721,10 +1637,7 @@ describe('Keyboard interactions', () => {
 
         // Verify it is visible
         assertListboxButton({ state: ListboxState.Visible })
-        assertListbox({
-          state: ListboxState.Visible,
-          attributes: { id: 'headlessui-listbox-options-2' },
-        })
+        assertListbox({ state: ListboxState.Visible })
         assertActiveElement(getListbox())
         assertListboxButtonLinkedWithListbox()
 
@@ -1778,10 +1691,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -1815,10 +1725,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -1854,10 +1761,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -1898,10 +1802,7 @@ describe('Keyboard interactions', () => {
 
         render(<Example />)
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Open listbox
@@ -1960,10 +1861,7 @@ describe('Keyboard interactions', () => {
 
         // Verify it is visible
         assertListboxButton({ state: ListboxState.Visible })
-        assertListbox({
-          state: ListboxState.Visible,
-          attributes: { id: 'headlessui-listbox-options-2' },
-        })
+        assertListbox({ state: ListboxState.Visible })
         assertActiveElement(getListbox())
         assertListboxButtonLinkedWithListbox()
 
@@ -1998,10 +1896,7 @@ describe('Keyboard interactions', () => {
           </>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -2012,10 +1907,7 @@ describe('Keyboard interactions', () => {
 
         // Verify it is visible
         assertListboxButton({ state: ListboxState.Visible })
-        assertListbox({
-          state: ListboxState.Visible,
-          attributes: { id: 'headlessui-listbox-options-2' },
-        })
+        assertListbox({ state: ListboxState.Visible })
         assertActiveElement(getListbox())
         assertListboxButtonLinkedWithListbox()
 
@@ -2052,10 +1944,7 @@ describe('Keyboard interactions', () => {
           </>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -2066,10 +1955,7 @@ describe('Keyboard interactions', () => {
 
         // Verify it is visible
         assertListboxButton({ state: ListboxState.Visible })
-        assertListbox({
-          state: ListboxState.Visible,
-          attributes: { id: 'headlessui-listbox-options-2' },
-        })
+        assertListbox({ state: ListboxState.Visible })
         assertActiveElement(getListbox())
         assertListboxButtonLinkedWithListbox()
 
@@ -2105,10 +1991,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -2119,10 +2002,7 @@ describe('Keyboard interactions', () => {
 
         // Verify it is visible
         assertListboxButton({ state: ListboxState.Visible })
-        assertListbox({
-          state: ListboxState.Visible,
-          attributes: { id: 'headlessui-listbox-options-2' },
-        })
+        assertListbox({ state: ListboxState.Visible })
         assertActiveElement(getListbox())
         assertListboxButtonLinkedWithListbox()
 
@@ -2150,10 +2030,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -2163,10 +2040,7 @@ describe('Keyboard interactions', () => {
         await press(Keys.ArrowDown)
 
         // Verify it is still closed
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
       })
     )
@@ -2185,10 +2059,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -2199,10 +2070,7 @@ describe('Keyboard interactions', () => {
 
         // Verify it is visible
         assertListboxButton({ state: ListboxState.Visible })
-        assertListbox({
-          state: ListboxState.Visible,
-          attributes: { id: 'headlessui-listbox-options-2' },
-        })
+        assertListbox({ state: ListboxState.Visible })
         assertActiveElement(getListbox())
         assertListboxButtonLinkedWithListbox()
 
@@ -2254,10 +2122,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -2302,10 +2167,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -2344,10 +2206,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -2380,10 +2239,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -2428,24 +2284,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
-        assertListbox({ state: ListboxState.InvisibleUnmounted })
-
-        // Focus the button
-        await focus(getListboxButton())
-
-        // Open listbox
-        await press(Keys.ArrowUp)
-
-        // Verify it is visible
-        assertListboxButton({ state: ListboxState.Visible })
-        assertListbox({
-          state: ListboxState.Visible,
-          attributes: { id: 'headlessui-listbox-options-2' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertActiveElement(getListbox())
         assertListboxButtonLinkedWithListbox()
 
@@ -2473,10 +2312,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -2486,10 +2322,7 @@ describe('Keyboard interactions', () => {
         await press(Keys.ArrowUp)
 
         // Verify it is still closed
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
       })
     )
@@ -2508,10 +2341,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -2522,10 +2352,7 @@ describe('Keyboard interactions', () => {
 
         // Verify it is visible
         assertListboxButton({ state: ListboxState.Visible })
-        assertListbox({
-          state: ListboxState.Visible,
-          attributes: { id: 'headlessui-listbox-options-2' },
-        })
+        assertListbox({ state: ListboxState.Visible })
         assertActiveElement(getListbox())
         assertListboxButtonLinkedWithListbox()
 
@@ -2581,10 +2408,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -2619,10 +2443,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -2661,10 +2482,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -2675,10 +2493,7 @@ describe('Keyboard interactions', () => {
 
         // Verify it is visible
         assertListboxButton({ state: ListboxState.Visible })
-        assertListbox({
-          state: ListboxState.Visible,
-          attributes: { id: 'headlessui-listbox-options-2' },
-        })
+        assertListbox({ state: ListboxState.Visible })
         assertActiveElement(getListbox())
         assertListboxButtonLinkedWithListbox()
 
@@ -2718,10 +2533,7 @@ describe('Keyboard interactions', () => {
           </Listbox>
         )
 
-        assertListboxButton({
-          state: ListboxState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-listbox-button-1' },
-        })
+        assertListboxButton({ state: ListboxState.InvisibleUnmounted })
         assertListbox({ state: ListboxState.InvisibleUnmounted })
 
         // Focus the button
@@ -2732,11 +2544,7 @@ describe('Keyboard interactions', () => {
 
         // Verify it is visible
         assertListboxButton({ state: ListboxState.Visible })
-        assertListbox({
-          state: ListboxState.Visible,
-          attributes: { id: 'headlessui-listbox-options-2' },
-          orientation: 'horizontal',
-        })
+        assertListbox({ state: ListboxState.Visible, orientation: 'horizontal' })
         assertActiveElement(getListbox())
         assertListboxButtonLinkedWithListbox()
 
@@ -3675,10 +3483,7 @@ describe('Mouse interactions', () => {
         </Listbox>
       )
 
-      assertListboxButton({
-        state: ListboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-listbox-button-1' },
-      })
+      assertListboxButton({ state: ListboxState.InvisibleUnmounted })
       assertListbox({ state: ListboxState.InvisibleUnmounted })
 
       // Open listbox
@@ -3686,10 +3491,7 @@ describe('Mouse interactions', () => {
 
       // Verify it is visible
       assertListboxButton({ state: ListboxState.Visible })
-      assertListbox({
-        state: ListboxState.Visible,
-        attributes: { id: 'headlessui-listbox-options-2' },
-      })
+      assertListbox({ state: ListboxState.Visible })
       assertActiveElement(getListbox())
       assertListboxButtonLinkedWithListbox()
 
@@ -3714,10 +3516,7 @@ describe('Mouse interactions', () => {
         </Listbox>
       )
 
-      assertListboxButton({
-        state: ListboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-listbox-button-1' },
-      })
+      assertListboxButton({ state: ListboxState.InvisibleUnmounted })
       assertListbox({ state: ListboxState.InvisibleUnmounted })
 
       // Try to open the listbox
@@ -3742,20 +3541,14 @@ describe('Mouse interactions', () => {
         </Listbox>
       )
 
-      assertListboxButton({
-        state: ListboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-listbox-button-1' },
-      })
+      assertListboxButton({ state: ListboxState.InvisibleUnmounted })
       assertListbox({ state: ListboxState.InvisibleUnmounted })
 
       // Try to open the listbox
       await click(getListboxButton())
 
       // Verify it is still closed
-      assertListboxButton({
-        state: ListboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-listbox-button-1' },
-      })
+      assertListboxButton({ state: ListboxState.InvisibleUnmounted })
       assertListbox({ state: ListboxState.InvisibleUnmounted })
     })
   )
@@ -3774,10 +3567,7 @@ describe('Mouse interactions', () => {
         </Listbox>
       )
 
-      assertListboxButton({
-        state: ListboxState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-listbox-button-1' },
-      })
+      assertListboxButton({ state: ListboxState.InvisibleUnmounted })
       assertListbox({ state: ListboxState.InvisibleUnmounted })
 
       // Open listbox
@@ -3785,10 +3575,7 @@ describe('Mouse interactions', () => {
 
       // Verify it is visible
       assertListboxButton({ state: ListboxState.Visible })
-      assertListbox({
-        state: ListboxState.Visible,
-        attributes: { id: 'headlessui-listbox-options-2' },
-      })
+      assertListbox({ state: ListboxState.Visible })
       assertActiveElement(getListbox())
       assertListboxButtonLinkedWithListbox()
 

--- a/packages/@headlessui-react/src/components/menu/menu.test.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.test.tsx
@@ -98,18 +98,12 @@ describe('Rendering', () => {
           </Menu>
         )
 
-        assertMenuButton({
-          state: MenuState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-menu-button-1' },
-        })
+        assertMenuButton({ state: MenuState.InvisibleUnmounted })
         assertMenu({ state: MenuState.InvisibleUnmounted })
 
         await click(getMenuButton())
 
-        assertMenuButton({
-          state: MenuState.Visible,
-          attributes: { id: 'headlessui-menu-button-1' },
-        })
+        assertMenuButton({ state: MenuState.Visible })
         assertMenu({ state: MenuState.Visible })
       })
     )
@@ -169,7 +163,6 @@ describe('Rendering', () => {
 
         assertMenuButton({
           state: MenuState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-menu-button-1' },
           textContent: JSON.stringify({
             open: false,
             active: false,
@@ -185,7 +178,6 @@ describe('Rendering', () => {
 
         assertMenuButton({
           state: MenuState.Visible,
-          attributes: { id: 'headlessui-menu-button-1' },
           textContent: JSON.stringify({
             open: true,
             active: true,
@@ -217,7 +209,6 @@ describe('Rendering', () => {
 
         assertMenuButton({
           state: MenuState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-menu-button-1' },
           textContent: JSON.stringify({
             open: false,
             active: false,
@@ -233,7 +224,6 @@ describe('Rendering', () => {
 
         assertMenuButton({
           state: MenuState.Visible,
-          attributes: { id: 'headlessui-menu-button-1' },
           textContent: JSON.stringify({
             open: true,
             active: true,
@@ -353,7 +343,6 @@ describe('Rendering', () => {
 
         assertMenuButton({
           state: MenuState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-menu-button-1' },
         })
         assertMenu({ state: MenuState.InvisibleUnmounted })
 
@@ -361,7 +350,6 @@ describe('Rendering', () => {
 
         assertMenuButton({
           state: MenuState.Visible,
-          attributes: { id: 'headlessui-menu-button-1' },
         })
         assertMenu({
           state: MenuState.Visible,
@@ -422,7 +410,6 @@ describe('Rendering', () => {
 
         assertMenuButton({
           state: MenuState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-menu-button-1' },
         })
         assertMenu({ state: MenuState.InvisibleUnmounted })
 
@@ -430,7 +417,6 @@ describe('Rendering', () => {
 
         assertMenuButton({
           state: MenuState.Visible,
-          attributes: { id: 'headlessui-menu-button-1' },
         })
         assertMenu({
           state: MenuState.Visible,
@@ -583,7 +569,6 @@ describe('Rendering composition', () => {
 
       assertMenuButton({
         state: MenuState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-menu-button-1' },
       })
       assertMenu({ state: MenuState.InvisibleUnmounted })
 
@@ -652,7 +637,6 @@ describe('Rendering composition', () => {
 
       assertMenuButton({
         state: MenuState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-menu-button-1' },
       })
       assertMenu({ state: MenuState.InvisibleUnmounted })
 
@@ -748,7 +732,6 @@ describe('Composition', () => {
 
       assertMenuButton({
         state: MenuState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-menu-button-1' },
       })
       assertMenu({ state: MenuState.InvisibleUnmounted })
 
@@ -756,7 +739,6 @@ describe('Composition', () => {
 
       assertMenuButton({
         state: MenuState.Visible,
-        attributes: { id: 'headlessui-menu-button-1' },
       })
       assertMenu({
         state: MenuState.Visible,
@@ -802,16 +784,12 @@ describe('Composition', () => {
 
       assertMenuButton({
         state: MenuState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-menu-button-1' },
       })
       assertMenu({ state: MenuState.InvisibleUnmounted })
 
       await rawClick(getMenuButton())
 
-      assertMenuButton({
-        state: MenuState.Visible,
-        attributes: { id: 'headlessui-menu-button-1' },
-      })
+      assertMenuButton({ state: MenuState.Visible })
       assertMenu({
         state: MenuState.Visible,
         textContent: JSON.stringify({ active: false, focus: false, disabled: false }),

--- a/packages/@headlessui-react/src/components/menu/menu.test.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.test.tsx
@@ -33,8 +33,6 @@ import { suppressConsoleLogs } from '../../test-utils/suppress-console-logs'
 import { Transition } from '../transition/transition'
 import { Menu, MenuButton, MenuItem, MenuItems } from './menu'
 
-jest.mock('../../hooks/use-id')
-
 beforeAll(() => {
   jest.spyOn(window, 'requestAnimationFrame').mockImplementation(setImmediate as any)
   jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(clearImmediate as any)

--- a/packages/@headlessui-react/src/components/popover/popover.test.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.test.tsx
@@ -18,8 +18,6 @@ import { Portal } from '../portal/portal'
 import { Transition } from '../transition/transition'
 import { Popover, PopoverButton, PopoverPanel } from './popover'
 
-jest.mock('../../hooks/use-id')
-
 afterAll(() => jest.restoreAllMocks())
 
 function nextFrame() {

--- a/packages/@headlessui-react/src/components/popover/popover.test.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.test.tsx
@@ -57,10 +57,7 @@ describe('Safe guards', () => {
         </Popover>
       )
 
-      assertPopoverButton({
-        state: PopoverState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-popover-button-1' },
-      })
+      assertPopoverButton({ state: PopoverState.InvisibleUnmounted })
       assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
     })
   )
@@ -124,18 +121,12 @@ describe('Rendering', () => {
           </Popover>
         )
 
-        assertPopoverButton({
-          state: PopoverState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-popover-button-1' },
-        })
+        assertPopoverButton({ state: PopoverState.InvisibleUnmounted })
         assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
 
         await click(getPopoverButton())
 
-        assertPopoverButton({
-          state: PopoverState.Visible,
-          attributes: { id: 'headlessui-popover-button-1' },
-        })
+        assertPopoverButton({ state: PopoverState.Visible })
         assertPopoverPanel({ state: PopoverState.Visible, textContent: 'Panel is: open' })
       })
     )
@@ -349,18 +340,12 @@ describe('Rendering', () => {
           </Popover>
         )
 
-        assertPopoverButton({
-          state: PopoverState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-popover-button-1' },
-        })
+        assertPopoverButton({ state: PopoverState.InvisibleUnmounted })
         assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
 
         await click(getPopoverButton())
 
-        assertPopoverButton({
-          state: PopoverState.Visible,
-          attributes: { id: 'headlessui-popover-button-1' },
-        })
+        assertPopoverButton({ state: PopoverState.Visible })
         assertPopoverPanel({ state: PopoverState.Visible })
       })
     )
@@ -376,7 +361,6 @@ describe('Rendering', () => {
 
         assertPopoverButton({
           state: PopoverState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-popover-button-1' },
           textContent: JSON.stringify({
             open: false,
             active: false,
@@ -392,7 +376,6 @@ describe('Rendering', () => {
 
         assertPopoverButton({
           state: PopoverState.Visible,
-          attributes: { id: 'headlessui-popover-button-1' },
           textContent: JSON.stringify({
             open: true,
             active: true,
@@ -420,7 +403,6 @@ describe('Rendering', () => {
 
         assertPopoverButton({
           state: PopoverState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-popover-button-1' },
           textContent: JSON.stringify({
             open: false,
             active: false,
@@ -436,7 +418,6 @@ describe('Rendering', () => {
 
         assertPopoverButton({
           state: PopoverState.Visible,
-          attributes: { id: 'headlessui-popover-button-1' },
           textContent: JSON.stringify({
             open: true,
             active: true,
@@ -522,18 +503,12 @@ describe('Rendering', () => {
           </Popover>
         )
 
-        assertPopoverButton({
-          state: PopoverState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-popover-button-1' },
-        })
+        assertPopoverButton({ state: PopoverState.InvisibleUnmounted })
         assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
 
         await click(getPopoverButton())
 
-        assertPopoverButton({
-          state: PopoverState.Visible,
-          attributes: { id: 'headlessui-popover-button-1' },
-        })
+        assertPopoverButton({ state: PopoverState.Visible })
         assertPopoverPanel({
           state: PopoverState.Visible,
           textContent: JSON.stringify({ open: true }),
@@ -1032,10 +1007,7 @@ describe('Keyboard interactions', () => {
           </Popover>
         )
 
-        assertPopoverButton({
-          state: PopoverState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-popover-button-1' },
-        })
+        assertPopoverButton({ state: PopoverState.InvisibleUnmounted })
         assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
 
         // Focus the button
@@ -1046,10 +1018,7 @@ describe('Keyboard interactions', () => {
 
         // Verify it is open
         assertPopoverButton({ state: PopoverState.Visible })
-        assertPopoverPanel({
-          state: PopoverState.Visible,
-          attributes: { id: 'headlessui-popover-panel-3' },
-        })
+        assertPopoverPanel({ state: PopoverState.Visible })
 
         // Close popover
         await press(Keys.Enter)
@@ -1067,10 +1036,7 @@ describe('Keyboard interactions', () => {
           </Popover>
         )
 
-        assertPopoverButton({
-          state: PopoverState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-popover-button-1' },
-        })
+        assertPopoverButton({ state: PopoverState.InvisibleUnmounted })
         assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
 
         // Focus the button
@@ -1080,10 +1046,7 @@ describe('Keyboard interactions', () => {
         await press(Keys.Enter)
 
         // Verify it is still closed
-        assertPopoverButton({
-          state: PopoverState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-popover-button-1' },
-        })
+        assertPopoverButton({ state: PopoverState.InvisibleUnmounted })
         assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
       })
     )
@@ -1098,10 +1061,7 @@ describe('Keyboard interactions', () => {
           </Popover>
         )
 
-        assertPopoverButton({
-          state: PopoverState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-popover-button-1' },
-        })
+        assertPopoverButton({ state: PopoverState.InvisibleUnmounted })
         assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
 
         // Focus the button
@@ -1112,10 +1072,7 @@ describe('Keyboard interactions', () => {
 
         // Verify it is open
         assertPopoverButton({ state: PopoverState.Visible })
-        assertPopoverPanel({
-          state: PopoverState.Visible,
-          attributes: { id: 'headlessui-popover-panel-3' },
-        })
+        assertPopoverPanel({ state: PopoverState.Visible })
 
         // Close popover
         await press(Keys.Enter)
@@ -2081,10 +2038,7 @@ describe('Keyboard interactions', () => {
           </Popover>
         )
 
-        assertPopoverButton({
-          state: PopoverState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-popover-button-1' },
-        })
+        assertPopoverButton({ state: PopoverState.InvisibleUnmounted })
         assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
 
         // Focus the button
@@ -2095,10 +2049,7 @@ describe('Keyboard interactions', () => {
 
         // Verify it is open
         assertPopoverButton({ state: PopoverState.Visible })
-        assertPopoverPanel({
-          state: PopoverState.Visible,
-          attributes: { id: 'headlessui-popover-panel-3' },
-        })
+        assertPopoverPanel({ state: PopoverState.Visible })
       })
     )
 
@@ -2112,10 +2063,7 @@ describe('Keyboard interactions', () => {
           </Popover>
         )
 
-        assertPopoverButton({
-          state: PopoverState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-popover-button-1' },
-        })
+        assertPopoverButton({ state: PopoverState.InvisibleUnmounted })
         assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
 
         // Focus the button
@@ -2125,10 +2073,7 @@ describe('Keyboard interactions', () => {
         await press(Keys.Space)
 
         // Verify it is still closed
-        assertPopoverButton({
-          state: PopoverState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-popover-button-1' },
-        })
+        assertPopoverButton({ state: PopoverState.InvisibleUnmounted })
         assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
       })
     )
@@ -2143,10 +2088,7 @@ describe('Keyboard interactions', () => {
           </Popover>
         )
 
-        assertPopoverButton({
-          state: PopoverState.InvisibleUnmounted,
-          attributes: { id: 'headlessui-popover-button-1' },
-        })
+        assertPopoverButton({ state: PopoverState.InvisibleUnmounted })
         assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
 
         // Focus the button
@@ -2157,10 +2099,7 @@ describe('Keyboard interactions', () => {
 
         // Verify it is open
         assertPopoverButton({ state: PopoverState.Visible })
-        assertPopoverPanel({
-          state: PopoverState.Visible,
-          attributes: { id: 'headlessui-popover-panel-3' },
-        })
+        assertPopoverPanel({ state: PopoverState.Visible })
 
         // Close popover
         await press(Keys.Space)
@@ -2292,10 +2231,7 @@ describe('Mouse interactions', () => {
         </Popover>
       )
 
-      assertPopoverButton({
-        state: PopoverState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-popover-button-1' },
-      })
+      assertPopoverButton({ state: PopoverState.InvisibleUnmounted })
       assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
 
       // Open popover
@@ -2303,10 +2239,7 @@ describe('Mouse interactions', () => {
 
       // Verify it is open
       assertPopoverButton({ state: PopoverState.Visible })
-      assertPopoverPanel({
-        state: PopoverState.Visible,
-        attributes: { id: 'headlessui-popover-panel-3' },
-      })
+      assertPopoverPanel({ state: PopoverState.Visible })
     })
   )
 
@@ -2320,20 +2253,14 @@ describe('Mouse interactions', () => {
         </Popover>
       )
 
-      assertPopoverButton({
-        state: PopoverState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-popover-button-1' },
-      })
+      assertPopoverButton({ state: PopoverState.InvisibleUnmounted })
       assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
 
       // Open popover
       await click(getPopoverButton(), MouseButton.Right)
 
       // Verify it is still closed
-      assertPopoverButton({
-        state: PopoverState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-popover-button-1' },
-      })
+      assertPopoverButton({ state: PopoverState.InvisibleUnmounted })
       assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
     })
   )
@@ -2348,20 +2275,14 @@ describe('Mouse interactions', () => {
         </Popover>
       )
 
-      assertPopoverButton({
-        state: PopoverState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-popover-button-1' },
-      })
+      assertPopoverButton({ state: PopoverState.InvisibleUnmounted })
       assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
 
       // Try to open the popover
       await click(getPopoverButton())
 
       // Verify it is still closed
-      assertPopoverButton({
-        state: PopoverState.InvisibleUnmounted,
-        attributes: { id: 'headlessui-popover-button-1' },
-      })
+      assertPopoverButton({ state: PopoverState.InvisibleUnmounted })
       assertPopoverPanel({ state: PopoverState.InvisibleUnmounted })
     })
   )

--- a/packages/@headlessui-react/src/components/radio-group/radio-group.test.tsx
+++ b/packages/@headlessui-react/src/components/radio-group/radio-group.test.tsx
@@ -12,8 +12,6 @@ import { Keys, click, focus, press, shift } from '../../test-utils/interactions'
 import { suppressConsoleLogs } from '../../test-utils/suppress-console-logs'
 import { RadioGroup } from './radio-group'
 
-jest.mock('../../hooks/use-id')
-
 beforeAll(() => {
   jest.spyOn(window, 'requestAnimationFrame').mockImplementation(setImmediate as any)
   jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(clearImmediate as any)

--- a/packages/@headlessui-react/src/components/switch/switch.test.tsx
+++ b/packages/@headlessui-react/src/components/switch/switch.test.tsx
@@ -11,8 +11,6 @@ import {
 import { click, focus, Keys, mouseEnter, press } from '../../test-utils/interactions'
 import { Switch } from './switch'
 
-jest.mock('../../hooks/use-id')
-
 describe('Safe guards', () => {
   it('should be possible to render a Switch without crashing', () => {
     render(<Switch checked={false} onChange={console.log} />)

--- a/packages/@headlessui-react/src/components/tabs/tabs.test.tsx
+++ b/packages/@headlessui-react/src/components/tabs/tabs.test.tsx
@@ -11,8 +11,6 @@ import { suppressConsoleLogs } from '../../test-utils/suppress-console-logs'
 import { Dialog } from '../dialog/dialog'
 import { Tab } from './tabs'
 
-jest.mock('../../hooks/use-id')
-
 beforeAll(() => {
   jest.spyOn(window, 'requestAnimationFrame').mockImplementation(setImmediate as any)
   jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(clearImmediate as any)


### PR DESCRIPTION
This PR simplifies the internal tests a bit.

1. Don't explicitly test if a component has a specific ID
1. Don't mock the `useId` hook if it's not necessary

What we care about more is that 2 components (E.g.: `MenuButton` and `MenuItems`) are connected to each other. This is done via `id` and `aria-controls` attributes. The exact ID is not important.

The main motivation for this is that every time we introduce some `useId()` hook call somewhere, the IDs will shift and it will look like some tests are broken.

If we are not explicitly testing the IDs, we also don't really care about deterministic incrementing IDs in tests, so therefore we can remove some `useId` mocking.

Note: some tests still have mocks like this (e.g.: `description.test.ts` & `label.test.ts`) but that's because they have some snapshot tests.
