### PR TITLE
Fix incorrect double invocation of menu items

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Fix incorrect double invocation of menu items, listbox options and combobox options ([#3766](https://github.com/tailwindlabs/headlessui/pull/3766))
 
 ## [2.2.6] - 2025-07-24
 

--- a/packages/@headlessui-react/src/hooks/use-quick-release.ts
+++ b/packages/@headlessui-react/src/hooks/use-quick-release.ts
@@ -75,9 +75,9 @@ export function useQuickRelease(
     'pointerup',
     (e) => {
       let triggeredAt = triggeredAtRef.current
+      if (triggeredAt === null) return
       triggeredAtRef.current = null
 
-      if (triggeredAt === null) return
       if (!DOM.isHTMLorSVGElement(e.target)) return
 
       // Ensure we moved the pointer a bit before considering it a quick

--- a/packages/@headlessui-react/src/hooks/use-quick-release.ts
+++ b/packages/@headlessui-react/src/hooks/use-quick-release.ts
@@ -91,14 +91,12 @@ export function useQuickRelease(
 
       let result = action(e as PointerEventWithTarget)
 
-      let diffInMs = e.timeStamp - triggeredAt
-
       switch (result.kind) {
         case ActionKind.Ignore:
           return
 
         case ActionKind.Select: {
-          if (diffInMs > POINTER_HOLD_THRESHOLD) {
+          if (e.timeStamp - triggeredAt > POINTER_HOLD_THRESHOLD) {
             select(result.target)
             close()
           }

--- a/packages/@headlessui-react/src/hooks/use-quick-release.ts
+++ b/packages/@headlessui-react/src/hooks/use-quick-release.ts
@@ -57,7 +57,7 @@ export function useQuickRelease(
 ) {
   // Capture the timestamp of when the `pointerdown` event happened on the
   // trigger.
-  let triggeredAtRef = useRef<Date | null>(null)
+  let triggeredAtRef = useRef<number | null>(null)
   let startXRef = useRef<number | null>(null)
   let startYRef = useRef<number | null>(null)
   useDocumentEvent(enabled && trigger !== null, 'pointerdown', (e) => {
@@ -67,7 +67,7 @@ export function useQuickRelease(
     startXRef.current = e.x
     startYRef.current = e.y
 
-    triggeredAtRef.current = new Date()
+    triggeredAtRef.current = e.timeStamp
   })
 
   useDocumentEvent(
@@ -89,7 +89,7 @@ export function useQuickRelease(
 
       let result = action(e as PointerEventWithTarget)
 
-      let diffInMs = new Date().getTime() - triggeredAtRef.current.getTime()
+      let diffInMs = e.timeStamp - triggeredAtRef.current
       triggeredAtRef.current = null
 
       switch (result.kind) {

--- a/packages/@headlessui-react/src/hooks/use-quick-release.ts
+++ b/packages/@headlessui-react/src/hooks/use-quick-release.ts
@@ -83,6 +83,7 @@ export function useQuickRelease(
         Math.abs(e.x - (startXRef.current ?? e.x)) < POINTER_MOVEMENT_THRESHOLD &&
         Math.abs(e.y - (startYRef.current ?? e.y)) < POINTER_MOVEMENT_THRESHOLD
       ) {
+        triggeredAtRef.current = null
         return
       }
 

--- a/packages/@headlessui-react/src/hooks/use-quick-release.ts
+++ b/packages/@headlessui-react/src/hooks/use-quick-release.ts
@@ -74,7 +74,10 @@ export function useQuickRelease(
     enabled && trigger !== null,
     'pointerup',
     (e) => {
-      if (triggeredAtRef.current === null) return
+      let triggeredAt = triggeredAtRef.current
+      triggeredAtRef.current = null
+
+      if (triggeredAt === null) return
       if (!DOM.isHTMLorSVGElement(e.target)) return
 
       // Ensure we moved the pointer a bit before considering it a quick
@@ -83,14 +86,12 @@ export function useQuickRelease(
         Math.abs(e.x - (startXRef.current ?? e.x)) < POINTER_MOVEMENT_THRESHOLD &&
         Math.abs(e.y - (startYRef.current ?? e.y)) < POINTER_MOVEMENT_THRESHOLD
       ) {
-        triggeredAtRef.current = null
         return
       }
 
       let result = action(e as PointerEventWithTarget)
 
-      let diffInMs = e.timeStamp - triggeredAtRef.current
-      triggeredAtRef.current = null
+      let diffInMs = e.timeStamp - triggeredAt
 
       switch (result.kind) {
         case ActionKind.Ignore:


### PR DESCRIPTION
This PR fixes an issue where menu items would be invoked twice when you click on an item.

This is due to a bug in the `useQuickRelease` hook where the timestamp was not reset correctly, which means that the actual click caused a quick release trigger. This in turn selects / invokes the menu item even though it was already triggered by the click of the user.

This PR fixes that by resetting the timestamp as soon as possible, which also cleans up the code a bit because there is only 1 branch where we need to reset instead of in every branch before returning.

Fixes: #3763
Fixes: #3764
Fixes: #3765
