### PR TITLE
Feat: Add inputRef to RadioGroup

### DIFF
--- a/packages/@headlessui-react/src/components/radio-group/radio-group.tsx
+++ b/packages/@headlessui-react/src/components/radio-group/radio-group.tsx
@@ -14,6 +14,7 @@ import React, {
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type Ref,
+  type RefObject,
 } from 'react'
 import { useByComparator, type ByComparator } from '../../hooks/use-by-comparator'
 import { useControllable } from '../../hooks/use-controllable'
@@ -161,6 +162,7 @@ export type RadioGroupProps<
     disabled?: boolean
     form?: string
     name?: string
+    inputRef?: RefObject<HTMLInputElement>
   }
 >
 
@@ -322,7 +324,7 @@ function RadioGroupFn<TTag extends ElementType = typeof DEFAULT_RADIO_GROUP_TAG,
               <FormFields
                 disabled={disabled}
                 data={{ [name]: value || 'on' }}
-                overrides={{ type: 'radio', checked: value != null }}
+                overrides={{ type: 'radio', checked: value != null, ref: theirProps?.inputRef }}
                 form={form}
                 onReset={reset}
               />


### PR DESCRIPTION
Add a new prop to allow adding a ref to the `input` element of the `Radiogroup`. 

There is also a Discussion in which some others had the same issue: https://github.com/tailwindlabs/headlessui/discussions/1674

Unfortunately I'm not sure what kind of tests to write for this since this a very small change.

Thank you :)