### PR TITLE
Improve focus management in shadow roots

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Improve focus management in shadow DOM roots ([#3794](https://github.com/tailwindlabs/headlessui/pull/3794))
 
 ## [2.2.8] - 2025-09-12
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -544,8 +544,6 @@ function InputFn<
     ...theirProps
   } = props
 
-  let [inputElement] = useSlice(machine, (state) => [state.inputElement])
-
   let internalInputRef = useRef<HTMLInputElement | null>(null)
   let inputRef = useSyncRefs(
     internalInputRef,

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -67,6 +67,7 @@ import { Focus } from '../../utils/calculate-active-index'
 import { disposables } from '../../utils/disposables'
 import * as DOM from '../../utils/dom'
 import { match } from '../../utils/match'
+import { isActiveElement } from '../../utils/owner'
 import { isMobile } from '../../utils/platform'
 import {
   RenderFeatures,
@@ -628,7 +629,7 @@ function InputFn<
         // Bail when the input is not the currently focused element. When it is not the focused
         // element, and we call the `setSelectionRange`, then it will become the focused
         // element which may be unwanted.
-        if (ownerDocument?.activeElement !== input) return
+        if (isActiveElement(input)) return
 
         let { selectionStart, selectionEnd } = input
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -553,7 +553,6 @@ function InputFn<
     useFloatingReference(),
     machine.actions.setInputElement
   )
-  let ownerDocument = useOwnerDocument(inputElement)
 
   let [comboboxState, isTyping] = useSlice(machine, (state) => [
     state.comboboxState,
@@ -643,7 +642,7 @@ function InputFn<
         input.setSelectionRange(input.value.length, input.value.length)
       })
     },
-    [currentDisplayValue, comboboxState, ownerDocument, isTyping]
+    [currentDisplayValue, comboboxState, isTyping]
   )
 
   // Trick VoiceOver in behaving a little bit better. Manually "resetting" the input makes VoiceOver

