### PR TITLE
fix(vue): skip deleting portal root node to avoid race condition

### DIFF
--- a/packages/@headlessui-vue/src/components/portal/portal.test.ts
+++ b/packages/@headlessui-vue/src/components/portal/portal.test.ts
@@ -167,76 +167,6 @@ it('should be possible to use multiple Portal elements', async () => {
   expect(content2).toHaveTextContent('Contents 2 ...')
 })
 
-it('should cleanup the Portal root when the last Portal is unmounted', async () => {
-  expect(getPortalRoot()).toBe(null)
-
-  renderTemplate({
-    template: html`
-      <main id="parent">
-        <button id="a" @click="toggleA">Toggle A</button>
-        <button id="b" @click="toggleB">Toggle B</button>
-
-        <Portal v-if="renderA">
-          <p id="content1">Contents 1 ...</p>
-        </Portal>
-
-        <Portal v-if="renderB">
-          <p id="content2">Contents 2 ...</p>
-        </Portal>
-      </main>
-    `,
-    setup() {
-      let renderA = ref(false)
-      let renderB = ref(false)
-
-      return {
-        renderA,
-        renderB,
-        toggleA() {
-          renderA.value = !renderA.value
-        },
-        toggleB() {
-          renderB.value = !renderB.value
-        },
-      }
-    },
-  })
-
-  let a = document.getElementById('a')
-  let b = document.getElementById('b')
-
-  expect(getPortalRoot()).toBe(null)
-
-  // Let's render the first Portal
-  await click(a)
-
-  expect(getPortalRoot()).not.toBe(null)
-  expect(getPortalRoot().children).toHaveLength(1)
-
-  // Let's render the second Portal
-  await click(b)
-
-  expect(getPortalRoot()).not.toBe(null)
-  expect(getPortalRoot().children).toHaveLength(2)
-
-  // Let's remove the first portal
-  await click(a)
-
-  expect(getPortalRoot()).not.toBe(null)
-  expect(getPortalRoot().children).toHaveLength(1)
-
-  // Let's remove the second Portal
-  await click(b)
-
-  expect(getPortalRoot()).toBe(null)
-
-  // Let's render the first Portal again
-  await click(a)
-
-  expect(getPortalRoot()).not.toBe(null)
-  expect(getPortalRoot().children).toHaveLength(1)
-})
-
 it('should be possible to render multiple portals at the same time', async () => {
   expect(getPortalRoot()).toBe(null)
 
@@ -311,7 +241,7 @@ it('should be possible to render multiple portals at the same time', async () =>
 
   // Remove Portal 1
   await click(document.getElementById('a'))
-  expect(getPortalRoot()).toBe(null)
+  expect(getPortalRoot().children).toHaveLength(0)
 
   // Render A and B at the same time!
   await click(document.getElementById('double'))

--- a/packages/@headlessui-vue/src/components/portal/portal.ts
+++ b/packages/@headlessui-vue/src/components/portal/portal.ts
@@ -1,6 +1,5 @@
 import {
   Teleport,
-  computed,
   defineComponent,
   getCurrentInstance,
   h,
@@ -51,7 +50,6 @@ export let Portal = defineComponent({
   },
   setup(props, { slots, attrs }) {
     let element = ref<HTMLElement | null>(null)
-    let ownerDocument = computed(() => getOwnerDocument(element))
 
     let forcePortalRoot = usePortalRoot()
     let groupContext = inject(PortalGroupContext, null)
@@ -88,16 +86,6 @@ export let Portal = defineComponent({
       if (!domElement) return
       onUnmounted(parent.register(domElement), instance)
       didRegister = true
-    })
-
-    onUnmounted(() => {
-      let root = ownerDocument.value?.getElementById('headlessui-portal-root')
-      if (!root) return
-      if (myTarget.value !== root) return
-
-      if (myTarget.value.children.length <= 0) {
-        myTarget.value.parentElement?.removeChild(myTarget.value)
-      }
     })
 
     return () => {


### PR DESCRIPTION
Even w/ the latest version of HeaadlessUI for Vue I was running into an issue where if a new dialog starts opening up while a previous dialog is in the process of closing down you can run into an issue where the old dialog starts removing the shared PortalRoot while the new dialog has already chosen to rely on it as its PortalRoot. This then ends up breaking the rendering of the 2nd dialog as it ends up being unmounted from the DOM along with the PortalRoot.

The fix is easy - just skip removing the portal root. I don't see any real benefits for removing it, I mean its just one single empty div node, there's no performance gain to having it be removed, and keeping it around fixes the race condition issue.