### PR TITLE
Performance improvement: only re-render top-level component

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure clicking on interactive elements inside `Label` component works ([#3709](https://github.com/tailwindlabs/headlessui/pull/3709))
 - Fix focus not returned to SVG Element ([#3704](https://github.com/tailwindlabs/headlessui/pull/3704))
 - Fix `Listbox` not focusing first or last option on ArrowUp / ArrowDown ([#3721](https://github.com/tailwindlabs/headlessui/pull/3721))
+- Performance improvement: only re-render top-level component when nesting components e.g.: `Menu` inside a `Dialog` ([#3722](https://github.com/tailwindlabs/headlessui/pull/3722))
 
 ## [2.2.2] - 2025-04-17
 

--- a/packages/@headlessui-react/src/machine.ts
+++ b/packages/@headlessui-react/src/machine.ts
@@ -8,8 +8,14 @@ export abstract class Machine<State, Event extends { type: number | string }> {
   )
   #subscribers: Set<Subscriber<State, any>> = new Set()
 
+  disposables = disposables()
+
   constructor(initialState: State) {
     this.#state = initialState
+  }
+
+  dispose() {
+    this.disposables.dispose()
   }
 
   get state(): Readonly<State> {
@@ -29,16 +35,16 @@ export abstract class Machine<State, Event extends { type: number | string }> {
     }
     this.#subscribers.add(subscriber)
 
-    return () => {
+    return this.disposables.add(() => {
       this.#subscribers.delete(subscriber)
-    }
+    })
   }
 
   on(type: Event['type'], callback: (state: State, event: Event) => void) {
     this.#eventSubscribers.get(type).add(callback)
-    return () => {
+    return this.disposables.add(() => {
       this.#eventSubscribers.get(type).delete(callback)
-    }
+    })
   }
 
   send(event: Event) {

--- a/packages/@headlessui-react/src/machine.ts
+++ b/packages/@headlessui-react/src/machine.ts
@@ -48,7 +48,10 @@ export abstract class Machine<State, Event extends { type: number | string }> {
   }
 
   send(event: Event) {
-    this.#state = this.reduce(this.#state, event)
+    let newState = this.reduce(this.#state, event)
+    if (newState === this.#state) return // No change
+
+    this.#state = newState
 
     for (let subscriber of this.#subscribers) {
       let slice = subscriber.selector(this.#state)

--- a/packages/@headlessui-react/src/machines/stack-machine.ts
+++ b/packages/@headlessui-react/src/machines/stack-machine.ts
@@ -1,0 +1,72 @@
+import { Machine } from '../machine'
+import { DefaultMap } from '../utils/default-map'
+import { match } from '../utils/match'
+
+type Scope = string | null
+type Id = string
+
+interface State {
+  stack: Id[]
+}
+
+export enum ActionTypes {
+  Push,
+  Pop,
+}
+
+export type Actions = { type: ActionTypes.Push; id: Id } | { type: ActionTypes.Pop; id: Id }
+
+let reducers: {
+  [P in ActionTypes]: (state: State, action: Extract<Actions, { type: P }>) => State
+} = {
+  [ActionTypes.Push](state, action) {
+    let id = action.id
+    let stack = state.stack
+    let idx = state.stack.indexOf(id)
+
+    // Already in the stack, move it to the top
+    if (idx !== -1) {
+      let copy = state.stack.slice()
+      copy.splice(idx, 1)
+      copy.push(id)
+
+      stack = copy
+      return { ...state, stack }
+    }
+
+    // Not in the stack, add it to the top
+    return { ...state, stack: [...state.stack, id] }
+  },
+  [ActionTypes.Pop](state, action) {
+    let id = action.id
+    let idx = state.stack.indexOf(id)
+    if (idx === -1) return state // Not in the stack
+
+    let copy = state.stack.slice()
+    copy.splice(idx, 1)
+
+    return { ...state, stack: copy }
+  },
+}
+
+class StackMachine extends Machine<State, Actions> {
+  static new() {
+    return new StackMachine({ stack: [] })
+  }
+
+  reduce(state: Readonly<State>, action: Actions): State {
+    return match(action.type, reducers, state, action)
+  }
+
+  actions = {
+    push: (id: Id) => this.send({ type: ActionTypes.Push, id }),
+    pop: (id: Id) => this.send({ type: ActionTypes.Pop, id }),
+  }
+
+  selectors = {
+    isTop: (state: State, id: Id) => state.stack[state.stack.length - 1] === id,
+    inStack: (state: State, id: Id) => state.stack.includes(id),
+  }
+}
+
+export const stackMachines = new DefaultMap<Scope, StackMachine>(() => StackMachine.new())

--- a/playgrounds/react/pages/dialog/dialog.tsx
+++ b/playgrounds/react/pages/dialog/dialog.tsx
@@ -95,6 +95,7 @@ export default function Home() {
 
               <Transition.Child
                 as="div"
+                className="relative"
                 enter="ease-out transform duration-300"
                 enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                 enterTo="opacity-100 translate-y-0 sm:scale-100"


### PR DESCRIPTION
This PR fixes a performance issue where all components using the `useIsTopLayer` hook will re-render when the hook changes.

For context, the internal hook is used to know which component is the top most component. This is important in a situation like this:

```
<Dialog>
  <Menu />
</Dialog>
```

If the Menu inside the Dialog is open, it is considered the top most component. Clicking outside of the Menu or pressing escape should only close the Menu and not the Dialog.

This behavior is similar to the native `#top-layer` you see when using native dialogs for example.

The issue however is that the `useIsTopLayer` subscribes to an external store which is shared across all components. This means that when the store changes, all components using the hook will re-render. 

To make things worse, since we can't use these hooks unconditionally, they will all be subscribed to the store even if the Menu component(s) are not open.

To solve this, we will use a new state machine and use the `useMachine` hook. This internally uses a `useSyncExternalStoreWithSelector` to subscribe to the store.

This means that the component will only re-render if the state computed by the selector changes.

This now means that at most 2 components will re-render when the store changes:

1. The component that _was_ in the top most position
2. The component that is going to be in the top most position

Fixes: #3630
Closes: #3662


# Test plan

Behavior before: notice how all Menu components re-render:

https://github.com/user-attachments/assets/3172b632-0fa4-42db-970c-39efc827dd84

After this change, only the Menu that was opened / closed will re-render:

https://github.com/user-attachments/assets/5d254bfc-5233-47a7-94d3-eb7a8593e14f

