### PR TITLE
Allow home/end key default behavior inside `ComboboxInput` when `Combobox` is closed

### DIFF
--- a/packages/@headlessui-react/CHANGELOG.md
+++ b/packages/@headlessui-react/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't accidentally open the `Combobox` when touching the `ComboboxButton` while dragging on mobile ([#3795](https://github.com/tailwindlabs/headlessui/pull/3795))
 - Ensure sibling `Dialog` components are scrollable on mobile ([#3796](https://github.com/tailwindlabs/headlessui/pull/3796))
 - Infer `Combobox` type based on `onChange` handler ([#3798](https://github.com/tailwindlabs/headlessui/pull/3798))
+- Allow home/end key default behavior inside `ComboboxInput` when `Combobox` is closed ([#3798](https://github.com/tailwindlabs/headlessui/pull/3798))
 
 ## [2.2.8] - 2025-09-12
 

--- a/packages/@headlessui-react/src/components/combobox/combobox.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.tsx
@@ -734,6 +734,10 @@ function InputFn<
         })
 
       case Keys.Home:
+        if (machine.state.comboboxState === ComboboxState.Closed) {
+          break
+        }
+
         if (event.shiftKey) {
           break
         }
@@ -748,6 +752,10 @@ function InputFn<
         return machine.actions.goToOption({ focus: Focus.First })
 
       case Keys.End:
+        if (machine.state.comboboxState === ComboboxState.Closed) {
+          break
+        }
+
         if (event.shiftKey) {
           break
         }


### PR DESCRIPTION
Fixes #3558

Our combobox uses them to jump to the beginning or end of the option list but it doesn't make sense to capture these if the combobox isn't open.

This will allow the home/end keys to function normally for the Combobox's input field which means, for Windows at least, the caret will moved to the beginning or end of the input. (macOS doesn't do this unless you also hold shift to select text).

Before:

https://github.com/user-attachments/assets/8d545613-cd93-4a46-8609-cc66dd960502

After:

https://github.com/user-attachments/assets/426748b5-f66d-4bb9-80ba-be6a9b621618


