### PR TITLE
Fix `Listbox` not focusing first or last option on ArrowUp/ArrowDown

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix clicking `Label` component should open `<Input type="file">` ([#3707](https://github.com/tailwindlabs/headlessui/pull/3707))
 - Ensure clicking on interactive elements inside `Label` component works ([#3709](https://github.com/tailwindlabs/headlessui/pull/3709))
 - Fix focus not returned to SVG Element ([#3704](https://github.com/tailwindlabs/headlessui/pull/3704))
+- Fix `Listbox` not focusing first or last option on ArrowUp / ArrowDown ([#3721](https://github.com/tailwindlabs/headlessui/pull/3721))
 
 ## [2.2.2] - 2025-04-17
 

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -404,14 +404,12 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
       case Keys.Space:
       case Keys.ArrowDown:
         event.preventDefault()
-        flushSync(() => machine.actions.openListbox())
-        if (!data.value) machine.actions.goToOption({ focus: Focus.First })
+        machine.actions.openListbox({ focus: data.value ? Focus.Nothing : Focus.First })
         break
 
       case Keys.ArrowUp:
         event.preventDefault()
-        flushSync(() => machine.actions.openListbox())
-        if (!data.value) machine.actions.goToOption({ focus: Focus.Last })
+        machine.actions.openListbox({ focus: data.value ? Focus.Nothing : Focus.Last })
         break
     }
   })
@@ -435,7 +433,7 @@ function ButtonFn<TTag extends ElementType = typeof DEFAULT_BUTTON_TAG>(
       machine.state.buttonElement?.focus({ preventScroll: true })
     } else {
       event.preventDefault()
-      machine.actions.openListbox()
+      machine.actions.openListbox({ focus: Focus.Nothing })
     }
   })
 


### PR DESCRIPTION
This PR fixes an issue where if a Listbox does not have a value yet, and it's opened via an ArrowUp or ArrowDown (on the ListboxButton) then it didn't correctly go to the firs or last option.

Before, we were opening the listbox in a `flushSync()` call, after that call we were focusing the first or last option depending on if you used the ArrowDown or ArrowUp keys.

However, the options can and will be registered at a later point in time, which means that the focus of first or last option is technically going to fail because no options are available yet.

With this fix we don't need the `flushSync` call, and instead we passthrough a pending focus. Once the options are registered, if a pending focus is present, only then will we focus the correct option.

This gets rid of timing issues.