--- a/packages/@headlessui-react/src/components/dialog/dialog.tsx
+++ b/packages/@headlessui-react/src/components/dialog/dialog.tsx
@@ -160,7 +160,7 @@ let InternalDialog = forwardRefWithAs(function InternalDialog<
   let internalDialogRef = useRef<HTMLElement | null>(null)
   let dialogRef = useSyncRefs(internalDialogRef, ref)
 
-  let ownerDocument = useOwnerDocument(internalDialogRef)
+  let ownerDocument = useOwnerDocument(internalDialogRef.current)
 
   let dialogState = open ? DialogStates.Open : DialogStates.Closed
 

--- a/packages/@headlessui-react/src/components/disclosure/disclosure.tsx
+++ b/packages/@headlessui-react/src/components/disclosure/disclosure.tsx
@@ -206,7 +206,7 @@ function DisclosureFn<TTag extends ElementType = typeof DEFAULT_DISCLOSURE_TAG>(
   let close = useEvent(
     (focusableElement?: HTMLOrSVGElement | MutableRefObject<HTMLOrSVGElement | null>) => {
       dispatch({ type: ActionTypes.CloseDisclosure })
-      let ownerDocument = getOwnerDocument(internalDisclosureRef)
+      let ownerDocument = getOwnerDocument(internalDisclosureRef.current)
       if (!ownerDocument) return
       if (!buttonId) return
 

--- a/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
+++ b/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
@@ -25,6 +25,7 @@ import * as DOM from '../../utils/dom'
 import { Focus, FocusResult, focusElement, focusIn } from '../../utils/focus-management'
 import { match } from '../../utils/match'
 import { microTask } from '../../utils/micro-task'
+import { isActiveElement } from '../../utils/owner'
 import { forwardRefWithAs, useRender, type HasDisplayName, type RefProp } from '../../utils/render'
 
 type Containers =
@@ -288,7 +289,7 @@ function useRestoreFocus(
   useWatch(() => {
     if (enabled) return
 
-    if (ownerDocument?.activeElement === ownerDocument?.body) {
+    if (isActiveElement(ownerDocument?.body)) {
       focusElement(getRestoreElement())
     }
   }, [enabled])

--- a/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
+++ b/packages/@headlessui-react/src/components/focus-trap/focus-trap.tsx
@@ -109,7 +109,7 @@ function FocusTrapFn<TTag extends ElementType = typeof DEFAULT_FOCUS_TRAP_TAG>(
     features = FocusTrapFeatures.None
   }
 
-  let ownerDocument = useOwnerDocument(container)
+  let ownerDocument = useOwnerDocument(container.current)
 
   useRestoreFocus(features, { ownerDocument })
   let previousActiveElement = useInitialFocus(features, {

--- a/packages/@headlessui-react/src/components/listbox/listbox.tsx
+++ b/packages/@headlessui-react/src/components/listbox/listbox.tsx
@@ -71,7 +71,7 @@ import {
 } from '../../utils/focus-management'
 import { attemptSubmit } from '../../utils/form'
 import { match } from '../../utils/match'
-import { getOwnerDocument } from '../../utils/owner'
+import { isActiveElement } from '../../utils/owner'
 import {
   RenderFeatures,
   forwardRefWithAs,
@@ -666,7 +666,7 @@ function OptionsFn<TTag extends ElementType = typeof DEFAULT_OPTIONS_TAG>(
     let container = optionsElement
     if (!container) return
     if (listboxState !== ListboxStates.Open) return
-    if (container === getOwnerDocument(container)?.activeElement) return
+    if (isActiveElement(container)) return
 
     container?.focus({ preventScroll: true })
   }, [listboxState, optionsElement])

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -457,7 +457,7 @@ function ItemsFn<TTag extends ElementType = typeof DEFAULT_ITEMS_TAG>(
     if (isActiveElement(container)) return
 
     container.focus({ preventScroll: true })
-  }, [menuState, localItemsElement, ownerDocument])
+  }, [menuState, localItemsElement])
 
   useTreeWalker(menuState === MenuState.Open, {
     container: localItemsElement,

--- a/packages/@headlessui-react/src/components/menu/menu.tsx
+++ b/packages/@headlessui-react/src/components/menu/menu.tsx
@@ -60,6 +60,7 @@ import {
   restoreFocusIfNecessary,
 } from '../../utils/focus-management'
 import { match } from '../../utils/match'
+import { isActiveElement } from '../../utils/owner'
 import {
   RenderFeatures,
   forwardRefWithAs,
@@ -453,7 +454,7 @@ function ItemsFn<TTag extends ElementType = typeof DEFAULT_ITEMS_TAG>(
     let container = localItemsElement
     if (!container) return
     if (menuState !== MenuState.Open) return
-    if (container === ownerDocument?.activeElement) return
+    if (isActiveElement(container)) return
 
     container.focus({ preventScroll: true })
   }, [menuState, localItemsElement, ownerDocument])

--- a/packages/@headlessui-react/src/components/popover/popover-machine.ts
+++ b/packages/@headlessui-react/src/components/popover/popover-machine.ts
@@ -143,12 +143,12 @@ export class PopoverMachine extends Machine<State, Actions> {
       if (!state.button) return false
       if (!state.panel) return false
 
-      let body = getOwnerDocument(state.button)?.body ?? document.body
+      let ownerDocument = getOwnerDocument(state.button) ?? document
 
       // We are part of a different "root" tree, so therefore we can consider it portalled. This is a
       // heuristic because 3rd party tools could use some form of portal, typically rendered at the
       // end of the body but we don't have an actual reference to that.
-      for (let root of body.querySelectorAll('body > *')) {
+      for (let root of ownerDocument.querySelectorAll('body > *')) {
         if (Number(root?.contains(state.button)) ^ Number(root?.contains(state.panel))) {
           return true
         }
@@ -160,7 +160,7 @@ export class PopoverMachine extends Machine<State, Actions> {
       // portalled or not because we can follow the default tab order. But if they
       // are not, then we can consider it being portalled so that we can ensure
       // that tab and shift+tab (hopefully) go to the correct spot.
-      let elements = getFocusableElements(body)
+      let elements = getFocusableElements(ownerDocument)
       let buttonIdx = elements.indexOf(state.button)
 
       let beforeIdx = (buttonIdx + elements.length - 1) % elements.length

--- a/packages/@headlessui-react/src/components/popover/popover-machine.ts
+++ b/packages/@headlessui-react/src/components/popover/popover-machine.ts
@@ -4,6 +4,7 @@ import { stackMachines } from '../../machines/stack-machine'
 import * as DOM from '../../utils/dom'
 import { getFocusableElements } from '../../utils/focus-management'
 import { match } from '../../utils/match'
+import { getOwnerDocument } from '../../utils/owner'
 
 type MouseEvent<T> = Parameters<MouseEventHandler<T>>[0]
 
@@ -142,10 +143,12 @@ export class PopoverMachine extends Machine<State, Actions> {
       if (!state.button) return false
       if (!state.panel) return false
 
+      let body = getOwnerDocument(state.button)?.body ?? document.body
+
       // We are part of a different "root" tree, so therefore we can consider it portalled. This is a
       // heuristic because 3rd party tools could use some form of portal, typically rendered at the
       // end of the body but we don't have an actual reference to that.
-      for (let root of document.querySelectorAll('body > *')) {
+      for (let root of body.querySelectorAll('body > *')) {
         if (Number(root?.contains(state.button)) ^ Number(root?.contains(state.panel))) {
           return true
         }
@@ -157,7 +160,7 @@ export class PopoverMachine extends Machine<State, Actions> {
       // portalled or not because we can follow the default tab order. But if they
       // are not, then we can consider it being portalled so that we can ensure
       // that tab and shift+tab (hopefully) go to the correct spot.
-      let elements = getFocusableElements()
+      let elements = getFocusableElements(body)
       let buttonIdx = elements.indexOf(state.button)
 
       let beforeIdx = (buttonIdx + elements.length - 1) % elements.length

--- a/packages/@headlessui-react/src/components/popover/popover.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.tsx
@@ -748,7 +748,7 @@ function PanelFn<TTag extends ElementType = typeof DEFAULT_PANEL_TAG>(
     setLocalPanelElement
   )
   let portalOwnerDocument = useOwnerDocument(button)
-  let ownerDocument = useOwnerDocument(internalPanelRef)
+  let ownerDocument = useOwnerDocument(internalPanelRef.current)
 
   useIsoMorphicEffect(() => {
     machine.actions.setPanelId(id)

--- a/packages/@headlessui-react/src/components/popover/popover.tsx
+++ b/packages/@headlessui-react/src/components/popover/popover.tsx
@@ -28,7 +28,7 @@ import { useIsoMorphicEffect } from '../../hooks/use-iso-morphic-effect'
 import { useLatestValue } from '../../hooks/use-latest-value'
 import { useOnDisappear } from '../../hooks/use-on-disappear'
 import { useOutsideClick } from '../../hooks/use-outside-click'
-import { useOwnerDocument } from '../../hooks/use-owner'
+import { useOwnerDocument, useRootDocument } from '../../hooks/use-owner'
 import { useResolveButtonType } from '../../hooks/use-resolve-button-type'
 import {
   MainTreeProvider,
@@ -156,7 +156,7 @@ function PopoverFn<TTag extends ElementType = typeof DEFAULT_POPOVER_TAG>(
     }, [])
   )
 
-  let ownerDocument = useOwnerDocument(internalPopoverRef.current ?? button)
+  let rootDocument = useRootDocument(internalPopoverRef.current ?? button)
 
   let buttonIdRef = useLatestValue(buttonId)
   let panelIdRef = useLatestValue(panelId)
@@ -204,7 +204,7 @@ function PopoverFn<TTag extends ElementType = typeof DEFAULT_POPOVER_TAG>(
 
   // Handle focus out
   useEventListener(
-    ownerDocument?.defaultView,
+    rootDocument,
     'focus',
     (event) => {
       if (event.target === window) return

--- a/packages/@headlessui-react/src/components/portal/portal.tsx
+++ b/packages/@headlessui-react/src/components/portal/portal.tsx
@@ -89,7 +89,7 @@ let InternalPortalFn = forwardRefWithAs(function InternalPortalFn<
     }),
     ref
   )
-  let defaultOwnerDocument = useOwnerDocument(internalPortalRootRef)
+  let defaultOwnerDocument = useOwnerDocument(internalPortalRootRef.current)
   let ownerDocument = incomingOwnerDocument ?? defaultOwnerDocument
   let target = usePortalTarget(ownerDocument)
   let parent = useContext(PortalParentContext)

--- a/packages/@headlessui-react/src/components/radio-group/radio-group.tsx
+++ b/packages/@headlessui-react/src/components/radio-group/radio-group.tsx
@@ -32,7 +32,7 @@ import { isDisabledReactIssue7711 } from '../../utils/bugs'
 import { Focus, FocusResult, focusIn, sortByDomNode } from '../../utils/focus-management'
 import { attemptSubmit } from '../../utils/form'
 import { match } from '../../utils/match'
-import { getOwnerDocument } from '../../utils/owner'
+import { isActiveElement } from '../../utils/owner'
 import {
   forwardRefWithAs,
   mergeProps,
@@ -224,8 +224,6 @@ function RadioGroupFn<TTag extends ElementType = typeof DEFAULT_RADIO_GROUP_TAG,
     let container = internalRadioGroupRef.current
     if (!container) return
 
-    let ownerDocument = getOwnerDocument(container)
-
     let all = options
       .filter((option) => option.propsRef.current.disabled === false)
       .map((radio) => radio.element.current) as HTMLElement[]
@@ -243,9 +241,7 @@ function RadioGroupFn<TTag extends ElementType = typeof DEFAULT_RADIO_GROUP_TAG,
           let result = focusIn(all, Focus.Previous | Focus.WrapAround)
 
           if (result === FocusResult.Success) {
-            let activeOption = options.find(
-              (option) => option.element.current === ownerDocument?.activeElement
-            )
+            let activeOption = options.find((option) => isActiveElement(option.element.current))
             if (activeOption) triggerChange(activeOption.propsRef.current.value)
           }
         }
@@ -260,9 +256,7 @@ function RadioGroupFn<TTag extends ElementType = typeof DEFAULT_RADIO_GROUP_TAG,
           let result = focusIn(all, Focus.Next | Focus.WrapAround)
 
           if (result === FocusResult.Success) {
-            let activeOption = options.find(
-              (option) => option.element.current === ownerDocument?.activeElement
-            )
+            let activeOption = options.find((option) => isActiveElement(option.element.current))
             if (activeOption) triggerChange(activeOption.propsRef.current.value)
           }
         }
@@ -273,9 +267,7 @@ function RadioGroupFn<TTag extends ElementType = typeof DEFAULT_RADIO_GROUP_TAG,
           event.preventDefault()
           event.stopPropagation()
 
-          let activeOption = options.find(
-            (option) => option.element.current === ownerDocument?.activeElement
-          )
+          let activeOption = options.find((option) => isActiveElement(option.element.current))
           if (activeOption) triggerChange(activeOption.propsRef.current.value)
         }
         break

--- a/packages/@headlessui-react/src/components/tabs/tabs.tsx
+++ b/packages/@headlessui-react/src/components/tabs/tabs.tsx
@@ -29,7 +29,7 @@ import type { Props } from '../../types'
 import { Focus, FocusResult, focusIn, sortByDomNode } from '../../utils/focus-management'
 import { match } from '../../utils/match'
 import { microTask } from '../../utils/micro-task'
-import { getOwnerDocument } from '../../utils/owner'
+import { getActiveElement } from '../../utils/owner'
 import {
   RenderFeatures,
   forwardRefWithAs,
@@ -449,7 +449,7 @@ function TabFn<TTag extends ElementType = typeof DEFAULT_TAB_TAG>(
   let activateUsing = useEvent((cb: () => FocusResult) => {
     let result = cb()
     if (result === FocusResult.Success && activation === 'auto') {
-      let newTab = getOwnerDocument(internalTabRef)?.activeElement
+      let newTab = getActiveElement(internalTabRef.current)
       let idx = data.tabs.findIndex((tab) => tab.current === newTab)
       if (idx !== -1) actions.change(idx)
     }

--- a/packages/@headlessui-react/src/hooks/use-owner.ts
+++ b/packages/@headlessui-react/src/hooks/use-owner.ts
@@ -1,6 +1,10 @@
 import { useMemo } from 'react'
-import { getOwnerDocument } from '../utils/owner'
+import { getOwnerDocument, getRootNode } from '../utils/owner'
 
 export function useOwnerDocument(...args: Parameters<typeof getOwnerDocument>) {
   return useMemo(() => getOwnerDocument(...args), [...args])
+}
+
+export function useRootDocument(...args: Parameters<typeof getRootNode>) {
+  return useMemo(() => getRootNode(...args), [...args])
 }

--- a/packages/@headlessui-react/src/hooks/use-refocusable-input.ts
+++ b/packages/@headlessui-react/src/hooks/use-refocusable-input.ts
@@ -1,5 +1,6 @@
 import { useRef } from 'react'
 import * as DOM from '../utils/dom'
+import { isActiveElement } from '../utils/owner'
 import { useEvent } from './use-event'
 import { useEventListener } from './use-event-listener'
 
@@ -30,7 +31,7 @@ export function useRefocusableInput(input: HTMLInputElement | null) {
 
   return useEvent(() => {
     // If the input is already focused, we don't need to do anything
-    if (document.activeElement === input) return
+    if (isActiveElement(input)) return
 
     if (!DOM.isHTMLInputElement(input)) return
     if (!input.isConnected) return

--- a/packages/@headlessui-react/src/hooks/use-root-containers.tsx
+++ b/packages/@headlessui-react/src/hooks/use-root-containers.tsx
@@ -3,7 +3,6 @@ import { Hidden, HiddenFeatures } from '../internal/hidden'
 import * as DOM from '../utils/dom'
 import { getOwnerDocument } from '../utils/owner'
 import { useEvent } from './use-event'
-import { useOwnerDocument } from './use-owner'
 
 export function useRootContainers({
   defaultContainers = [],
@@ -16,9 +15,8 @@ export function useRootContainers({
   portals?: MutableRefObject<Element[]>
   mainTreeNode?: Element | null
 } = {}) {
-  let ownerDocument = useOwnerDocument(mainTreeNode)
-
   let resolveContainers = useEvent(() => {
+    let ownerDocument = getOwnerDocument(mainTreeNode)
     let containers: Element[] = []
 
     // Resolve default containers

--- a/packages/@headlessui-react/src/test-utils/accessibility-assertions.ts
+++ b/packages/@headlessui-react/src/test-utils/accessibility-assertions.ts
@@ -1,4 +1,5 @@
 import { FocusableMode, isFocusableElement } from '../utils/focus-management'
+import { getActiveElement } from '../utils/owner'
 
 function assertNever(x: never): never {
   throw new Error('Unexpected object: ' + x)
@@ -1814,9 +1815,9 @@ export function assertActiveElement(element: HTMLElement | null) {
       //   "Cannot assign to read only property 'Symbol(impl)' of object '[object DOMImplementation]'"
       // when this assertion fails.
       // Therefore we will catch it when something goes wrong, and just look at the outerHTML string.
-      expect(document.activeElement).toBe(element)
+      expect(getActiveElement(element)).toBe(element)
     } catch (err) {
-      expect(document.activeElement?.outerHTML).toBe(element.outerHTML)
+      expect(getActiveElement(element)?.outerHTML).toBe(element.outerHTML)
     }
   } catch (err) {
     if (err instanceof Error) Error.captureStackTrace(err, assertActiveElement)
@@ -1827,7 +1828,7 @@ export function assertActiveElement(element: HTMLElement | null) {
 export function assertContainsActiveElement(element: HTMLElement | null) {
   try {
     if (element === null) return expect(element).not.toBe(null)
-    expect(element.contains(document.activeElement)).toBe(true)
+    expect(element.contains(getActiveElement(element))).toBe(true)
   } catch (err) {
     if (err instanceof Error) Error.captureStackTrace(err, assertContainsActiveElement)
     throw err

--- a/packages/@headlessui-react/src/utils/focus-management.ts
+++ b/packages/@headlessui-react/src/utils/focus-management.ts
@@ -86,7 +86,11 @@ enum Direction {
   Next = 1,
 }
 
-export function getFocusableElements(container: HTMLElement | null = document.body) {
+interface QuerySelectorAll {
+  querySelectorAll<E extends Element = Element>(selectors: string): NodeListOf<E>
+}
+
+export function getFocusableElements(container: QuerySelectorAll | null = document.body) {
   if (container == null) return []
   return Array.from(container.querySelectorAll<HTMLElement>(focusableSelector)).sort(
     // We want to move `tabIndex={0}` to the end of the list, this is what the browser does as well.

--- a/packages/@headlessui-react/src/utils/focus-management.ts
+++ b/packages/@headlessui-react/src/utils/focus-management.ts
@@ -220,8 +220,12 @@ export function sortByDomNode<T>(
   })
 }
 
-export function focusFrom(current: HTMLElement | null, focus: Focus) {
-  return focusIn(getFocusableElements(), focus, { relativeTo: current })
+export function focusFrom(
+  current: HTMLElement | null,
+  focus: Focus,
+  container = current === null ? document.body : getRootNode(current)
+) {
+  return focusIn(getFocusableElements(container), focus, { relativeTo: current })
 }
 
 export function focusIn(

--- a/packages/@headlessui-react/src/utils/owner.ts
+++ b/packages/@headlessui-react/src/utils/owner.ts
@@ -5,9 +5,28 @@ export function getOwnerDocument<T extends Element | MutableRefObject<Element | 
   element: T | null | undefined
 ): Document | null {
   if (env.isServer) return null
-  if (!element) return document
-  if ('ownerDocument' in element) return element.ownerDocument
-  if ('current' in element) return element.current?.ownerDocument ?? document
+  if (element == null) return document
 
-  return null
+  let target: Element | null = 'current' in element ? element.current : element
+  return target?.ownerDocument ?? document
+}
+
+export function getRootNode<T extends Element | MutableRefObject<Element | null>>(
+  element: T | null | undefined
+): Document | ShadowRoot | null {
+  if (env.isServer) return null
+  if (element == null) return document
+
+  let target: Element | null = 'current' in element ? element.current : element
+
+  // @ts-expect-error `getRootNode`'s return type is typed as `Node`, but we want to type it a bit better
+  return target?.getRootNode?.() ?? document
+}
+
+export function getActiveElement(element: Element | null | undefined): Element | null {
+  return getRootNode(element)?.activeElement ?? null
+}
+
+export function isActiveElement(element: Element | null | undefined): boolean {
+  return getActiveElement(element) === element
 }

--- a/packages/@headlessui-react/src/utils/owner.ts
+++ b/packages/@headlessui-react/src/utils/owner.ts
@@ -1,26 +1,22 @@
-import type { MutableRefObject } from 'react'
 import { env } from './env'
 
-export function getOwnerDocument<T extends Element | MutableRefObject<Element | null>>(
+export function getOwnerDocument<T extends Element>(
   element: T | null | undefined
 ): Document | null {
   if (env.isServer) return null
   if (element == null) return document
 
-  let target: Element | null = 'current' in element ? element.current : element
-  return target?.ownerDocument ?? document
+  return element?.ownerDocument ?? document
 }
 
-export function getRootNode<T extends Element | MutableRefObject<Element | null>>(
+export function getRootNode<T extends Element>(
   element: T | null | undefined
 ): Document | ShadowRoot | null {
   if (env.isServer) return null
   if (element == null) return document
 
-  let target: Element | null = 'current' in element ? element.current : element
-
   // @ts-expect-error `getRootNode`'s return type is typed as `Node`, but we want to type it a bit better
-  return target?.getRootNode?.() ?? document
+  return element?.getRootNode?.() ?? document
 }
 
 export function getActiveElement(element: Element | null | undefined): Element | null {


### PR DESCRIPTION
This PR improves the focus management when Headless UI components are used inside of a shadow DOM.

We already tried to not use `document` directly, but instead rely on `someKnownElement.ownerDocument` to get the correct document context. 

This is unfortunately not enough, because if you have a focused element _inside_ the shadow DOM, then `ownerDocument.activeElement` will return the wrapping shadow DOM node and not the actual focused element inside of the shadow DOM.

This PR improves that behavior by using `getRootNode()` instead and then we read information such as the `activeElement` from there.

It's going to be easier if you look at this reproduction. The element with the black border is a shadow DOM element. The `toggle` button is a Popover button.

Expected behavior:

1. You can tab through the elements in order from outside the shadow DOM into the shadow DOM and out again.
1. You can shift+tab in reverse order as well.
1. When the Popover is open, pressing `Escape` should close the Popover.
1. When tabbing outside of the open popover, the popover should close.

Let's see these things in action:

---

1. Pressing escape on an open Popover should close it

**before:**

https://github.com/user-attachments/assets/99ff5768-f6ac-490f-a607-391bbdd21d65


The reason it doesn't is because we check the `activeElement`, and we only close the popover if it is the active element. But if you look at devtools, the button is not the active element so therefore it doesn't work.

**after:**

https://github.com/user-attachments/assets/22511835-98d3-452d-baac-447fa4e5a5e7

---

2. Tabbing out of an open popover with <kbd>Tab</kbd> should close the Popover and focus the next element.

**before:**

https://github.com/user-attachments/assets/ab2c5849-f524-436b-aa7c-9e65e5debc67

Here it does all the wrong things, it doesn't go into the PopoverPanel, it doesn't go to the next button, but it goes to the next button _outside_ of the shadow dom.

**after:**

https://github.com/user-attachments/assets/c5f653f1-338d-41c4-a166-735e6c1d1435

---

## Test plan

1. Existing code still passes (we don't have shadow DOM tests)
2. Tested the behavior from the reproduction and it all works as expected now:

https://github.com/user-attachments/assets/a90206e6-ae5e-4748-a4e4-c65dfa69d8f6


Fixes: https://github.com/tailwindlabs/headlessui/issues/2951
