### PR TITLE
docs: fix article grammar in tests

### DIFF
--- a/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
+++ b/packages/@headlessui-react/src/components/combobox/combobox.test.tsx
@@ -4155,7 +4155,7 @@ describe.each([{ virtual: true }, { virtual: false }])(
             await press(Keys.Backspace)
             expect(getComboboxInput()?.value).toBe('')
 
-            // Verify that we don't have an selected option anymore
+            // Verify that we don't have a selected option anymore
             assertNotActiveComboboxOption(options[1])
 
             // Verify that we saw the `null` change coming in
@@ -5324,10 +5324,10 @@ describe.each([{ virtual: true }, { virtual: false }])('Mouse interactions %s', 
         )
       }
 
-      // Render a uncontrolled combobox
+      // Render an uncontrolled combobox
       render(<Example />)
 
-      // Change to an controlled combobox
+      // Change to a controlled combobox
       await click(getByText('to controlled'))
 
       // Make sure we get a warning
@@ -5339,7 +5339,7 @@ describe.each([{ virtual: true }, { virtual: false }])('Mouse interactions %s', 
       // Render a fresh uncontrolled combobox
       render(<Example />)
 
-      // Change to an controlled combobox
+      // Change to a controlled combobox
       await click(getByText('to controlled'))
 
       // We shouldn't have gotten another warning as we do not want to warn on every render

--- a/packages/@headlessui-react/src/components/switch/switch.test.tsx
+++ b/packages/@headlessui-react/src/components/switch/switch.test.tsx
@@ -731,7 +731,7 @@ describe('Form compatibility', () => {
     expect(submits).toHaveBeenLastCalledWith([['notifications', 'on']])
   })
 
-  it('should be possible to submit a form with an boolean value', async () => {
+  it('should be possible to submit a form with a boolean value', async () => {
     let submits = jest.fn()
 
     function Example() {

--- a/packages/@headlessui-react/src/utils/form.test.ts
+++ b/packages/@headlessui-react/src/utils/form.test.ts
@@ -20,6 +20,6 @@ it.each([
       ['name[nickname][preferred]', 'JDoe'],
     ],
   ],
-])('should encode an input of %j to an form data output', (input, output) => {
+])('should encode an input of %j to a form data output', (input, output) => {
   expect(objectToFormEntries(input)).toEqual(output)
 })

--- a/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
+++ b/packages/@headlessui-vue/src/components/combobox/combobox.test.ts
@@ -4352,7 +4352,7 @@ describe.each([{ virtual: false }, { virtual: false }])(
             await press(Keys.Backspace)
             expect(getComboboxInput()?.value).toBe('')
 
-            // Verify that we don't have an selected option anymore since we are in `nullable` mode
+            // Verify that we don't have a selected option anymore since we are in `nullable` mode
             assertNotActiveComboboxOption(options[1])
             assertNoSelectedComboboxOption()
 

--- a/packages/@headlessui-vue/src/components/switch/switch.test.tsx
+++ b/packages/@headlessui-vue/src/components/switch/switch.test.tsx
@@ -848,7 +848,7 @@ describe('Form compatibility', () => {
     expect(submits).toHaveBeenLastCalledWith([['notifications', 'on']])
   })
 
-  it('should be possible to submit a form with an boolean value', async () => {
+  it('should be possible to submit a form with a boolean value', async () => {
     let submits = jest.fn()
 
     renderTemplate({

--- a/packages/@headlessui-vue/src/utils/form.test.ts
+++ b/packages/@headlessui-vue/src/utils/form.test.ts
@@ -20,6 +20,6 @@ it.each([
       ['name[nickname][preferred]', 'JDoe'],
     ],
   ],
-])('should encode an input of %j to an form data output', (input, output) => {
+])('should encode an input of %j to a form data output', (input, output) => {
   expect(objectToFormEntries(input)).toEqual(output)
 })


### PR DESCRIPTION
Fixes a few article grammar typos in React/Vue test descriptions and comments.

These are text-only changes in tests and do not affect runtime behavior.